### PR TITLE
Add list command

### DIFF
--- a/aws-vault.go
+++ b/aws-vault.go
@@ -41,6 +41,12 @@ func main() {
 				Keyring: k,
 			}, nil
 		},
+		"ls": func() (cli.Command, error) {
+			return &command.ListCommand{
+				Ui:      ui,
+				Keyring: k,
+			}, nil
+		},
 	}
 
 	exitStatus, err := c.Run()

--- a/command/list.go
+++ b/command/list.go
@@ -1,0 +1,39 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/mitchellh/cli"
+	"github.com/99designs/aws-vault/keyring"
+	"github.com/99designs/aws-vault/vault"
+)
+
+type ListCommand struct {
+	Ui      cli.Ui
+	Keyring keyring.Keyring
+}
+
+func (c *ListCommand) Run(args []string) int {
+
+	profileNames, err := c.Keyring.List(vault.ServiceName)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 4
+	}
+
+	c.Ui.Output(strings.Join(profileNames, "\n"))
+
+	return 0
+}
+
+func (c *ListCommand) Help() string {
+	helpText := `
+Usage: aws-vault ls
+  Lists profiles with credentials in the vault
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *ListCommand) Synopsis() string {
+	return "Lists profiles with credentials in the vault"
+}

--- a/keyring/keychain_darwin.go
+++ b/keyring/keychain_darwin.go
@@ -38,6 +38,10 @@ func (k *OSXKeychain) Remove(service, key string) error {
 	return keychain.FindAndRemoveGenericPassword(&attributes)
 }
 
+func (k *OSXKeychain) List(service string) ([]string, error) {
+	return keychain.GetAllAccountNames(service)
+}
+
 func init() {
 	DefaultKeyring = &OSXKeychain{}
 }

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -6,6 +6,7 @@ type Keyring interface {
 	Get(service, key string) ([]byte, error)
 	Set(service, key string, secret []byte) error
 	Remove(service, key string) error
+	List(service string) ([]string, error)
 }
 
 func Marshal(k Keyring, service, key string, obj interface{}) error {


### PR DESCRIPTION
Adds an `ls` command to list profiles stored in the vault.

```
$ aws-vault ls
default
work
home
```
