### PR TITLE
Write errors and warnings to stderr, not stdout.

### DIFF
--- a/aws-vault.go
+++ b/aws-vault.go
@@ -15,8 +15,9 @@ var (
 
 func main() {
 	ui := &cli.BasicUi{
-		Writer: os.Stdout,
-		Reader: os.Stdin,
+		Writer:      os.Stdout,
+		Reader:      os.Stdin,
+		ErrorWriter: os.Stderr,
 	}
 
 	k := keyring.DefaultKeyring


### PR DESCRIPTION
Set `cli.Ui.ErrorWriter` to `os.Stderr` to that warnings and errors go to stderr not stdout.
[`BasicUi.Error()` from `mitchellh/cli`](https://github.com/mitchellh/cli/blob/8102d0ed5ea2709ade1243798785888175f6e415/ui.go#L109-L117) defaults to using `Writer` if `ErrorWriter` hasn't been set.