### PR TITLE
Error for missing profile reports profile name and config file.

### DIFF
--- a/vault/profiles.go
+++ b/vault/profiles.go
@@ -1,7 +1,7 @@
 package vault
 
 import (
-	"errors"
+	"fmt"
 	"os"
 	"os/user"
 	"strings"
@@ -45,7 +45,10 @@ func LoadAWSProfile(name string) (AWSProfile, error) {
 			}, nil
 		}
 	}
-	return AWSProfile{}, ErrProfileNotFound
+	err = fmt.Errorf(
+		"Profile '%s' not found in %s",
+		name,
+		AWSConfigFile,
+	)
+	return AWSProfile{}, err
 }
-
-var ErrProfileNotFound = errors.New("Profile not found")


### PR DESCRIPTION
Before:

```
$ aws-vault exec env
Profile not found

$ aws-vault exec --profile=foo env >/dev/null
Profile not found
```

After:

```
$ aws-vault exec env
Profile 'default' not found in /Users/pda/.aws/config

$ aws-vault exec --profile=foo env >/dev/null
Profile 'foo' not found in /Users/pda/.aws/config
```

It's not immediately obvious that an entry needs to exist in `~/.aws/config` for each `aws-vault store` credential, so this error should help explain that.

This could also be helped by `aws-vault store` adding a stub entry to the AWS config if one did not already exist.