### PR TITLE
Refactor sts calls into vault session

### DIFF
--- a/aws-vault.go
+++ b/aws-vault.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
 
 	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/mitchellh/cli"
 	"github.com/99designs/aws-vault/command"
-	"github.com/99designs/aws-vault/keyring"
 )
 
 var (
@@ -21,44 +19,27 @@ func main() {
 		ErrorWriter: os.Stderr,
 	}
 
-	// handle profile at the top level, I always do this.
-	var profile string
-	flag.StringVar(&profile, "profile", command.ProfileFromEnv(), "")
-	flag.StringVar(&profile, "p", command.ProfileFromEnv(), "")
-	flag.Parse()
-
-	// log.Printf("%s %#v",)
-
-	k := keyring.DefaultKeyring
 	c := cli.NewCLI("aws-vault", Version)
-	c.Args = flag.Args()
+	c.Args = os.Args[1:]
 	c.Commands = map[string]cli.CommandFactory{
 		"store": func() (cli.Command, error) {
 			return &command.StoreCommand{
-				Ui:             ui,
-				Keyring:        k,
-				DefaultProfile: profile,
+				Ui: ui,
 			}, nil
 		},
 		"rm": func() (cli.Command, error) {
 			return &command.RemoveCommand{
-				Ui:             ui,
-				Keyring:        k,
-				DefaultProfile: profile,
+				Ui: ui,
 			}, nil
 		},
 		"exec": func() (cli.Command, error) {
 			return &command.ExecCommand{
-				Ui:             ui,
-				Keyring:        k,
-				Env:            os.Environ(),
-				DefaultProfile: profile,
+				Ui: ui,
 			}, nil
 		},
 		"ls": func() (cli.Command, error) {
 			return &command.ListCommand{
-				Ui:      ui,
-				Keyring: k,
+				Ui: ui,
 			}, nil
 		},
 	}

--- a/command/exec.go
+++ b/command/exec.go
@@ -3,13 +3,12 @@ package command
 import (
 	"flag"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"syscall"
 	"time"
 
-	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws"
-	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/aws/aws-sdk-go/service/sts"
 	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/mitchellh/cli"
 	"github.com/99designs/aws-vault/keyring"
 	"github.com/99designs/aws-vault/vault"
@@ -19,118 +18,104 @@ const (
 	DefaultSessionDuration = time.Hour * 10
 )
 
+type execSessionProvider interface {
+	Session(conf vault.SessionConfig) (vault.SessionCredentials, error)
+}
+
+type execProfileConfig interface {
+	Profile(name string) (*vault.Profile, error)
+}
+
 // Executes a subcommand with credentials passed to it via the environment
 type ExecCommand struct {
-	Ui cli.Ui
-
-	// things passed in from main
-	Keyring        keyring.Keyring
-	MFASerial      string
-	Env            []string
-	DefaultProfile string
-
-	// template functions for testing
-	loadProfileFunc func(name string) (vault.AWSProfile, error)
-	execFunc        func(cmd string, argv []string, env []string) error
+	Ui              cli.Ui
+	Keyring         keyring.Keyring
+	env             []string
+	sessionProvider execSessionProvider
+	profileConfig   execProfileConfig
 }
 
 func (c *ExecCommand) Run(args []string) int {
 	var (
-		refresh, noMfa, noSession, session bool
-		profileName                        string
-		sessionDuration                    time.Duration
+		refresh, noSession, session bool
+		profileName                 string
+		sessionDuration             time.Duration
 	)
 	flagSet := flag.NewFlagSet("exec", flag.ExitOnError)
-	flagSet.StringVar(&profileName, "profile", c.DefaultProfile, "")
-	flagSet.StringVar(&profileName, "p", c.DefaultProfile, "")
+	flagSet.StringVar(&profileName, "profile", ProfileFromEnv(), "")
+	flagSet.StringVar(&profileName, "p", ProfileFromEnv(), "")
 	flagSet.BoolVar(&session, "session", true, "")
 	flagSet.DurationVar(&sessionDuration, "duration", DefaultSessionDuration, "")
 	flagSet.BoolVar(&refresh, "refresh", false, "")
-	flagSet.BoolVar(&noMfa, "no-mfa", false, "")
 	flagSet.BoolVar(&noSession, "no-session", false, "")
 	flagSet.Usage = func() { c.Ui.Output(c.Help()) }
 
 	if err := flagSet.Parse(args); err != nil {
-		c.Ui.Error(err.Error())
+		c.Ui.Error("Error parsing flags: " + err.Error())
 		return 1
 	}
 
 	cmdArgs := flagSet.Args()
 	if len(cmdArgs) < 1 {
-		c.Ui.Output(c.Help())
+		c.Ui.Output("Expected arguments: " + c.Help())
 		return 1
 	}
 
-	if c.loadProfileFunc == nil {
-		c.loadProfileFunc = vault.LoadAWSProfile
+	if c.Keyring == nil {
+		c.Keyring = keyring.DefaultKeyring
 	}
 
-	profile, err := c.loadProfileFunc(profileName)
+	if c.profileConfig == nil {
+		c.profileConfig = vault.DefaultProfileConfig
+	}
+
+	profile, err := c.profileConfig.Profile(profileName)
+	if err != nil {
+		c.Ui.Output(err.Error())
+		return 1
+	}
+
+	if c.env == nil {
+		c.env = os.Environ()
+	}
+
+	c.env = append(c.env, "AWS_DEFAULT_PROFILE="+profile.Name)
+
+	if session && !noSession {
+		if c.sessionProvider == nil {
+			c.sessionProvider = &vault.KeyringSessionProvider{
+				Keyring: c.Keyring,
+				CredsFunc: func() (vault.Credentials, error) {
+					return profile.Keyring(c.Keyring).Read()
+				},
+			}
+		}
+		sessCreds, err := c.sessionProvider.Session(vault.SessionConfig{
+			Profile:    profile,
+			TokenAgent: c,
+			Duration:   sessionDuration,
+		})
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		c.env = append(c.env, sessCreds.Environ()...)
+	} else {
+		creds, err := profile.Keyring(c.Keyring).Read()
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		c.env = append(c.env, creds.Environ()...)
+	}
+
+	bin, err := exec.LookPath(cmdArgs[0])
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
 	}
 
-	if !noMfa && profile.MFASerial != "" {
-		c.MFASerial = profile.MFASerial
-	}
-
-	env := append(c.Env, "AWS_DEFAULT_PROFILE="+profileName)
-
-	if session && !noSession {
-		var sessionCreds *vault.SessionCredentials
-		var err error
-		var sourceProfile string = profileName
-
-		if profile.SourceProfile != "" {
-			sourceProfile = profile.SourceProfile
-		}
-
-		// look for cached session credentials first
-		keyring.Unmarshal(c.Keyring, vault.SessionServiceName, profileName, &sessionCreds)
-
-		// otherwise get fresh credentials
-		if sessionCreds == nil || refresh || time.Now().After(*sessionCreds.Expiration) {
-			if profile.RoleARN != "" {
-				sessionCreds, err = c.assumeRole(sourceProfile, profile.RoleARN, sessionDuration)
-				if err != nil {
-					c.Ui.Error(err.Error())
-					return 1
-				}
-			} else {
-				sessionCreds, err = c.session(sourceProfile, sessionDuration)
-				if err != nil {
-					c.Ui.Error(err.Error())
-					return 1
-				}
-			}
-
-			// cache the session credentials for next time
-			err = keyring.Marshal(c.Keyring, vault.SessionServiceName, profileName, sessionCreds)
-			if err != nil {
-				c.Ui.Error(err.Error())
-				return 1
-			}
-		}
-
-		env = append(env, "AWS_ACCESS_KEY_ID="+*sessionCreds.AccessKeyID)
-		env = append(env, "AWS_SECRET_ACCESS_KEY="+*sessionCreds.SecretAccessKey)
-		env = append(env, "AWS_SESSION_TOKEN="+*sessionCreds.SessionToken)
-	} else {
-		creds, err := c.credentials(profileName)
-		if err != nil {
-			c.Ui.Error(err.Error())
-			return 1
-		}
-
-		env = append(env, creds.Environ()...)
-	}
-
-	if c.execFunc == nil {
-		c.execFunc = c.exec
-	}
-
-	if err = c.execFunc(cmdArgs[0], cmdArgs, env); err != nil {
+	if err = syscall.Exec(bin, cmdArgs, c.env); err != nil {
 		c.Ui.Error(err.Error())
 		return 1
 	}
@@ -138,80 +123,13 @@ func (c *ExecCommand) Run(args []string) int {
 	return 0
 }
 
-func (c *ExecCommand) exec(cmd string, argv []string, env []string) error {
-	bin, err := exec.LookPath(argv[0])
-	if err != nil {
-		return err
-	}
-
-	return syscall.Exec(bin, argv, env)
-}
-
-func (c *ExecCommand) promptToken(MFASerial string) (string, error) {
-	token, err := c.Ui.AskSecret(fmt.Sprintf("Enter token code for %q:", MFASerial))
+func (c *ExecCommand) GetToken(serial string) (string, error) {
+	token, err := c.Ui.AskSecret(fmt.Sprintf("Enter token code for %q:", serial))
 	if err != nil {
 		return "", err
 	}
 	c.Ui.Output("")
 	return token, nil
-}
-
-func (c *ExecCommand) credentials(sourceProfile string) (*vault.Credentials, error) {
-	var creds vault.Credentials
-	if err := keyring.Unmarshal(c.Keyring, vault.ServiceName, sourceProfile, &creds); err != nil {
-		return nil, err
-	}
-	return &creds, nil
-}
-
-func (c *ExecCommand) session(sourceProfile string, d time.Duration) (*vault.SessionCredentials, error) {
-	creds, err := c.credentials(sourceProfile)
-	if err != nil {
-		return nil, err
-	}
-	input := &sts.GetSessionTokenInput{
-		DurationSeconds: aws.Int64(int64(d.Seconds())),
-	}
-	if c.MFASerial != "" {
-		token, err := c.promptToken(c.MFASerial)
-		if err != nil {
-			return nil, err
-		}
-		input.SerialNumber = aws.String(c.MFASerial)
-		input.TokenCode = aws.String(token)
-	}
-	svc := sts.New(creds.AwsConfig())
-	resp, err := svc.GetSessionToken(input)
-	if err != nil {
-		return nil, err
-	}
-	return &vault.SessionCredentials{resp.Credentials}, nil
-}
-
-func (c *ExecCommand) assumeRole(sourceProfile string, roleArn string, d time.Duration) (*vault.SessionCredentials, error) {
-	creds, err := c.credentials(sourceProfile)
-	if err != nil {
-		return nil, err
-	}
-	input := &sts.AssumeRoleInput{
-		RoleARN:         aws.String(roleArn),
-		RoleSessionName: aws.String(sourceProfile),
-		DurationSeconds: aws.Int64(int64(d.Seconds())),
-	}
-	if c.MFASerial != "" {
-		token, err := c.promptToken(c.MFASerial)
-		if err != nil {
-			return nil, err
-		}
-		input.SerialNumber = aws.String(c.MFASerial)
-		input.TokenCode = aws.String(token)
-	}
-	svc := sts.New(creds.AwsConfig())
-	resp, err := svc.AssumeRole(input)
-	if err != nil {
-		return nil, err
-	}
-	return &vault.SessionCredentials{resp.Credentials}, nil
 }
 
 func (c *ExecCommand) Help() string {

--- a/command/exec.go
+++ b/command/exec.go
@@ -18,21 +18,13 @@ const (
 	DefaultSessionDuration = time.Hour * 10
 )
 
-type execSessionProvider interface {
-	Session(conf vault.SessionConfig) (vault.SessionCredentials, error)
-}
-
-type execProfileConfig interface {
-	Profile(name string) (*vault.Profile, error)
-}
-
 // Executes a subcommand with credentials passed to it via the environment
 type ExecCommand struct {
 	Ui              cli.Ui
 	Keyring         keyring.Keyring
 	env             []string
-	sessionProvider execSessionProvider
-	profileConfig   execProfileConfig
+	sessionProvider sessionProvider
+	profileConfig   profileConfig
 }
 
 func (c *ExecCommand) Run(args []string) int {

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -1,0 +1,23 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/mitchellh/cli"
+)
+
+func TestExecCommand_implements(t *testing.T) {
+	var _ cli.Command = &ExecCommand{}
+}
+
+func TestExecCommandRun(t *testing.T) {
+	ui := new(cli.MockUi)
+	c := &ExecCommand{
+		Ui: ui, sessionProvider: &fakeSessionProvider{},
+	}
+	args := []string{"true"}
+	code := c.Run(args)
+	if code != 0 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+}

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -1,9 +1,12 @@
 package command
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/mitchellh/cli"
+	"github.com/99designs/aws-vault/keyring"
+	"github.com/99designs/aws-vault/vault"
 )
 
 func TestExecCommand_implements(t *testing.T) {
@@ -12,12 +15,42 @@ func TestExecCommand_implements(t *testing.T) {
 
 func TestExecCommandRun(t *testing.T) {
 	ui := new(cli.MockUi)
-	c := &ExecCommand{
-		Ui: ui, sessionProvider: &fakeSessionProvider{},
+	kr := &keyring.ArrayKeyring{}
+	p := &vault.Profile{Name: "llamas"}
+
+	if err := p.Keyring(kr).Store(vault.Credentials{"ABCDEFG", "XYZ"}); err != nil {
+		t.Fatal(err)
 	}
-	args := []string{"true"}
-	code := c.Run(args)
+
+	c := &ExecCommand{
+		Ui:              ui,
+		Keyring:         kr,
+		sessionProvider: &testSessionProvider{},
+		profileConfig:   vault.NewProfileConfig(p),
+	}
+	code := c.Run([]string{"-profile", "llamas", "true"})
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+}
+
+func TestExecCommandRunWithMissingProfile(t *testing.T) {
+	ui := new(cli.MockUi)
+	kr := &keyring.ArrayKeyring{}
+
+	c := &ExecCommand{
+		Ui:              ui,
+		Keyring:         kr,
+		sessionProvider: &testSessionProvider{},
+		profileConfig:   vault.NewProfileConfig(),
+	}
+
+	code := c.Run([]string{"-profile", "llamas", "true"})
+	if code != 1 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+
+	if !strings.Contains(ui.OutputWriter.String(), "Profile 'llamas' not found") {
+		t.Fatalf("bad: %#v", ui.OutputWriter.String())
 	}
 }

--- a/command/list.go
+++ b/command/list.go
@@ -14,7 +14,6 @@ type ListCommand struct {
 }
 
 func (c *ListCommand) Run(args []string) int {
-
 	profileNames, err := c.Keyring.List(vault.ServiceName)
 	if err != nil {
 		c.Ui.Error(err.Error())
@@ -22,7 +21,6 @@ func (c *ListCommand) Run(args []string) int {
 	}
 
 	c.Ui.Output(strings.Join(profileNames, "\n"))
-
 	return 0
 }
 

--- a/command/list.go
+++ b/command/list.go
@@ -14,13 +14,18 @@ type ListCommand struct {
 }
 
 func (c *ListCommand) Run(args []string) int {
+	if c.Keyring == nil {
+		c.Keyring = keyring.DefaultKeyring
+	}
+
 	profileNames, err := c.Keyring.List(vault.ServiceName)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 4
 	}
-
-	c.Ui.Output(strings.Join(profileNames, "\n"))
+	for _, p := range profileNames {
+		c.Ui.Output(p)
+	}
 	return 0
 }
 

--- a/command/list_test.go
+++ b/command/list_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/mitchellh/cli"
 	"github.com/99designs/aws-vault/keyring"
+	"github.com/99designs/aws-vault/vault"
 )
 
 func TestListCommand_implements(t *testing.T) {
@@ -15,8 +16,9 @@ func TestListCommand_implements(t *testing.T) {
 func TestListCommandRun(t *testing.T) {
 	ui := new(cli.MockUi)
 	kr := &keyring.ArrayKeyring{}
+	p := &vault.Profile{Name: "llamas"}
 
-	if err := storeCredentials(kr, "llamas", "ABCDEFG", "XYZ"); err != nil {
+	if err := p.Keyring(kr).Store(vault.Credentials{"ABCDEFG", "XYZ"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/command/list_test.go
+++ b/command/list_test.go
@@ -1,0 +1,33 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/mitchellh/cli"
+	"github.com/99designs/aws-vault/keyring"
+)
+
+func TestListCommand_implements(t *testing.T) {
+	var _ cli.Command = &ListCommand{}
+}
+
+func TestListCommandRun(t *testing.T) {
+	ui := new(cli.MockUi)
+	kr := &keyring.ArrayKeyring{}
+
+	if err := storeCredentials(kr, "llamas", "ABCDEFG", "XYZ"); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &ListCommand{Ui: ui, Keyring: kr}
+	args := []string{}
+	code := c.Run(args)
+	if code != 0 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+
+	if !strings.Contains(ui.OutputWriter.String(), "llamas") {
+		t.Fatalf("bad: %#v", ui.OutputWriter.String())
+	}
+}

--- a/command/remove.go
+++ b/command/remove.go
@@ -10,10 +10,14 @@ import (
 	"github.com/99designs/aws-vault/vault"
 )
 
+type removeProfileConfig interface {
+	Profile(name string) (*vault.Profile, error)
+}
+
 type RemoveCommand struct {
-	Ui             cli.Ui
-	Keyring        keyring.Keyring
-	DefaultProfile string
+	Ui            cli.Ui
+	Keyring       keyring.Keyring
+	profileConfig removeProfileConfig
 }
 
 func (c *RemoveCommand) Run(args []string) int {
@@ -21,12 +25,25 @@ func (c *RemoveCommand) Run(args []string) int {
 		profileName string
 	)
 	flagSet := flag.NewFlagSet("rm", flag.ExitOnError)
-	flagSet.StringVar(&profileName, "profile", c.DefaultProfile, "")
-	flagSet.StringVar(&profileName, "p", c.DefaultProfile, "")
+	flagSet.StringVar(&profileName, "profile", ProfileFromEnv(), "")
+	flagSet.StringVar(&profileName, "p", ProfileFromEnv(), "")
 	flagSet.Usage = func() { c.Ui.Output(c.Help()) }
 
 	if err := flagSet.Parse(args); err != nil {
 		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	if c.Keyring == nil {
+		c.Keyring = keyring.DefaultKeyring
+	}
+
+	if c.profileConfig == nil {
+		c.profileConfig = vault.DefaultProfileConfig
+	}
+
+	if _, err := c.profileConfig.Profile(profileName); err != nil {
+		c.Ui.Output(err.Error())
 		return 1
 	}
 

--- a/command/remove.go
+++ b/command/remove.go
@@ -10,14 +10,10 @@ import (
 	"github.com/99designs/aws-vault/vault"
 )
 
-type removeProfileConfig interface {
-	Profile(name string) (*vault.Profile, error)
-}
-
 type RemoveCommand struct {
 	Ui            cli.Ui
 	Keyring       keyring.Keyring
-	profileConfig removeProfileConfig
+	profileConfig profileConfig
 }
 
 func (c *RemoveCommand) Run(args []string) int {

--- a/command/store.go
+++ b/command/store.go
@@ -10,14 +10,10 @@ import (
 	"github.com/99designs/aws-vault/vault"
 )
 
-type storeProfileConfig interface {
-	Profile(name string) (*vault.Profile, error)
-}
-
 type StoreCommand struct {
 	Ui            cli.Ui
 	Keyring       keyring.Keyring
-	profileConfig storeProfileConfig
+	profileConfig profileConfig
 }
 
 func (c *StoreCommand) Run(args []string) int {
@@ -44,7 +40,7 @@ func (c *StoreCommand) Run(args []string) int {
 
 	profile, err := c.profileConfig.Profile(profileName)
 	if err != nil {
-		c.Ui.Output(err.Error())
+		c.Ui.Error(err.Error())
 		return 1
 	}
 

--- a/command/store.go
+++ b/command/store.go
@@ -69,12 +69,6 @@ func (c *StoreCommand) Run(args []string) int {
 	return 0
 }
 
-func storeCredentials(k keyring.Keyring, profileName, accessKeyId, secretKey string) error {
-	creds := vault.Credentials{accessKeyId, secretKey}
-
-	return keyring.Marshal(k, vault.ServiceName, profileName, &creds)
-}
-
 func (c *StoreCommand) Help() string {
 	helpText := `
 Usage: aws-vault store [--profile=default]

--- a/command/store_test.go
+++ b/command/store_test.go
@@ -1,0 +1,41 @@
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/mitchellh/cli"
+	"github.com/99designs/aws-vault/keyring"
+	"github.com/99designs/aws-vault/vault"
+)
+
+func TestStoreCommand_implements(t *testing.T) {
+	var _ cli.Command = &StoreCommand{}
+}
+
+func TestStoreCommandRunUsesDefault(t *testing.T) {
+	ui := &cli.MockUi{InputReader: bytes.NewBufferString("ABC\nXYZ\n")}
+	kr := &keyring.ArrayKeyring{}
+	p := &vault.Profile{Name: "default"}
+
+	c := &StoreCommand{Ui: ui, Keyring: kr, profileConfig: vault.NewProfileConfig(p)}
+	code := c.Run([]string{})
+	if code != 0 {
+		fmt.Println(ui.OutputWriter.String())
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+
+	creds, err := p.Keyring(kr).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if creds.AccessKeyId != "ABC" {
+		t.Fatalf("Unexpected AccessKeyId of %q", creds.AccessKeyId)
+	}
+
+	if creds.SecretKey != "XYZ" {
+		t.Fatalf("Unexpected SecretKey of %q", creds.SecretKey)
+	}
+}

--- a/command/util.go
+++ b/command/util.go
@@ -1,0 +1,11 @@
+package command
+
+import "github.com/99designs/aws-vault/vault"
+
+type sessionProvider interface {
+	Session(conf vault.SessionConfig) (vault.SessionCredentials, error)
+}
+
+type profileConfig interface {
+	Profile(name string) (*vault.Profile, error)
+}

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -1,0 +1,10 @@
+package command
+
+import "github.com/99designs/aws-vault/vault"
+
+type fakeSessionProvider struct {
+}
+
+func (f *fakeSessionProvider) Session(conf vault.SessionConfig) (vault.SessionCredentials, error) {
+	return vault.SessionCredentials{}, nil
+}

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -2,9 +2,10 @@ package command
 
 import "github.com/99designs/aws-vault/vault"
 
-type fakeSessionProvider struct {
+type testSessionProvider struct {
+	Creds vault.SessionCredentials
 }
 
-func (f *fakeSessionProvider) Session(conf vault.SessionConfig) (vault.SessionCredentials, error) {
-	return vault.SessionCredentials{}, nil
+func (t *testSessionProvider) Session(conf vault.SessionConfig) (vault.SessionCredentials, error) {
+	return t.Creds, nil
 }

--- a/keyring/array.go
+++ b/keyring/array.go
@@ -13,7 +13,14 @@ func (k *ArrayKeyring) Get(service, key string) ([]byte, error) {
 }
 
 func (k *ArrayKeyring) Set(service, key string, secret []byte) error {
-	k.secrets[service][key] = secret
+	if k.secrets == nil {
+		k.secrets = map[string]map[string][]byte{}
+	}
+	if _, ok := k.secrets[service]; !ok {
+		k.secrets[service] = map[string][]byte{key: secret}
+	} else {
+		k.secrets[service][key] = secret
+	}
 	return nil
 }
 

--- a/keyring/array.go
+++ b/keyring/array.go
@@ -1,0 +1,39 @@
+package keyring
+
+type ArrayKeyring struct {
+	secrets map[string]map[string][]byte
+}
+
+func (k *ArrayKeyring) Get(service, key string) ([]byte, error) {
+	if b, ok := k.secrets[service][key]; ok {
+		return b, nil
+	} else {
+		return nil, ErrKeyNotFound
+	}
+}
+
+func (k *ArrayKeyring) Set(service, key string, secret []byte) error {
+	k.secrets[service][key] = secret
+	return nil
+}
+
+func (k *ArrayKeyring) Remove(service, key string) error {
+	if service, ok := k.secrets[service]; !ok {
+		return ErrKeyNotFound
+	} else {
+		delete(service, key)
+	}
+	return nil
+}
+
+func (k *ArrayKeyring) List(service string) ([]string, error) {
+	if serviceSecrets, ok := k.secrets[service]; !ok {
+		return nil, ErrKeyNotFound
+	} else {
+		var keys = []string{}
+		for key := range serviceSecrets {
+			keys = append(keys, key)
+		}
+		return keys, nil
+	}
+}

--- a/keyring/array_test.go
+++ b/keyring/array_test.go
@@ -1,0 +1,20 @@
+package keyring
+
+import "testing"
+
+func TestArrayKeyringSetWhenEmpty(t *testing.T) {
+	k := &ArrayKeyring{}
+
+	if err := k.Set("test", "llamas", []byte("llamas are great")); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := k.Get("test", "llamas")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(v) != "llamas are great" {
+		t.Fatalf("Value stored was not the value retrieved: %q", v)
+	}
+}

--- a/keyring/keychain_darwin.go
+++ b/keyring/keychain_darwin.go
@@ -11,7 +11,11 @@ func (k *OSXKeychain) Get(service, key string) ([]byte, error) {
 		AccountName: key,
 	}
 
-	return keychain.FindGenericPassword(&attributes)
+	if b, err := keychain.FindGenericPassword(&attributes); err == keychain.ErrItemNotFound {
+		return b, ErrKeyNotFound
+	} else {
+		return b, err
+	}
 }
 
 func (k *OSXKeychain) Set(service, key string, secret []byte) error {
@@ -35,7 +39,11 @@ func (k *OSXKeychain) Remove(service, key string) error {
 		AccountName: key,
 	}
 
-	return keychain.FindAndRemoveGenericPassword(&attributes)
+	if err := keychain.FindAndRemoveGenericPassword(&attributes); err == keychain.ErrItemNotFound {
+		return ErrKeyNotFound
+	} else {
+		return err
+	}
 }
 
 func (k *OSXKeychain) List(service string) ([]string, error) {

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -1,6 +1,9 @@
 package keyring
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+)
 
 type Keyring interface {
 	Get(service, key string) ([]byte, error)
@@ -29,3 +32,5 @@ func Unmarshal(k Keyring, service, key string, obj interface{}) error {
 }
 
 var DefaultKeyring Keyring
+
+var ErrKeyNotFound = errors.New("The specified item could not be found in the keychain.")

--- a/vault/credentials.go
+++ b/vault/credentials.go
@@ -1,15 +1,6 @@
 package vault
 
-import (
-	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws"
-	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/aws/aws-sdk-go/service/sts"
-)
-
-const (
-	ServiceName        = "aws-vault"
-	SessionServiceName = "aws-vault.sessions"
-)
+import "github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/aws/aws-sdk-go/service/sts"
 
 type Credentials struct {
 	AccessKeyId string
@@ -23,12 +14,17 @@ func (c Credentials) Environ() []string {
 	}
 }
 
-func (c Credentials) AwsConfig() *aws.Config {
-	return aws.DefaultConfig.WithCredentials(credentials.NewStaticCredentials(
-		c.AccessKeyId, c.SecretKey, "",
-	))
-}
-
 type SessionCredentials struct {
 	*sts.Credentials
+}
+
+func (sc SessionCredentials) Environ() []string {
+	if sc.Credentials == nil {
+		return []string{}
+	}
+	return []string{
+		"AWS_ACCESS_KEY_ID=" + *sc.Credentials.AccessKeyID,
+		"AWS_SECRET_ACCESS_KEY=" + *sc.Credentials.SecretAccessKey,
+		"AWS_SESSION_TOKEN=" + *sc.Credentials.SessionToken,
+	}
 }

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -1,0 +1,41 @@
+package vault
+
+import "github.com/99designs/aws-vault/keyring"
+
+const (
+	ServiceName        = "aws-vault"
+	SessionServiceName = "aws-vault.sessions"
+)
+
+type ProfileKeyring struct {
+	kr      keyring.Keyring
+	profile *Profile
+}
+
+func (pk *ProfileKeyring) Read() (Credentials, error) {
+	var sourceProfile string = pk.profile.Name
+	if pk.profile.SourceProfile != nil {
+		sourceProfile = pk.profile.SourceProfile.Name
+	}
+	var creds Credentials
+	err := keyring.Unmarshal(pk.kr, ServiceName, sourceProfile, &creds)
+	return creds, err
+}
+
+func (pk *ProfileKeyring) Store(c Credentials) error {
+	return keyring.Marshal(pk.kr, ServiceName, pk.profile.Name, &c)
+}
+
+func (pk *ProfileKeyring) ReadSession() (SessionCredentials, error) {
+	var sourceProfile string = pk.profile.Name
+	if pk.profile.SourceProfile != nil {
+		sourceProfile = pk.profile.SourceProfile.Name
+	}
+	var creds SessionCredentials
+	err := keyring.Unmarshal(pk.kr, SessionServiceName, sourceProfile, &creds)
+	return creds, err
+}
+
+func (pk *ProfileKeyring) StoreSession(c SessionCredentials) error {
+	return keyring.Marshal(pk.kr, SessionServiceName, pk.profile.Name, &c)
+}

--- a/vault/profiles.go
+++ b/vault/profiles.go
@@ -7,48 +7,96 @@ import (
 	"strings"
 
 	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/vaughan0/go-ini"
+	"github.com/99designs/aws-vault/keyring"
 )
 
-var AWSConfigFile string
+var DefaultProfileConfig = &ProfileConfig{}
 
-func init() {
-	AWSConfigFile = os.Getenv("AWS_CONFIG_FILE")
-	if AWSConfigFile == "" {
-		usr, err := user.Current()
-		if err != nil {
-			panic(err)
-		}
-		AWSConfigFile = usr.HomeDir + "/.aws/config"
-	}
+type ProfileConfig struct {
+	File     string
+	parsed   bool
+	profiles map[string]*Profile
 }
 
-type AWSProfile struct {
+type Profile struct {
 	Name          string
 	Region        string
 	MFASerial     string
 	RoleARN       string
-	SourceProfile string
+	SourceProfile *Profile
 }
 
-func LoadAWSProfile(name string) (AWSProfile, error) {
-	f, err := ini.LoadFile(AWSConfigFile)
-	if err != nil {
-		return AWSProfile{}, err
+func defaultConfigFile() (string, error) {
+	file := os.Getenv("AWS_CONFIG_FILE")
+	if file == "" {
+		usr, err := user.Current()
+		if err != nil {
+			return "", err
+		}
+		file = usr.HomeDir + "/.aws/config"
 	}
-	for sectionName, section := range f {
-		if strings.TrimPrefix(sectionName, "profile ") == name {
-			return AWSProfile{
-				Region:        section["region"],
-				MFASerial:     section["mfa_serial"],
-				RoleARN:       section["role_arn"],
-				SourceProfile: section["source_profile"],
-			}, nil
+	return file, nil
+}
+
+func (c *ProfileConfig) parse() error {
+	if c.File == "" {
+		if file, err := defaultConfigFile(); err != nil {
+			return err
+		} else {
+			c.File = file
 		}
 	}
-	err = fmt.Errorf(
-		"Profile '%s' not found in %s",
-		name,
-		AWSConfigFile,
-	)
-	return AWSProfile{}, err
+
+	c.profiles = map[string]*Profile{}
+	sources := map[string]string{}
+	f, err := ini.LoadFile(c.File)
+	if err != nil {
+		return err
+	}
+
+	// read default and profiles
+	for sectionName, section := range f {
+		name := strings.TrimPrefix(sectionName, "profile ")
+		c.profiles[name] = &Profile{
+			Name:      name,
+			Region:    section["region"],
+			MFASerial: section["mfa_serial"],
+			RoleARN:   section["role_arn"],
+		}
+		if section["source_profile"] != "" {
+			sources[name] = section["source_profile"]
+		}
+	}
+
+	// link source_profile stanzas
+	for k, v := range sources {
+		p, ok := c.profiles[v]
+		if !ok {
+			return fmt.Errorf("Profile %s references a non-existent source %s", k, v)
+		}
+		c.profiles[k].SourceProfile = p
+	}
+	return nil
+}
+
+func (c *ProfileConfig) Profile(name string) (*Profile, error) {
+	if !c.parsed {
+		if err := c.parse(); err != nil {
+			return nil, err
+		}
+		c.parsed = true
+	}
+	profile, ok := c.profiles[name]
+	if !ok {
+		return &Profile{Name: name}, fmt.Errorf(
+			"Profile '%s' not found in %s",
+			name,
+			c.File,
+		)
+	}
+	return profile, nil
+}
+
+func (p *Profile) Keyring(k keyring.Keyring) *ProfileKeyring {
+	return &ProfileKeyring{k, p}
 }

--- a/vault/profiles.go
+++ b/vault/profiles.go
@@ -18,6 +18,20 @@ type ProfileConfig struct {
 	profiles map[string]*Profile
 }
 
+func NewProfileConfig(profiles ...*Profile) *ProfileConfig {
+	c := &ProfileConfig{
+		File:     "map",
+		profiles: map[string]*Profile{},
+		parsed:   true,
+	}
+
+	for _, p := range profiles {
+		c.profiles[p.Name] = p
+	}
+
+	return c
+}
+
 type Profile struct {
 	Name          string
 	Region        string

--- a/vault/session.go
+++ b/vault/session.go
@@ -1,0 +1,117 @@
+package vault
+
+import (
+	"time"
+
+	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws"
+	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/99designs/aws-vault/Godeps/_workspace/src/github.com/aws/aws-sdk-go/service/sts"
+	"github.com/99designs/aws-vault/keyring"
+)
+
+type TokenAgent interface {
+	GetToken(serial string) (string, error)
+}
+
+type SessionConfig struct {
+	Profile     *Profile
+	TokenAgent  TokenAgent
+	Duration    time.Duration
+	Credentials *Credentials
+	Refresh     bool
+}
+
+type SessionProvider struct {
+}
+
+func (sp *SessionProvider) Session(conf SessionConfig) (SessionCredentials, error) {
+	awsConf := aws.DefaultConfig
+
+	if conf.Credentials != nil {
+		awsConf = awsConf.WithCredentials(credentials.NewStaticCredentials(
+			conf.Credentials.AccessKeyId, conf.Credentials.SecretKey, "",
+		))
+	}
+
+	svc := sts.New(awsConf)
+
+	var serialNumber, token string
+
+	if conf.Profile.MFASerial != "" && conf.TokenAgent != nil {
+		var err error
+		if token, err = conf.TokenAgent.GetToken(conf.Profile.MFASerial); err != nil {
+			return SessionCredentials{}, err
+		}
+		serialNumber = conf.Profile.MFASerial
+	}
+
+	// handle assume role
+	if conf.Profile.RoleARN != "" {
+		input := &sts.AssumeRoleInput{
+			RoleARN:         aws.String(conf.Profile.RoleARN),
+			RoleSessionName: aws.String(conf.Profile.Name),
+			DurationSeconds: aws.Int64(int64(conf.Duration.Seconds())),
+			SerialNumber:    aws.String(serialNumber),
+			TokenCode:       aws.String(token),
+		}
+
+		resp, err := svc.AssumeRole(input)
+		if err != nil {
+			return SessionCredentials{}, err
+		}
+		return SessionCredentials{resp.Credentials}, nil
+	}
+
+	// otherwise get a session token
+	input := &sts.GetSessionTokenInput{
+		DurationSeconds: aws.Int64(int64(conf.Duration.Seconds())),
+		SerialNumber:    aws.String(serialNumber),
+		TokenCode:       aws.String(token),
+	}
+
+	resp, err := svc.GetSessionToken(input)
+	if err != nil {
+		return SessionCredentials{}, err
+	}
+
+	return SessionCredentials{resp.Credentials}, nil
+}
+
+type KeyringSessionProvider struct {
+	SessionProvider
+	Keyring   keyring.Keyring
+	CredsFunc func() (Credentials, error)
+}
+
+func (ksp *KeyringSessionProvider) Session(conf SessionConfig) (SessionCredentials, error) {
+	var sessionCreds *SessionCredentials
+
+	if !conf.Refresh {
+		// look for cached session credentials first
+		keyring.Unmarshal(ksp.Keyring, SessionServiceName, conf.Profile.Name, &sessionCreds)
+	}
+
+	if sessionCreds == nil || time.Now().After(*sessionCreds.Expiration) {
+		if ksp.CredsFunc != nil {
+			creds, err := ksp.CredsFunc()
+			if err != nil {
+				return SessionCredentials{}, err
+			}
+			conf.Credentials = &creds
+		}
+
+		newCreds, err := ksp.SessionProvider.Session(conf)
+		if err != nil {
+			return SessionCredentials{}, err
+		}
+
+		// cache the session credentials for next time
+		if err = keyring.Marshal(ksp.Keyring, SessionServiceName, conf.Profile.Name, &newCreds); err != nil {
+			return SessionCredentials{}, err
+		}
+
+		sessionCreds = &newCreds
+	}
+
+	return *sessionCreds, nil
+}


### PR DESCRIPTION
My aim here was to apply [SRP](https://en.wikipedia.org/wiki/Single_responsibility_principle) more to the exec command so that it's easier (or possible at all) to test. 

This moves the logic for getting temporary session credentials from AWS into `vault/session.go`, which should in turn be easier to test its self. The keychain session caching moves into a decorator.

Along the way, this also wraps access to the serialized credentials in a decorate on the Keychain that is accessible from the new Profile object. 
