### PR TITLE
Add a profile to your aws config when storing keys

### DIFF
--- a/add.go
+++ b/add.go
@@ -17,7 +17,7 @@ func AddCommand(ui Ui, input AddCommandInput) {
 		ui.Error.Fatal(err)
 	}
 
-	secretKey, err := speakeasy.Ask("Enter Secret Access Key: ")
+	secretKey, err := speakeasy.Ask("Enter Secret Access Key : ")
 	if err != nil {
 		ui.Error.Fatal(err)
 	}
@@ -26,6 +26,13 @@ func AddCommand(ui Ui, input AddCommandInput) {
 	provider := &KeyringProvider{Keyring: input.Keyring, Profile: input.Profile}
 
 	if err := provider.Store(creds); err != nil {
+		ui.Error.Fatal(err)
+	}
+
+	if exists, err := profileExists(input.Profile); !exists {
+		ui.Printf("Profile didn't exist in your aws config, adding it")
+		addProfile(input.Profile)
+	} else if err != nil {
 		ui.Error.Fatal(err)
 	}
 

--- a/add.go
+++ b/add.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/99designs/aws-vault/keyring"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/bgentry/speakeasy"
 )
 
 type AddCommandInput struct {
@@ -17,7 +16,7 @@ func AddCommand(ui Ui, input AddCommandInput) {
 		ui.Error.Fatal(err)
 	}
 
-	secretKey, err := speakeasy.Ask("Enter Secret Access Key : ")
+	secretKey, err := promptPassword("Enter Secret Access Key : ")
 	if err != nil {
 		ui.Error.Fatal(err)
 	}

--- a/prompt.go
+++ b/prompt.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/bgentry/speakeasy"
 )
 
 func prompt(prompt string) (string, error) {
@@ -15,4 +17,8 @@ func prompt(prompt string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(text), nil
+}
+
+func promptPassword(prompt string) (string, error) {
+	return speakeasy.Ask(prompt)
 }


### PR DESCRIPTION
I've noticed that people add keys without having a profile in `~/.aws/config`, this is a slightly hacky fix for this, it appends an empty profile.