### PR TITLE
Configurable session time, default 8 hours (was 15m)

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/99designs/aws-vault/keyring"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -10,14 +11,15 @@ import (
 )
 
 type ExecCommandInput struct {
-	Profile string
-	Command string
-	Args    []string
-	Keyring keyring.Keyring
+	Profile  string
+	Command  string
+	Args     []string
+	Keyring  keyring.Keyring
+	Duration time.Duration
 }
 
 func ExecCommand(ui Ui, input ExecCommandInput) {
-	provider, err := NewVaultProvider(input.Keyring, input.Profile)
+	provider, err := NewVaultProvider(input.Keyring, input.Profile, input.Duration)
 	if err != nil {
 		ui.Error.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"time"
 
 	"github.com/99designs/aws-vault/keyring"
 
@@ -37,7 +36,7 @@ func main() {
 		ls               = kingpin.Command("ls", "List profiles")
 		exec             = kingpin.Command("exec", "Executes a command with AWS credentials in the environment")
 		execProfile      = exec.Arg("profile", "Name of the profile").Required().String()
-		execSessDuration = exec.Flag("duration", "Length of session duration").Duration()
+		execSessDuration = exec.Flag("session-ttl", "Expiration time for aws session").Default("8h").OverrideDefaultFromEnvar("AWS_SESSION_TTL").Short('t').Duration()
 		execCmd          = exec.Arg("cmd", "Command to execute").Required().String()
 		execCmdArgs      = exec.Arg("args", "Command arguments").Strings()
 		rm               = kingpin.Command("rm", "Removes credentials")
@@ -90,17 +89,12 @@ func main() {
 		})
 
 	case exec.FullCommand():
-		duration := time.Hour * 1
-		if execSessDuration != nil {
-			duration = *execSessDuration
-		}
-
 		ExecCommand(ui, ExecCommandInput{
 			Profile:  *execProfile,
 			Command:  *execCmd,
 			Args:     *execCmdArgs,
 			Keyring:  keyring,
-			Duration: duration,
+			Duration: *execSessDuration,
 		})
 	}
 }

--- a/provider.go
+++ b/provider.go
@@ -28,7 +28,7 @@ type VaultProvider struct {
 	client          stsClient
 }
 
-func NewVaultProvider(k keyring.Keyring, profile string) (*VaultProvider, error) {
+func NewVaultProvider(k keyring.Keyring, profile string, d time.Duration) (*VaultProvider, error) {
 	conf, err := parseProfiles()
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func NewVaultProvider(k keyring.Keyring, profile string) (*VaultProvider, error)
 	return &VaultProvider{
 		Keyring:         k,
 		Profile:         profile,
-		SessionDuration: time.Second * 900, // the shortest AWS will allow
+		SessionDuration: d,
 		ExpiryWindow:    time.Second * 90,
 		profilesConf:    conf,
 	}, nil
@@ -139,7 +139,7 @@ func (p *VaultProvider) assumeRole(session sts.Credentials, roleArn string) (sts
 	input := &sts.AssumeRoleInput{
 		RoleArn:         aws.String(roleArn),
 		RoleSessionName: aws.String(roleSessionName),
-		DurationSeconds: aws.Int64(int64(15 * 60)),
+		DurationSeconds: aws.Int64(int64(p.SessionDuration.Seconds())),
 	}
 
 	log.Printf("Assuming role %s", roleArn)


### PR DESCRIPTION
Where previously the session length was fixed at 15 minutes, this extends it to an hour. It also adds a duration flag to `exec`:

```bash
$ aws-vault exec --session-ttl 2h myprofile -- env     
```

Ping @mtibben @pda 