### PR TITLE
Store sessions encrypted on disk locally

### DIFF
--- a/add.go
+++ b/add.go
@@ -8,9 +8,10 @@ import (
 )
 
 type AddCommandInput struct {
-	Profile string
-	Keyring keyring.Keyring
-	FromEnv bool
+	Profile      string
+	Keyring      keyring.Keyring
+	SessionStore *sessionStore
+	FromEnv      bool
 }
 
 func AddCommand(ui Ui, input AddCommandInput) {
@@ -34,7 +35,11 @@ func AddCommand(ui Ui, input AddCommandInput) {
 	}
 
 	creds := credentials.Value{AccessKeyID: accessKeyId, SecretAccessKey: secretKey}
-	provider := &KeyringProvider{Keyring: input.Keyring, Profile: input.Profile}
+	provider := &KeyringProvider{
+		Keyring:      input.Keyring,
+		SessionStore: input.SessionStore,
+		Profile:      input.Profile,
+	}
 
 	if err := provider.Store(creds); err != nil {
 		ui.Error.Fatal(err)

--- a/session.go
+++ b/session.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"crypto/sha1"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/dvsekhvalnov/jose2go"
+)
+
+var sessionVersion = "1"
+var defaultSessionStore *sessionStore = newSessionStore(os.Getenv("AWSVAULT_SESSION_DIR"))
+
+type sessionKey struct {
+	credentials.Value
+	Profile   string
+	MFASerial string
+}
+
+func (s *sessionKey) String() string {
+	return fmt.Sprintf("%x",
+		sha1.Sum([]byte(fmt.Sprintf("%s:%s:%s", s.AccessKeyID, s.Profile, s.MFASerial))),
+	)
+}
+
+type sessionStore struct {
+	Dir    string
+	create sync.Once
+}
+
+func newSessionStore(dir string) *sessionStore {
+	return &sessionStore{Dir: dir}
+}
+
+func (s *sessionStore) dir() (string, error) {
+	dir := s.Dir
+	if dir == "" {
+		usr, err := user.Current()
+		if err != nil {
+			return dir, err
+		}
+		dir = usr.HomeDir + "/.awsvault/sessions/"
+	}
+
+	stat, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		os.MkdirAll(dir, 0700)
+	} else if err != nil && !stat.IsDir() {
+		err = fmt.Errorf("%s is a file, not a directory", dir)
+	}
+
+	return dir, nil
+}
+
+func (s *sessionStore) Get(key sessionKey) (sts.Credentials, error) {
+	dir, err := s.dir()
+	if err != nil {
+		return sts.Credentials{}, err
+	}
+
+	bytes, err := ioutil.ReadFile(filepath.Join(dir, key.String()))
+	if os.IsNotExist(err) {
+		return sts.Credentials{}, errSessionNotFound
+	} else if err != nil {
+		return sts.Credentials{}, err
+	}
+
+	payload, headers, err := jose.Decode(string(bytes), key.SecretAccessKey)
+	if err != nil {
+		return sts.Credentials{}, err
+	}
+
+	expires, err := time.Parse(time.RFC822Z, headers["expires"].(string))
+	if err != nil {
+		return sts.Credentials{}, err
+	}
+
+	if time.Now().After(expires) {
+		log.Printf("Found expired session, removing")
+		defer s.Remove(key)
+		return sts.Credentials{}, errSessionNotFound
+	}
+
+	var decoded sts.Credentials
+	err = json.Unmarshal([]byte(payload), &decoded)
+
+	return decoded, err
+}
+
+func (s *sessionStore) Set(key sessionKey, creds sts.Credentials) error {
+	bytes, err := json.Marshal(creds)
+	if err != nil {
+		return err
+	}
+
+	token, err := jose.Encrypt(string(bytes), jose.PBES2_HS256_A128KW, jose.A256GCM, key.SecretAccessKey,
+		jose.Headers(map[string]interface{}{
+			"keyid":   key.AccessKeyID,
+			"version": sessionVersion,
+			"expires": creds.Expiration.Format(time.RFC822Z),
+		}))
+	if err != nil {
+		return err
+	}
+
+	dir, err := s.dir()
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filepath.Join(dir, key.String()), []byte(token), 0600)
+}
+
+func (s *sessionStore) Remove(key sessionKey) error {
+	dir, err := s.dir()
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(filepath.Join(dir, key.String()))
+}
+
+var errSessionNotFound = errors.New("Session not found")


### PR DESCRIPTION
Previously sessions (from GetSessionToken and AssumeRole) were stored in the keyring. This had the annoying effect of prompting you about whether to allow access to the session, rather than simply the original profile. 

The secondary issue was that sessions were tied to profile. This change stores them locally (in `~/.awsvault/sessions`), encrypted with the AWS secret access key, with the filename a hash of the profile name, the access key id and the mfa_serial of the profile. This means if you change your profile config or the credentials you will get a new session.

Currently there is no garbage collection on old sessions, but the expiry time is in the token metadata, so doesn't need a private key to read.

This makes use of https://github.com/dvsekhvalnov/jose2go with PBES2_HS256_A128KW for key derivation and the A256GCM encryption algorithm.