### PR TITLE
Refactor keyring package to allow for rich items

### DIFF
--- a/keyring/array.go
+++ b/keyring/array.go
@@ -1,35 +1,33 @@
 package keyring
 
-type ArrayKeyring struct {
-	secrets map[string][]byte
+type arrayKeyring struct {
+	items map[string]Item
 }
 
-var _ Keyring = &ArrayKeyring{}
-
-func (k *ArrayKeyring) Get(key string) ([]byte, error) {
-	if b, ok := k.secrets[key]; ok {
-		return b, nil
+func (k *arrayKeyring) Get(key string) (Item, error) {
+	if i, ok := k.items[key]; ok {
+		return i, nil
 	} else {
-		return nil, ErrKeyNotFound
+		return Item{}, ErrKeyNotFound
 	}
 }
 
-func (k *ArrayKeyring) Set(key string, secret []byte) error {
-	if k.secrets == nil {
-		k.secrets = map[string][]byte{}
+func (k *arrayKeyring) Set(i Item) error {
+	if k.items == nil {
+		k.items = map[string]Item{}
 	}
-	k.secrets[key] = secret
+	k.items[i.Key] = i
 	return nil
 }
 
-func (k *ArrayKeyring) Remove(key string) error {
-	delete(k.secrets, key)
+func (k *arrayKeyring) Remove(key string) error {
+	delete(k.items, key)
 	return nil
 }
 
-func (k *ArrayKeyring) Keys() ([]string, error) {
+func (k *arrayKeyring) Keys() ([]string, error) {
 	var keys = []string{}
-	for key := range k.secrets {
+	for key := range k.items {
 		keys = append(keys, key)
 	}
 	return keys, nil

--- a/keyring/array_test.go
+++ b/keyring/array_test.go
@@ -3,18 +3,23 @@ package keyring
 import "testing"
 
 func TestArrayKeyringSetWhenEmpty(t *testing.T) {
-	k := &ArrayKeyring{}
+	k := &arrayKeyring{}
+	item := Item{Key: "llamas", Data: []byte("llamas are great")}
 
-	if err := k.Set("llamas", []byte("llamas are great")); err != nil {
+	if err := k.Set(item); err != nil {
 		t.Fatal(err)
 	}
 
-	v, err := k.Get("llamas")
+	foundItem, err := k.Get("llamas")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if string(v) != "llamas are great" {
-		t.Fatalf("Value stored was not the value retrieved: %q", v)
+	if string(foundItem.Data) != "llamas are great" {
+		t.Fatalf("Value stored was not the value retrieved: %q", foundItem.Data)
+	}
+
+	if foundItem.Key != "llamas" {
+		t.Fatalf("Key wasn't persisted: %q", foundItem.Key)
 	}
 }

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -36,7 +36,6 @@ type Item struct {
 	Label       string
 	Description string
 	TrustSelf   bool
-	Metadata    map[string]string
 }
 
 type Keyring interface {

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 		Exit:   os.Exit,
 	}
 
-	keyring, err := keyring.ForPlatform()
+	keyring, err := keyring.Open("aws-vault")
 	if err != nil {
 		ui.Error.Fatal(err)
 	}


### PR DESCRIPTION
The keyring package now exposes more of the services it supports (keychain at present), with the following:

```go
type Item struct {
	Key         string
	Data        []byte
	Label       string
	Description string
	TrustSelf   bool
}

type Keyring interface {
	Get(key string) (Item, error)
	Set(item Item) error
	Remove(key string) error
	Keys() ([]string, error)
}
```