### PR TITLE
Use a local metadata server for credentials, fixes #24

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/user"
@@ -11,14 +14,22 @@ import (
 
 type profiles map[string]map[string]string
 
-func parseProfiles() (profiles, error) {
-	file := os.Getenv("AWS_CONFIG_FILE")
+func configFile() (file string, err error) {
+	file = os.Getenv("AWS_CONFIG_FILE")
 	if file == "" {
 		usr, err := user.Current()
 		if err != nil {
-			return nil, err
+			return file, err
 		}
 		file = usr.HomeDir + "/.aws/config"
+	}
+	return file, err
+}
+
+func parseProfiles() (profiles, error) {
+	file, err := configFile()
+	if err != nil {
+		return nil, err
 	}
 
 	log.Printf("Parsing config file %s", file)
@@ -43,4 +54,35 @@ func (p profiles) sourceProfile(profile string) string {
 		}
 	}
 	return profile
+}
+
+func rewriteConfig(f func(line string) (string, bool)) (*os.File, error) {
+	srcFile, err := configFile()
+	if err != nil {
+		return nil, err
+	}
+
+	src, err := os.Open(srcFile)
+	if err != nil {
+		return nil, err
+	}
+	defer src.Close()
+
+	dest, err := ioutil.TempFile(os.TempDir(), "aws-vault")
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(src)
+	for scanner.Scan() {
+		if line, write := f(scanner.Text()); write {
+			fmt.Fprintln(dest, line)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return dest, err
+	}
+
+	return dest, nil
 }

--- a/config.go
+++ b/config.go
@@ -58,7 +58,7 @@ func writeProfiles(dest *os.File, profiles profiles) error {
 	for profile, vals := range profiles {
 		fmt.Fprintf(dest, "[profile %s]\n", profile)
 		for k, v := range vals {
-			fmt.Fprintf(dest, "%s = %q\n", k, v)
+			fmt.Fprintf(dest, "%s = %s\n", k, v)
 		}
 		fmt.Fprintln(dest, "")
 	}

--- a/exec.go
+++ b/exec.go
@@ -61,10 +61,10 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 	if input.WriteEnv {
 		env = overwriteEnv(env, "AWS_ACCESS_KEY_ID", val.AccessKeyID)
 		env = overwriteEnv(env, "AWS_SECRET_ACCESS_KEY", val.SecretAccessKey)
-	}
 
-	if val.SessionToken != "" {
-		env = overwriteEnv(env, "AWS_SESSION_TOKEN", val.SessionToken)
+		if val.SessionToken != "" {
+			env = overwriteEnv(env, "AWS_SESSION_TOKEN", val.SessionToken)
+		}
 	}
 
 	cmd := exec.Command(input.Command, input.Args...)
@@ -94,6 +94,10 @@ func profileConfig(profile string) (*os.File, error) {
 			delete(p, k)
 		}
 	}
+
+	// allow some time for keychain prompt
+	p["metadata_service_timeout"] = "15"
+	p["metadata_service_num_attempts"] = "2"
 
 	return tmpConfig, writeProfiles(tmpConfig, profiles{profile: p})
 }

--- a/exec.go
+++ b/exec.go
@@ -1,14 +1,16 @@
 package main
 
 import (
+	"log"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
-	"syscall"
+	"strings"
 	"time"
 
 	"github.com/99designs/aws-vault/keyring"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
 type ExecCommandInput struct {
@@ -17,15 +19,15 @@ type ExecCommandInput struct {
 	Args     []string
 	Keyring  keyring.Keyring
 	Duration time.Duration
+	WriteEnv bool
 }
 
 func ExecCommand(ui Ui, input ExecCommandInput) {
-	provider, err := NewVaultProvider(input.Keyring, input.Profile, input.Duration)
+	creds, err := NewVaultCredentials(input.Keyring, input.Profile, input.Duration)
 	if err != nil {
 		ui.Error.Fatal(err)
 	}
 
-	creds := credentials.NewCredentials(provider)
 	val, err := creds.Get()
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
@@ -35,24 +37,53 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 		}
 	}
 
-	env := append(os.Environ(),
-		"AWS_ACCESS_KEY_ID="+val.AccessKeyID,
-		"AWS_SECRET_ACCESS_KEY="+val.SecretAccessKey,
-		"AWS_DEFAULT_PROFILE="+input.Profile,
-	)
-
-	if val.SessionToken != "" {
-		env = append(env, "AWS_SESSION_TOKEN="+val.SessionToken)
-	}
-
-	path, err := exec.LookPath(input.Command)
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		ui.Error.Fatal(err)
 	}
 
-	argv := append([]string{input.Command}, input.Args...)
+	go func() {
+		log.Printf("Metadata server listening on %s", l.Addr().String())
+		ui.Error.Fatal(http.Serve(l, NewMetadataHandler(creds)))
+	}()
 
-	if err := syscall.Exec(path, argv, env); err != nil {
-		ui.Error.Fatal(err)
+	env := os.Environ()
+
+	env = overwriteEnv(env, "HTTP_PROXY", l.Addr().String())
+	// env = overwriteEnv(env, "AWS_DEFAULT_PROFILE", input.Profile)
+
+	if input.WriteEnv {
+		env = overwriteEnv(env, "AWS_ACCESS_KEY_ID", val.AccessKeyID)
+		env = overwriteEnv(env, "AWS_SECRET_ACCESS_KEY", val.SecretAccessKey)
 	}
+
+	if val.SessionToken != "" {
+		env = overwriteEnv(env, "AWS_SESSION_TOKEN", val.SessionToken)
+	}
+
+	cmd := exec.Command(input.Command, input.Args...)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Run()
+}
+
+func overwriteEnv(env []string, key, val string) []string {
+	var found bool
+
+	for idx, e := range env {
+		if strings.HasPrefix(key+"=", e) {
+			env[idx] = key + "=" + val
+			found = true
+		} else {
+			env[idx] = e
+		}
+	}
+
+	if !found {
+		env = append(env, key+"="+val)
+	}
+
+	return env
 }

--- a/exec.go
+++ b/exec.go
@@ -48,9 +48,7 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 	}()
 
 	env := os.Environ()
-
 	env = overwriteEnv(env, "HTTP_PROXY", l.Addr().String())
-	// env = overwriteEnv(env, "AWS_DEFAULT_PROFILE", input.Profile)
 
 	if input.WriteEnv {
 		env = overwriteEnv(env, "AWS_ACCESS_KEY_ID", val.AccessKeyID)

--- a/keyring/keychain.go
+++ b/keyring/keychain.go
@@ -165,8 +165,6 @@ func (k *keychain) Set(item Item) error {
 	}
 	defer C.CFRelease(C.CFTypeRef(label))
 
-	log.Printf("storing %q", item.Data)
-
 	dataBytes := bytesToCFData(item.Data)
 	defer C.CFRelease(C.CFTypeRef(dataBytes))
 
@@ -201,9 +199,6 @@ func (k *keychain) Set(item Item) error {
 		}
 		err = newKeychainError(C.SecItemAdd(queryDict, nil))
 	}
-
-	rt, _ := k.Get(item.Key)
-	log.Printf("%#v", rt)
 
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 		ls               = kingpin.Command("ls", "List profiles")
 		exec             = kingpin.Command("exec", "Executes a command with AWS credentials in the environment")
 		execProfile      = exec.Arg("profile", "Name of the profile").Required().String()
-		execSessDuration = exec.Flag("session-ttl", "Expiration time for aws session").Default("1h").OverrideDefaultFromEnvar("AWS_SESSION_TTL").Short('t').Duration()
+		execSessDuration = exec.Flag("session-ttl", "Expiration time for aws session").Default("4h").OverrideDefaultFromEnvar("AWS_SESSION_TTL").Short('t').Duration()
 		execWriteEnv     = exec.Flag("write-env", "Write AWS environment vars").Short('e').Bool()
 		execCmd          = exec.Arg("cmd", "Command to execute").Default(os.Getenv("SHELL")).String()
 		execCmdArgs      = exec.Arg("args", "Command arguments").Strings()

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 		exec             = kingpin.Command("exec", "Executes a command with AWS credentials in the environment")
 		execProfile      = exec.Arg("profile", "Name of the profile").Required().String()
 		execSessDuration = exec.Flag("session-ttl", "Expiration time for aws session").Default("1h").OverrideDefaultFromEnvar("AWS_SESSION_TTL").Short('t').Duration()
+		execWriteEnv     = exec.Flag("write-env", "Write AWS environment vars").Short('e').Bool()
 		execCmd          = exec.Arg("cmd", "Command to execute").Default(os.Getenv("SHELL")).String()
 		execCmdArgs      = exec.Arg("args", "Command arguments").Strings()
 		rm               = kingpin.Command("rm", "Removes credentials")
@@ -97,6 +98,7 @@ func main() {
 			Args:     *execCmdArgs,
 			Keyring:  keyring,
 			Duration: *execSessDuration,
+			WriteEnv: *execWriteEnv,
 		})
 
 	case login.FullCommand():
@@ -105,5 +107,4 @@ func main() {
 			Keyring: keyring,
 		})
 	}
-
 }

--- a/metadata.go
+++ b/metadata.go
@@ -3,37 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httputil"
-	"os/exec"
 	"time"
 )
 
 const (
 	awsTimeFormat = "2006-01-02T15:04:05Z"
 )
-
-// type ServerCommandInput struct {
-// 	Listen string
-// }
-
-// func ServerCommand(ui Ui, input ServerCommandInput) {
-// 	installLoAlias(ec2MetadataHost)
-
-// 	listenAddr := input.Listen
-// 	if listenAddr == "" {
-// 		listenAddr = ec2MetadataHost + ":80"
-// 	}
-
-// 	l, err := net.Listen("tcp", listenAddr)
-// 	if err != nil {
-// 		ui.Error.Fatal(err)
-// 	}
-
-// 	log.Printf("Metadata server listening on %s", l.Addr().String())
-// 	ui.Error.Fatal(http.Serve(l, newMetadataHandler()))
-// }
 
 type metadataHandler struct {
 	http.Handler
@@ -92,23 +69,3 @@ func (s *metadataHandler) credentialsHandler(w http.ResponseWriter, r *http.Requ
 		Expiration:      s.credentials.Expires().Format(awsTimeFormat),
 	})
 }
-
-func installLoAlias(ip string) error {
-	cmd := exec.Command("ifconfig", "lo0", "alias", ip)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Println(out)
-		return err
-	}
-	return nil
-}
-
-// sudo  lo0 alias ${METADATA_HOST_IP}
-
-// cat <<EOF > ${BASE_DIR}/pf.conf
-// rdr-anchor "forwarding"
-// load anchor "forwarding" from "${BASE_DIR}/pf.anchor"
-// EOF
-
-// sudo pfctl -evf "${BASE_DIR}/pf.conf"
-// }

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"os/exec"
+	"time"
+)
+
+const (
+	awsTimeFormat = "2006-01-02T15:04:05Z"
+)
+
+// type ServerCommandInput struct {
+// 	Listen string
+// }
+
+// func ServerCommand(ui Ui, input ServerCommandInput) {
+// 	installLoAlias(ec2MetadataHost)
+
+// 	listenAddr := input.Listen
+// 	if listenAddr == "" {
+// 		listenAddr = ec2MetadataHost + ":80"
+// 	}
+
+// 	l, err := net.Listen("tcp", listenAddr)
+// 	if err != nil {
+// 		ui.Error.Fatal(err)
+// 	}
+
+// 	log.Printf("Metadata server listening on %s", l.Addr().String())
+// 	ui.Error.Fatal(http.Serve(l, newMetadataHandler()))
+// }
+
+type metadataHandler struct {
+	http.Handler
+	credentials *VaultCredentials
+}
+
+func NewMetadataHandler(vc *VaultCredentials) http.Handler {
+	h := &metadataHandler{credentials: vc}
+	router := http.NewServeMux()
+	router.HandleFunc("/latest/meta-data/iam/security-credentials/", h.indexHandler)
+	router.HandleFunc("/latest/meta-data/iam/security-credentials/local-credentials", h.credentialsHandler)
+	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		director := func(req *http.Request) {
+			req.URL.Scheme = "http"
+			req.URL.Host = r.Host
+		}
+		proxy := &httputil.ReverseProxy{Director: director}
+		proxy.ServeHTTP(w, r)
+	})
+
+	h.Handler = router
+	return h
+}
+
+func (s *metadataHandler) indexHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "local-credentials")
+}
+
+type credentialsResponse struct {
+	AccessKeyID     string `json:"AccessKeyId"`
+	Code            string `json:"Code"`
+	Expiration      string `json:"Expiration"`
+	LastUpdated     string `json:"LastUpdated"`
+	SecretAccessKey string `json:"SecretAccessKey"`
+	Token           string `json:"Token"`
+	Type            string `json:"Type"`
+}
+
+func (s *metadataHandler) credentialsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+
+	val, err := s.credentials.Get()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusGatewayTimeout)
+		return
+	}
+
+	json.NewEncoder(w).Encode(&credentialsResponse{
+		Code:            "Success",
+		LastUpdated:     time.Now().Format(awsTimeFormat),
+		Type:            "AWS-HMAC",
+		AccessKeyID:     val.AccessKeyID,
+		SecretAccessKey: val.SecretAccessKey,
+		Token:           val.SessionToken,
+		Expiration:      s.credentials.Expires().Format(awsTimeFormat),
+	})
+}
+
+func installLoAlias(ip string) error {
+	cmd := exec.Command("ifconfig", "lo0", "alias", ip)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Println(out)
+		return err
+	}
+	return nil
+}
+
+// sudo  lo0 alias ${METADATA_HOST_IP}
+
+// cat <<EOF > ${BASE_DIR}/pf.conf
+// rdr-anchor "forwarding"
+// load anchor "forwarding" from "${BASE_DIR}/pf.anchor"
+// EOF
+
+// sudo pfctl -evf "${BASE_DIR}/pf.conf"
+// }

--- a/metadata.go
+++ b/metadata.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
-	"net/http/httputil"
 	"time"
 )
 
@@ -22,15 +22,6 @@ func NewMetadataHandler(vc *VaultCredentials) http.Handler {
 	router := http.NewServeMux()
 	router.HandleFunc("/latest/meta-data/iam/security-credentials/", h.indexHandler)
 	router.HandleFunc("/latest/meta-data/iam/security-credentials/local-credentials", h.credentialsHandler)
-	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		director := func(req *http.Request) {
-			req.URL.Scheme = "http"
-			req.URL.Host = r.Host
-		}
-		proxy := &httputil.ReverseProxy{Director: director}
-		proxy.ServeHTTP(w, r)
-	})
-
 	h.Handler = router
 	return h
 }
@@ -50,6 +41,8 @@ type credentialsResponse struct {
 }
 
 func (s *metadataHandler) credentialsHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("%s %s", r.Method, r.RequestURI)
+
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 

--- a/provider.go
+++ b/provider.go
@@ -77,8 +77,9 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 
 		// store a session in the keyring
 		p.Keyring.Set(keyring.Item{
-			Key:  sessionKey(p.Profile),
-			Data: bytes,
+			Key:       sessionKey(p.Profile),
+			Data:      bytes,
+			TrustSelf: true,
 		})
 	}
 


### PR DESCRIPTION
All AWS SDK's check for a [metadata service](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) at http://169.254.169.254, which is used for instance roles. 

This PR runs a server for every exec call and passes it to the subprocess as an `HTTP_PROXY` var and then intercepts the call to the metadata service and returns credentials. This seems to work great and the SDK's know to fetch new credentials when the current ones expire. If one provides a longer underlying session expiry then your role credentials will be renewed without prompting for MFA.

There is a `--write-env` fallback that will also write the env variables like the earlier versions.