### PR TITLE
exec: report cmd.Run() error; e.g. command not found.

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -75,7 +75,9 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Run()
+	if err = cmd.Run(); err != nil {
+		ui.Error.Fatal(err)
+	}
 }
 
 // write out a config excluding role switching keys


### PR DESCRIPTION
Capture and pass the error from `cmd.Run()` to `ui.Error.Fatal()` so that failed commands are reported and exit with a non-zero status.

Before:

```
$ aws-vault exec 99designs true ; echo $?
0

$ aws-vault exec 99designs false ; echo $?
0

$ aws-vault exec 99designs blargh ; echo $?
0
```

After:

```
$ aws-vault exec 99designs true ; echo $?
0

$ aws-vault exec 99designs false ; echo $?
exit status 1
1

$ aws-vault exec 99designs blargh ; echo $?
exec: "blargh": executable file not found in $PATH
1
```

This needs fine-tuning so that the second case silently passes through the exit status, while the third case still reports that the command wasn't found.  But for now this fixes the much bigger problem of failing to propagate errors at all.