### PR TITLE
Show MFA token while typing

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -126,7 +126,7 @@ func (p *VaultProvider) getSessionToken(length time.Duration) (sts.Credentials, 
 	}
 
 	if mfa, ok := p.profilesConf[p.Profile]["mfa_serial"]; ok {
-		token, err := promptPassword(fmt.Sprintf("Enter token for %s: ", mfa))
+		token, err := prompt(fmt.Sprintf("Enter token for %s: ", mfa))
 		if err != nil {
 			return sts.Credentials{}, err
 		}


### PR DESCRIPTION
This makes the MFA token visible while entering. It is not vulnerable to being pulled out of the scrollback buffer as it only lasts for a short duration. 

Both AWS and Google show the MFA token as its being typed.