### PR TITLE
Add a --master arg to exec to use master credentials

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -18,18 +18,23 @@ import (
 )
 
 type ExecCommandInput struct {
-	Profile  string
-	Command  string
-	Args     []string
-	Keyring  keyring.Keyring
-	Duration time.Duration
-	WriteEnv bool
-	Signals  chan os.Signal
+	Profile        string
+	Command        string
+	Args           []string
+	Keyring        keyring.Keyring
+	Duration       time.Duration
+	WriteEnv       bool
+	UseMasterCreds bool
+	Signals        chan os.Signal
 }
 
 func ExecCommand(ui Ui, input ExecCommandInput) {
+	if input.UseMasterCreds {
+		ui.Error.Println("CAUTION: Using master credentials is a security risk!")
+	}
 	creds, err := NewVaultCredentials(input.Keyring, input.Profile, VaultOptions{
 		SessionDuration: input.Duration,
+		UseMasterCreds:  input.UseMasterCreds,
 		WriteEnv:        input.WriteEnv,
 	})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 		execProfile      = exec.Arg("profile", "Name of the profile").Required().String()
 		execSessDuration = exec.Flag("session-ttl", "Expiration time for aws session").Default("4h").OverrideDefaultFromEnvar("AWS_SESSION_TTL").Short('t').Duration()
 		execWriteEnv     = exec.Flag("write-env", "Write AWS env vars").Short('e').Bool()
+		execMaster       = exec.Flag("master", "Use master credentials").Short('e').Bool()
 		execCmd          = exec.Arg("cmd", "Command to execute").Default(os.Getenv("SHELL")).String()
 		execCmdArgs      = exec.Arg("args", "Command arguments").Strings()
 		rm               = kingpin.Command("rm", "Removes credentials")
@@ -96,13 +97,14 @@ func main() {
 		signal.Notify(signals, os.Interrupt, os.Kill)
 
 		ExecCommand(ui, ExecCommandInput{
-			Profile:  *execProfile,
-			Command:  *execCmd,
-			Args:     *execCmdArgs,
-			Keyring:  keyring,
-			Duration: *execSessDuration,
-			WriteEnv: *execWriteEnv,
-			Signals:  signals,
+			Profile:        *execProfile,
+			Command:        *execCmd,
+			Args:           *execCmdArgs,
+			Keyring:        keyring,
+			Duration:       *execSessDuration,
+			WriteEnv:       *execWriteEnv,
+			UseMasterCreds: *execMaster,
+			Signals:        signals,
 		})
 
 	case login.FullCommand():

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 		execProfile      = exec.Arg("profile", "Name of the profile").Required().String()
 		execSessDuration = exec.Flag("session-ttl", "Expiration time for aws session").Default("4h").OverrideDefaultFromEnvar("AWS_SESSION_TTL").Short('t').Duration()
 		execWriteEnv     = exec.Flag("write-env", "Write AWS env vars").Short('e').Bool()
-		execMaster       = exec.Flag("master", "Use master credentials").Short('e').Bool()
+		execMaster       = exec.Flag("master", "Use master credentials").Short('m').Bool()
 		execCmd          = exec.Arg("cmd", "Command to execute").Default(os.Getenv("SHELL")).String()
 		execCmdArgs      = exec.Arg("args", "Command arguments").Strings()
 		rm               = kingpin.Command("rm", "Removes credentials")

--- a/provider.go
+++ b/provider.go
@@ -33,6 +33,7 @@ type VaultOptions struct {
 	AssumeRoleDuration time.Duration
 	ExpiryWindow       time.Duration
 	WriteEnv           bool
+	UseMasterCreds     bool
 }
 
 func (o VaultOptions) Validate() error {
@@ -86,6 +87,14 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 	creds, err := p.getMasterCreds()
 	if err != nil {
 		return credentials.Value{}, err
+	}
+
+	if p.UseMasterCreds {
+		if _, hasRole := p.profiles[p.profile]["role_arn"]; hasRole {
+			return credentials.Value{},
+				errors.New("Can't use master creds for profiles with a role")
+		}
+		return creds, nil
 	}
 
 	session, err := p.getCachedSession()


### PR DESCRIPTION
I've run into a few tools that use older boto libraries that don't support STS tokens
or IAM instance credentials. 

I'm torn on whether this is a good idea, and if it is a good idea what it should be called.
It came down to either `--master` or `--no-session`. 

Thoughts? @joho @pda @dgoodlad