### PR TITLE
Added protocol to http_proxy, fixes #33

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -61,7 +61,7 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 	}
 
 	env := os.Environ()
-	env = overwriteEnv(env, "http_proxy", l.Addr().String())
+	env = overwriteEnv(env, "http_proxy", "http://"+l.Addr().String())
 	env = overwriteEnv(env, "no_proxy", "amazonaws.com")
 	env = overwriteEnv(env, "AWS_CONFIG_FILE", cfg.Name())
 	env = overwriteEnv(env, "AWS_DEFAULT_PROFILE", input.Profile)


### PR DESCRIPTION
This adds a protocol to the `http_proxy` env variable. Verified this fixes the issue for aws-sdk-1.42.0, but having the usual nokogiri issues with getting aws-sdk-1.66.0 installed.