### PR TITLE
aws-vault logout <profile>: delete session credential.

### DIFF
--- a/logout.go
+++ b/logout.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/99designs/aws-vault/keyring"
+)
+
+type LogoutCommandInput struct {
+	Profile string
+	Keyring keyring.Keyring
+}
+
+func LogoutCommand(ui Ui, input LogoutCommandInput) {
+	provider := &KeyringProvider{Keyring: input.Keyring, Profile: input.Profile}
+	if err := provider.DeleteSession(); err != nil {
+		ui.Error.Fatal(err)
+	}
+	ui.Printf("Deleted session for %s.", input.Profile)
+}

--- a/main.go
+++ b/main.go
@@ -46,6 +46,8 @@ func main() {
 		login            = kingpin.Command("login", "Generate a login link for the AWS Console")
 		loginProfile     = login.Arg("profile", "Name of the profile").Required().String()
 		loginMfaToken    = login.Flag("mfa-token", "The mfa token to use").Short('t').String()
+		logout           = kingpin.Command("logout", "Remove session credential")
+		logoutProfile    = logout.Arg("profile", "Name of the profile").Required().String()
 	)
 
 	kingpin.Version(Version)
@@ -113,6 +115,12 @@ func main() {
 			Profile: *loginProfile,
 			Keyring: keyring,
 			MfaToken: *loginMfaToken,
+		})
+
+	case logout.FullCommand():
+		LogoutCommand(ui, LogoutCommandInput{
+			Profile: *logoutProfile,
+			Keyring: keyring,
 		})
 	}
 }

--- a/provider.go
+++ b/provider.go
@@ -276,8 +276,12 @@ func (p *KeyringProvider) Store(val credentials.Value) error {
 }
 
 func (p *KeyringProvider) Delete() error {
-	p.Keyring.Remove(sessionKey(p.Profile))
+	p.DeleteSession()
 	return p.Keyring.Remove(p.Profile)
+}
+
+func (p *KeyringProvider) DeleteSession() error {
+	return p.Keyring.Remove(sessionKey(p.Profile))
 }
 
 type VaultCredentials struct {


### PR DESCRIPTION
`aws-vault logout <profile>` removes the session credential for that profile.

I was trying to solve an aws-vault problem and suspected a bad session credential, but that turned out to not be the case. Figured this command might be useful in future anyway.