### PR TITLE
Use ForkExec rather than Subprocesses

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -22,6 +22,10 @@ type ExecCommandInput struct {
 }
 
 func ExecCommand(ui Ui, input ExecCommandInput) {
+	if os.Getenv("AWS_VAULT") != "" {
+		ui.Fatal("aws-vault sessions should be nested with care, unset $AWS_VAULT to force")
+	}
+
 	creds, err := NewVaultCredentials(input.Keyring, input.Profile, VaultOptions{
 		SessionDuration: input.Duration,
 		MfaToken:        input.MfaToken,

--- a/exec.go
+++ b/exec.go
@@ -19,7 +19,6 @@ type ExecCommandInput struct {
 	Duration    time.Duration
 	MfaToken    string
 	StartServer bool
-	Signals     chan os.Signal
 }
 
 func ExecCommand(ui Ui, input ExecCommandInput) {

--- a/exec.go
+++ b/exec.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -46,23 +45,16 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 		ui.Error.Fatal(err)
 	}
 
-	cfg, err := writeTempConfig(input.Profile, profs)
-	if err != nil {
-		ui.Error.Fatal(err)
-	}
-
-	env := os.Environ()
-	env = overwriteEnv(env, "AWS_CONFIG_FILE", cfg.Name())
-	env = overwriteEnv(env, "AWS_DEFAULT_PROFILE", input.Profile)
-	env = overwriteEnv(env, "AWS_PROFILE", input.Profile)
-
-	env = unsetEnv(env, "AWS_ACCESS_KEY_ID")
-	env = unsetEnv(env, "AWS_SECRET_ACCESS_KEY")
-	env = unsetEnv(env, "AWS_CREDENTIAL_FILE")
+	env := environ(os.Environ())
+	env.Set("AWS_CONFIG_FILE", "/dev/null")
+	env.Set("AWS_VAULT", input.Profile)
+	env.Unset("AWS_ACCESS_KEY_ID")
+	env.Unset("AWS_SECRET_ACCESS_KEY")
+	env.Unset("AWS_CREDENTIAL_FILE")
 
 	if region, ok := profs[input.Profile]["region"]; ok {
-		env = overwriteEnv(env, "AWS_DEFAULT_REGION", region)
-		env = overwriteEnv(env, "AWS_REGION", region)
+		env.Set("AWS_DEFAULT_REGION", region)
+		env.Set("AWS_REGION", region)
 	}
 
 	writeEnv := true
@@ -78,85 +70,49 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 	if writeEnv {
 		ui.Debug.Println("Writing temporary credentials to ENV")
 
-		env = overwriteEnv(env, "AWS_ACCESS_KEY_ID", val.AccessKeyID)
-		env = overwriteEnv(env, "AWS_SECRET_ACCESS_KEY", val.SecretAccessKey)
+		env.Set("AWS_ACCESS_KEY_ID", val.AccessKeyID)
+		env.Set("AWS_SECRET_ACCESS_KEY", val.SecretAccessKey)
 
 		if val.SessionToken != "" {
-			env = overwriteEnv(env, "AWS_SESSION_TOKEN", val.SessionToken)
-			env = overwriteEnv(env, "AWS_SECURITY_TOKEN", val.SessionToken)
+			env.Set("AWS_SESSION_TOKEN", val.SessionToken)
+			env.Set("AWS_SECURITY_TOKEN", val.SessionToken)
 		}
 	}
 
-	cmd := exec.Command(input.Command, input.Args...)
-	cmd.Env = env
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	go func() {
-		sig := <-input.Signals
-		if cmd.Process != nil {
-			cmd.Process.Signal(sig)
-		}
-	}()
-
-	var waitStatus syscall.WaitStatus
-	if err := cmd.Run(); err != nil {
-		if err != nil {
-			ui.Error.Println(err)
-		}
-		if exitError, ok := err.(*exec.ExitError); ok {
-			waitStatus = exitError.Sys().(syscall.WaitStatus)
-			os.Exit(waitStatus.ExitStatus())
-		}
-	}
-}
-
-// write out a config excluding role switching keys
-func writeTempConfig(profile string, conf profiles) (*os.File, error) {
-	tmpConfig, err := ioutil.TempFile(os.TempDir(), "aws-vault")
+	path, err := exec.LookPath(input.Command)
 	if err != nil {
-		return nil, err
+		ui.Error.Fatal(err)
 	}
 
-	newConfig := map[string]string{}
+	pid, err := syscall.ForkExec(path, append([]string{input.Command}, input.Args...), &syscall.ProcAttr{
+		Env:   env,
+		Files: []uintptr{0, 1, 2},
+	})
 
-	for k, v := range conf[profile] {
-		if k != "source_profile" && k != "role_arn" {
-			newConfig[k] = v
-		}
+	if err != nil {
+		ui.Error.Fatal(err)
 	}
 
-	return tmpConfig, writeProfiles(tmpConfig, profiles{profile: newConfig})
+	proc := &os.Process{Pid: pid}
+	proc.Wait()
 }
 
-func unsetEnv(env []string, key string) []string {
-	envCopy := []string{}
+// environ is a slice of strings representing the environment, in the form "key=value".
+type environ []string
 
-	for _, e := range env {
-		if !strings.HasPrefix(key+"=", e) {
-			envCopy = append(envCopy, e)
+// Unset an environment variable by key
+func (e *environ) Unset(key string) {
+	for i := range *e {
+		if strings.HasPrefix((*e)[i], key+"=") {
+			(*e)[i] = (*e)[len(*e)-1]
+			*e = (*e)[:len(*e)-1]
+			break
 		}
 	}
-
-	return envCopy
 }
 
-func overwriteEnv(env []string, key, val string) []string {
-	var found bool
-
-	for idx, e := range env {
-		if strings.HasPrefix(key+"=", e) {
-			env[idx] = key + "=" + val
-			found = true
-		} else {
-			env[idx] = e
-		}
-	}
-
-	if !found {
-		env = append(env, key+"="+val)
-	}
-
-	return env
+// Set adds an environment variable, replacing any existing ones of the same key
+func (e *environ) Set(key, val string) {
+	e.Unset(key)
+	*e = append(*e, key+"="+val)
 }

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/signal"
 
 	"github.com/99designs/aws-vault/keyring"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -95,16 +94,12 @@ func main() {
 		})
 
 	case exec.FullCommand():
-		signals := make(chan os.Signal)
-		signal.Notify(signals, os.Interrupt, os.Kill)
-
 		ExecCommand(ui, ExecCommandInput{
 			Profile:     *execProfile,
 			Command:     *execCmd,
 			Args:        *execCmdArgs,
 			Keyring:     keyring,
 			Duration:    *execSessDuration,
-			Signals:     signals,
 			MfaToken:    *execMfaToken,
 			StartServer: *execServer,
 		})


### PR DESCRIPTION
Things are simpler with ForkExec/Exec vs Subprocesses. Refactoring the env handling also saved a fair amount of code. 

This also gets rid of the generation of a config. Everything that is needed from the config goes into the environment vars. 