### PR TITLE
Use open-golang to open login url in default browser

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -54,6 +54,10 @@
 			"Rev": "200c3052657e041d0b8abab4ad65e0ba64a9f8c4"
 		},
 		{
+			"ImportPath": "github.com/skratchdot/open-golang/open",
+			"Rev": "c8748311a7528d0ba7330d302adbc5a677ef9c9e"
+		},
+		{
 			"ImportPath": "github.com/vaughan0/go-ini",
 			"Rev": "a98ad7ee00ec53921f08832bc06ecf7fd600e6a1"
 		},

--- a/login.go
+++ b/login.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 
 	"github.com/99designs/aws-vault/keyring"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/skratchdot/open-golang/open"
 )
 
 type LoginCommandInput struct {
@@ -84,5 +86,8 @@ func LoginCommand(ui Ui, input LoginCommandInput) {
 		url.QueryEscape(signinToken),
 	)
 
-	fmt.Println(loginUrl)
+	if err = open.Run(loginUrl); err != nil {
+		log.Println(err)
+		fmt.Println(loginUrl)
+	}
 }


### PR DESCRIPTION
I got sick of copying and pasting or command-clicking the url for `aws-vault login`, so this uses http://github.com/skratchdot/open-golang/open for cross-platform "open in default browser". 