### PR TITLE
Add a --no-session flag to exec

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/99designs/aws-vault/keyring"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
 type ExecCommandInput struct {
@@ -20,6 +22,7 @@ type ExecCommandInput struct {
 	MfaToken    string
 	StartServer bool
 	Signals     chan os.Signal
+	NoSession   bool
 }
 
 func ExecCommand(ui Ui, input ExecCommandInput) {
@@ -27,21 +30,49 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 		ui.Fatal("aws-vault sessions should be nested with care, unset $AWS_VAULT to force")
 	}
 
-	creds, err := NewVaultCredentials(input.Keyring, input.Profile, VaultOptions{
-		SessionDuration: input.Duration,
-		MfaToken:        input.MfaToken,
-	})
-	if err != nil {
-		ui.Error.Fatal(err)
-	}
+	var (
+		err      error
+		val      credentials.Value
+		writeEnv bool = true
+	)
 
-	val, err := creds.Get()
-	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
-			ui.Error.Fatalf("No credentials found for profile %q", input.Profile)
-		} else {
+	if input.NoSession {
+		if input.StartServer {
+			ui.Error.Fatal("Can't start a credential server without a session")
+		}
+
+		log.Println("No session requested, be careful!")
+		provider := &KeyringProvider{input.Keyring, input.Profile}
+		val, err = provider.Retrieve()
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		creds, err := NewVaultCredentials(input.Keyring, input.Profile, VaultOptions{
+			SessionDuration: input.Duration,
+			MfaToken:        input.MfaToken,
+		})
+		if err != nil {
 			ui.Error.Fatal(err)
 		}
+
+		val, err = creds.Get()
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
+				ui.Error.Fatalf("No credentials found for profile %q", input.Profile)
+			} else {
+				ui.Error.Fatal(err)
+			}
+		}
+
+		if input.StartServer {
+			if err := startCredentialsServer(ui, creds); err != nil {
+				ui.Error.Fatal(err)
+			} else {
+				writeEnv = false
+			}
+		}
+
 	}
 
 	profs, err := parseProfiles()
@@ -62,16 +93,6 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 	if region, ok := profs[input.Profile]["region"]; ok {
 		env.Set("AWS_DEFAULT_REGION", region)
 		env.Set("AWS_REGION", region)
-	}
-
-	writeEnv := true
-
-	if input.StartServer {
-		if err := startCredentialsServer(ui, creds); err != nil {
-			ui.Error.Fatal(err)
-		} else {
-			writeEnv = false
-		}
 	}
 
 	if writeEnv {

--- a/main.go
+++ b/main.go
@@ -35,10 +35,11 @@ func main() {
 		addFromEnv       = add.Flag("env", "Read the credentials from the environment").Bool()
 		ls               = kingpin.Command("ls", "List profiles")
 		exec             = kingpin.Command("exec", "Executes a command with AWS credentials in the environment")
-		execProfile      = exec.Arg("profile", "Name of the profile").Required().String()
+		execNoSession    = exec.Flag("no-session", "Use root credentials, no session created").Short('n').Bool()
 		execSessDuration = exec.Flag("session-ttl", "Expiration time for aws session").Default("4h").OverrideDefaultFromEnvar("AWS_SESSION_TTL").Short('t').Duration()
 		execMfaToken     = exec.Flag("mfa-token", "The mfa token to use").Short('m').String()
 		execServer       = exec.Flag("server", "Run the server in the background for credentials").Short('s').Bool()
+		execProfile      = exec.Arg("profile", "Name of the profile").Required().String()
 		execCmd          = exec.Arg("cmd", "Command to execute").Default(os.Getenv("SHELL")).String()
 		execCmdArgs      = exec.Arg("args", "Command arguments").Strings()
 		rm               = kingpin.Command("rm", "Removes credentials, including sessions")
@@ -67,6 +68,8 @@ func main() {
 	}
 
 	cmd := kingpin.Parse()
+
+	log.Printf("%#v", *execNoSession)
 
 	if *debug {
 		ui.Debug = log.New(os.Stderr, "DEBUG ", log.LstdFlags)
@@ -109,6 +112,7 @@ func main() {
 			Signals:     signals,
 			MfaToken:    *execMfaToken,
 			StartServer: *execServer,
+			NoSession:   true,
 		})
 
 	case login.FullCommand():

--- a/main.go
+++ b/main.go
@@ -69,8 +69,6 @@ func main() {
 
 	cmd := kingpin.Parse()
 
-	log.Printf("%#v", *execNoSession)
-
 	if *debug {
 		ui.Debug = log.New(os.Stderr, "DEBUG ", log.LstdFlags)
 		log.SetFlags(0)
@@ -112,7 +110,7 @@ func main() {
 			Signals:     signals,
 			MfaToken:    *execMfaToken,
 			StartServer: *execServer,
-			NoSession:   true,
+			NoSession:   *execNoSession,
 		})
 
 	case login.FullCommand():


### PR DESCRIPTION
Sometimes you need to use root credentials (see #15) without an MFA. This flag allows that.