### PR TITLE
Add an Assumed Role duration flag.

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -15,16 +15,17 @@ import (
 )
 
 type ExecCommandInput struct {
-	Profile     string
-	Command     string
-	Args        []string
-	Keyring     keyring.Keyring
-	Duration    time.Duration
-	MfaToken    string
-	MfaPrompt   prompt.PromptFunc
-	StartServer bool
-	Signals     chan os.Signal
-	NoSession   bool
+	Profile      string
+	Command      string
+	Args         []string
+	Keyring      keyring.Keyring
+	Duration     time.Duration
+	RoleDuration time.Duration
+	MfaToken     string
+	MfaPrompt    prompt.PromptFunc
+	StartServer  bool
+	Signals      chan os.Signal
+	NoSession    bool
 }
 
 func ExecCommand(ui Ui, input ExecCommandInput) {
@@ -51,9 +52,10 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 		}
 	} else {
 		creds, err := NewVaultCredentials(input.Keyring, input.Profile, VaultOptions{
-			SessionDuration: input.Duration,
-			MfaToken:        input.MfaToken,
-			MfaPrompt:       input.MfaPrompt,
+			SessionDuration:    input.Duration,
+			AssumeRoleDuration: input.RoleDuration,
+			MfaToken:           input.MfaToken,
+			MfaPrompt:          input.MfaPrompt,
 		})
 		if err != nil {
 			ui.Error.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func main() {
 		exec             = kingpin.Command("exec", "Executes a command with AWS credentials in the environment")
 		execNoSession    = exec.Flag("no-session", "Use root credentials, no session created").Short('n').Bool()
 		execSessDuration = exec.Flag("session-ttl", "Expiration time for aws session").Default("4h").OverrideDefaultFromEnvar("AWS_SESSION_TTL").Short('t').Duration()
+		execRoleDuration = exec.Flag("assume-role-ttl", "Expiration time for aws assumed role").Default("15m").Duration()
 		execMfaToken     = exec.Flag("mfa-token", "The mfa token to use").Short('m').String()
 		execServer       = exec.Flag("server", "Run the server in the background for credentials").Short('s').Bool()
 		execProfile      = exec.Arg("profile", "Name of the profile").Required().String()
@@ -108,16 +109,17 @@ func main() {
 		signal.Notify(signals, os.Interrupt, os.Kill)
 
 		ExecCommand(ui, ExecCommandInput{
-			Profile:     *execProfile,
-			Command:     *execCmd,
-			Args:        *execCmdArgs,
-			Keyring:     keyring,
-			Duration:    *execSessDuration,
-			Signals:     signals,
-			MfaToken:    *execMfaToken,
-			MfaPrompt:   prompt.Method(*promptDriver),
-			StartServer: *execServer,
-			NoSession:   *execNoSession,
+			Profile:      *execProfile,
+			Command:      *execCmd,
+			Args:         *execCmdArgs,
+			Keyring:      keyring,
+			Duration:     *execSessDuration,
+			RoleDuration: *execRoleDuration,
+			Signals:      signals,
+			MfaToken:     *execMfaToken,
+			MfaPrompt:    prompt.Method(*promptDriver),
+			StartServer:  *execServer,
+			NoSession:    *execNoSession,
 		})
 
 	case login.FullCommand():

--- a/provider.go
+++ b/provider.go
@@ -43,6 +43,12 @@ func (o VaultOptions) Validate() error {
 	} else if o.SessionDuration > MaxSessionDuration {
 		return errors.New("Maximum session duration is " + MaxSessionDuration.String())
 	}
+	if o.AssumeRoleDuration < MinAssumeRoleDuration {
+		return errors.New("Minimum duration for assumed roles is " + MinAssumeRoleDuration.String())
+	} else if o.AssumeRoleDuration > MaxAssumeRoleDuration {
+		return errors.New("Maximum duration for assumed roles is " + MaxAssumeRoleDuration.String())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Adds a flag (--assume-role-ttl) and support for passing through a custom duration for the assumed role to the VaultProvider.

(Edited to add: this is the first time I've done anything with go - I think I've done this right, and it works for me (TM), but happy to take suggestions on board.)