### PR TITLE
fix build due to non-backward compatible AWS SDK changes

### DIFF
--- a/rotate.go
+++ b/rotate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
@@ -47,9 +48,9 @@ func RotateCommand(ui Ui, input RotateCommandInput) {
 		}
 	}
 
-	client := iam.New(&aws.Config{
+	client := iam.New(session.New(&aws.Config{
 		Credentials: credentials.NewCredentials(&credentials.StaticProvider{Value: oldVal}),
-	})
+	}))
 
 	createOut, err := client.CreateAccessKey(&iam.CreateAccessKeyInput{})
 	if err != nil {
@@ -59,7 +60,7 @@ func RotateCommand(ui Ui, input RotateCommandInput) {
 	ui.Debug.Println("Created new access key")
 
 	newMasterCreds := credentials.Value{
-		AccessKeyID: *createOut.AccessKey.AccessKeyId,
+		AccessKeyID:     *createOut.AccessKey.AccessKeyId,
 		SecretAccessKey: *createOut.AccessKey.SecretAccessKey,
 	}
 
@@ -96,9 +97,9 @@ func RotateCommand(ui Ui, input RotateCommandInput) {
 		}
 	}
 
-	client = iam.New(&aws.Config{
+	client = iam.New(session.New(&aws.Config{
 		Credentials: credentials.NewCredentials(&credentials.StaticProvider{Value: newVal}),
-	})
+	}))
 
 	_, err = client.DeleteAccessKey(&iam.DeleteAccessKeyInput{
 		AccessKeyId: aws.String(oldMasterCreds.AccessKeyID),


### PR DESCRIPTION
Hello,

I was facing an issue while trying to build the latest version of aws-vault which I think were caused by non-backward compatible changes that have been introduced to the AWS SDK:
```
$ go build .
# github.com/99designs/aws-vault
./provider.go:197: cannot use aws.Config literal (type *aws.Config) as type client.ConfigProvider in argument to sts.New:
	*aws.Config does not implement client.ConfigProvider (missing ClientConfig method)
./provider.go:217: cannot use aws.Config literal (type *aws.Config) as type client.ConfigProvider in argument to sts.New:
	*aws.Config does not implement client.ConfigProvider (missing ClientConfig method)
./rotate.go:51: cannot use aws.Config literal (type *aws.Config) as type client.ConfigProvider in argument to iam.New:
	*aws.Config does not implement client.ConfigProvider (missing ClientConfig method)
./rotate.go:100: cannot use aws.Config literal (type *aws.Config) as type client.ConfigProvider in argument to iam.New:
	*aws.Config does not implement client.ConfigProvider (missing ClientConfig method)
```

The changes in this PR fix the issue and allow compiling with the latest release of the AWS SDK.

Please let me know if you want to see anything changed.


PS: The README mentions that aws-vault should be built with `GO15VENDOREXPERIMENT=1`, I was using go 1.6 which has this turned on by default, but there are no `vendor` directory in the repo so dependencies aren't matched on a specific release which is why the issue happened (I didn't know what version of the AWS SDK aws-vault should be built with tho that's why I had to fix the sources).