### PR TITLE
Don't kill AWS_CONFIG_FILE in forked environment

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -86,7 +86,6 @@ func ExecCommand(ui Ui, input ExecCommandInput) {
 	}
 
 	env := environ(os.Environ())
-	env.Set("AWS_CONFIG_FILE", "/dev/null")
 	env.Set("AWS_VAULT", input.Profile)
 
 	env.Unset("AWS_ACCESS_KEY_ID")


### PR DESCRIPTION
The aws CLI needs access to the config file for more than credentials, e.g. setting the default region, or enabling the cloudfront cli preview feature.

This variable was originally nuked in cb5710d. According to @lox's memory:

> I seem to recall the issue is that subshells would try and read the
> aws config file, rather than use the injected credentials and this
> lead to strange combinations of credentials and failures.

While this could cause trouble, it's probably a misconfiguration to have credentials in your config file for profiles managed by aws-vault.

Fixes #65