### PR TITLE
Stdout parameter to not open login URL in default browser

### DIFF
--- a/login.go
+++ b/login.go
@@ -20,6 +20,7 @@ type LoginCommandInput struct {
 	Keyring   keyring.Keyring
 	MfaToken  string
 	MfaPrompt prompt.PromptFunc
+	UseStdout bool
 }
 
 func LoginCommand(ui Ui, input LoginCommandInput) {
@@ -89,7 +90,9 @@ func LoginCommand(ui Ui, input LoginCommandInput) {
 		url.QueryEscape(signinToken),
 	)
 
-	if err = open.Run(loginUrl); err != nil {
+	if input.UseStdout {
+		fmt.Println(loginUrl)
+	} else if err = open.Run(loginUrl); err != nil {
 		log.Println(err)
 		fmt.Println(loginUrl)
 	}

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 		login            = kingpin.Command("login", "Generate a login link for the AWS Console")
 		loginProfile     = login.Arg("profile", "Name of the profile").Required().String()
 		loginMfaToken    = login.Flag("mfa-token", "The mfa token to use").Short('t').String()
+		useStdout        = login.Flag("stdout", "Print login URL to stdout instead of opening in default browser").Short('s').Bool()
 		server           = kingpin.Command("server", "Run an ec2 instance role server locally")
 	)
 
@@ -131,6 +132,7 @@ func main() {
 			Keyring:   keyring,
 			MfaToken:  *loginMfaToken,
 			MfaPrompt: prompt.Method(*promptDriver),
+			UseStdout: *useStdout,
 		})
 
 	case server.FullCommand():


### PR DESCRIPTION
New flag for login: `aws-vault login --stdout xxx`: prints the login URL to stdout instead of opening in default browser.