### PR TITLE
prompt flag writes to globals.PromptDriver

### DIFF
--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func main() {
 	app.Flag("prompt", fmt.Sprintf("Prompt driver to use %v", promptsAvailable)).
 		Default("terminal").
 		OverrideDefaultFromEnvar("AWS_VAULT_PROMPT").
-		Enum(promptsAvailable...)
+		EnumVar(&globals.PromptDriver, promptsAvailable...)
 
 	app.PreAction(func(c *kingpin.ParseContext) (err error) {
 		keyringImpl, err = keyring.Open(KeyringName, globals.Backend)


### PR DESCRIPTION
Broken by https://github.com/99designs/aws-vault/pull/74

With `Enum` (return the value) rather than `EnumVar` (write to var), `PromptDriver` never gets set, causing this error:

```
panic: Prompt method "" doesn't exist

goroutine 1 [running]:
panic(0x44bcb00, 0xc82000fcf0)
        /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:481 +0x3e6
github.com/99designs/aws-vault/prompt.Method(0x0, 0x0, 0xc8200e1450)
        /Users/pda/code/go/src/github.com/99designs/aws-vault/prompt/prompt.go:22 +0x1b1
main.configureLoginCommand.func1(0xc820082cf0, 0x0, 0x0)
        /Users/pda/code/go/src/github.com/99designs/aws-vault/main.go:185 +0x5e
github.com/99designs/aws-vault/vendor/gopkg.in/alecthomas/kingpin%2ev2.(*actionMixin).applyActions(0xc8200c4498, 0xc820082cf0, 0x0, 0x0)
        /Users/pda/code/go/src/github.com/99designs/aws-vault/vendor/gopkg.in/alecthomas/kingpin.v2/actions.go:28 +0x7b
github.com/99designs/aws-vault/vendor/gopkg.in/alecthomas/kingpin%2ev2.(*Application).applyActions(0xc82008e780, 0xc820082cf0, 0x0, 0x0)
        /Users/pda/code/go/src/github.com/99designs/aws-vault/vendor/gopkg.in/alecthomas/kingpin.v2/app.go:554 +0x161
github.com/99designs/aws-vault/vendor/gopkg.in/alecthomas/kingpin%2ev2.(*Application).execute(0xc82008e780, 0xc820082cf0, 0xc82000fc80, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0)
        /Users/pda/code/go/src/github.com/99designs/aws-vault/vendor/gopkg.in/alecthomas/kingpin.v2/app.go:390 +0x108
github.com/99designs/aws-vault/vendor/gopkg.in/alecthomas/kingpin%2ev2.(*Application).Parse(0xc82008e780, 0xc82000a1a0, 0x4, 0x4, 0x0, 0x0, 0x0, 0x0)
        /Users/pda/code/go/src/github.com/99designs/aws-vault/vendor/gopkg.in/alecthomas/kingpin.v2/app.go:222 +0x447
main.main()
        /Users/pda/code/go/src/github.com/99designs/aws-vault/main.go:243 +0x1177
```