### PR TITLE
Add `brew cask` install instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Currently OSX/Keychain and Linux/KWallet are supported, support for Linux's libs
 
 Download the [latest release](https://github.com/99designs/aws-vault/releases). The OSX release is code-signed, and you can verify this with `codesign -dvvv aws-vault`.
 
+On macOS, you may instead use [homebrew cask](https://github.com/caskroom/homebrew-cask) to install that same code-signed binary:
+
+    brew cask install aws-vault
+    # Verify the code-signed binary
+    codesign -dvvv $(which aws-vault)
+
 ## Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ On macOS, you may instead use [homebrew cask](https://github.com/caskroom/homebr
 
 The macOS release is code-signed, and you can verify this with `codesign`:
 
-    codesign -dvvv $(which aws-vault)
+    codesign -dvvv $(which aws-vault) | grep NRM9HVJ62Z
+    Authority=3rd Party Mac Developer Application: 99designs Inc (NRM9HVJ62Z)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ AWS Vault
 
 Securely store and access credentials for AWS. AWS Vault stores IAM credentials in your operating systems secure keystore and then generates temporary credentials from those to expose to your shell and applications. It's designed to be complementary to the aws cli tools, and is aware of your [profiles and configuration in `~/.aws/config`](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files).
 
-Currently macOS (OSX)/Keychain and Linux/KWallet are supported, support for Linux's libsecret and Windows planned.
+Currently macOS (Mac OS X)/Keychain and Linux/KWallet are supported, support for Linux's libsecret and Windows planned.
 
 ## Installing
 
 Download the [latest release](https://github.com/99designs/aws-vault/releases).
 
-On macOS (OSX), you may instead use [homebrew cask](https://github.com/caskroom/homebrew-cask) to install:
+On macOS, you may instead use [homebrew cask](https://github.com/caskroom/homebrew-cask) to install:
 
     brew cask install aws-vault
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,18 @@ AWS Vault
 
 Securely store and access credentials for AWS. AWS Vault stores IAM credentials in your operating systems secure keystore and then generates temporary credentials from those to expose to your shell and applications. It's designed to be complementary to the aws cli tools, and is aware of your [profiles and configuration in `~/.aws/config`](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files).
 
-Currently OSX/Keychain and Linux/KWallet are supported, support for Linux's libsecret and Windows planned.
+Currently macOS (OSX)/Keychain and Linux/KWallet are supported, support for Linux's libsecret and Windows planned.
 
 ## Installing
 
-Download the [latest release](https://github.com/99designs/aws-vault/releases). The OSX release is code-signed, and you can verify this with `codesign -dvvv aws-vault`.
+Download the [latest release](https://github.com/99designs/aws-vault/releases).
 
-On macOS, you may instead use [homebrew cask](https://github.com/caskroom/homebrew-cask) to install that same code-signed binary:
+On macOS (OSX), you may instead use [homebrew cask](https://github.com/caskroom/homebrew-cask) to install:
 
     brew cask install aws-vault
-    # Verify the code-signed binary
+
+The macOS release is code-signed, and you can verify this with `codesign`:
+
     codesign -dvvv $(which aws-vault)
 
 ## Usage


### PR DESCRIPTION
I added a formula for `aws-vault` to homebrew cask in https://github.com/caskroom/homebrew-cask/pull/23637. I _propose_ that the README should talk about that as an installation method since many folks just aren't used to or comfortable with manually dropping binaries in place, setting permissions correctly, etc.

I'm not wedded to this at all, though, so feel free to close if you disagree :smile: