### PR TITLE
Fix crashes in keychain Get & Remove

### DIFF
--- a/keyring/keychain.go
+++ b/keyring/keychain.go
@@ -62,7 +62,7 @@ func (k *keychain) Get(key string) (Item, error) {
 	if err != nil {
 		return Item{}, err
 	}
-	defer C.CFRelease(C.CFTypeRef(serviceRef))
+	defer C.CFRelease(C.CFTypeRef(accountRef))
 
 	query := map[C.CFTypeRef]C.CFTypeRef{
 		C.CFTypeRef(C.kSecClass):            C.CFTypeRef(C.kSecClassGenericPassword),

--- a/keyring/keychain.go
+++ b/keyring/keychain.go
@@ -221,7 +221,7 @@ func (k *keychain) Remove(key string) error {
 	if err != nil {
 		return err
 	}
-	defer C.CFRelease(C.CFTypeRef(serviceRef))
+	defer C.CFRelease(C.CFTypeRef(accountRef))
 
 	query := map[C.CFTypeRef]C.CFTypeRef{
 		C.CFTypeRef(C.kSecClass):       C.CFTypeRef(C.kSecClassGenericPassword),


### PR DESCRIPTION
These lines were causing `serviceRef` to be released twice. It looks like some copy/paste shenanigans from the blocks just above where I've made these changes, e.g. [keychain.go:59](https://github.com/99designs/aws-vault/blob/42854c4d7d2af53a0978244ee20db25038312989/keyring/keychain.go#L59). I think it's pretty safe to assume from the context that these lines were meant to release `accountRef` not `serviceRef`.

These were causing a crash on macOS 10.12 beta that looked like:

```
SIGTRAP: trace trap
PC=0x7fff86a8b985 m=5
signal arrived during cgo execution

goroutine 1 [syscall, locked to thread]:
runtime.cgocall(0x442a000, 0xc8200dfe20, 0xc800000000)
        /usr/local/Cellar/go/1.5.3/libexec/src/runtime/cgocall.go:120 +0x11b fp=0xc8200dfdf0 sp=0xc8200dfdc0
github.com/99designs/aws-vault/keyring._Cfunc_CFRelease(0x4f00000)
        ??:0 +0x31 fp=0xc8200dfe20 sp=0xc8200dfdf0
github.com/99designs/aws-vault/keyring.(*keychain).Get(0xc8200e5380, 0x7fff5fbffa77, 0xa, 0x7fff5fbffa77, 0xa, 0xc820017050, 0x87, 0x87, 0xc820
013800, 0x16, ...)
        /Users/lachlan/Projects/99designs/go/src/github.com/99designs/aws-vault/keyring/keychain.go:117 +0x97c fp=0xc8200dffb8 sp=0xc8200dfe20
main.(*KeyringProvider).Retrieve(0xc820013740, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
```