### PR TITLE
Makefile check doesn't handle golang 1.6 and 1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,21 +4,15 @@ PREFIX=github.com/99designs/aws-vault
 GOVERSION=$(shell go version)
 GOBIN=$(shell go env GOBIN)
 VERSION=$(shell git describe --tags --candidates=1 --dirty)
-FLAGS=-v -X main.Version=$(VERSION) -s
+FLAGS=-X main.Version=$(VERSION) -s
 CERT="3rd Party Mac Developer Application: 99designs Inc (NRM9HVJ62Z)"
 
 build:
 	go build -o aws-vault -ldflags="$(FLAGS)" $(PREFIX)
-ifeq "$(OS)" "Darwin"
+
+sign:
 	codesign -s $(CERT) ./aws-vault
-endif
 
-install:
-	go install -ldflags="$(FLAGS)" $(PREFIX)
-ifeq "$(OS)" "Darwin"
-	codesign -s $(CERT) $(GOBIN)/aws-vault
-endif
-
-release: build
+release: build sign
 	cp aws-vault aws-vault-$(OS)-$(ARCH)
 	@echo Upload aws-vault-$(OS)-$(ARCH) as $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,8 @@ PREFIX=github.com/99designs/aws-vault
 GOVERSION=$(shell go version)
 GOBIN=$(shell go env GOBIN)
 VERSION=$(shell git describe --tags --candidates=1 --dirty)
-FLAGS=-v -X main.Version=$(VERSION)
+FLAGS=-v -X main.Version=$(VERSION) -s
 CERT="3rd Party Mac Developer Application: 99designs Inc (NRM9HVJ62Z)"
-
-# Prevent broken code-signing
-# https://github.com/golang/go/issues/11887#issuecomment-126117692.
-ifneq (,$(findstring 1.5, $(GOVERSION)))
-FLAGS+=-s
-endif
 
 build:
 	go build -o aws-vault -ldflags="$(FLAGS)" $(PREFIX)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then when you use the `admin` profile, `aws-vault` will look in the `read-only` 
 
 ## Development
 
-Developed with golang 1.5 with `GO15VENDOREXPERIMENT=1`, to install:
+Developed with golang 1.5.2+ with `GO15VENDOREXPERIMENT=1`, to install:
 
 ```
 export GO15VENDOREXPERIMENT=1


### PR DESCRIPTION
This leads to broken binaries if codesigning is used after building with golang 1.6 or 1.7.