### PR TITLE
Check keychain exists with SecKeychainGetStatus

### DIFF
--- a/keyring/keychain.go
+++ b/keyring/keychain.go
@@ -20,9 +20,6 @@ import (
 	"log"
 	"os"
 	"os/user"
-	"strconv"
-	"strings"
-	"syscall"
 	"unicode/utf8"
 	"unsafe"
 )
@@ -33,44 +30,18 @@ type keychain struct {
 	Passphrase string
 }
 
-func keychainPath(name string) (string, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-
-	// As of macOS Sierra, Keychain files are stored with the `.keychain-db`
-	// extension, rather than `.keychain`. The result of the kern.osrelease
-	// sysctl is the kernel version number in the form "major.minor.patch",
-	// and Sierra is the first macOS release to use kernel major version 16
-	osver, err := syscall.Sysctl("kern.osrelease")
-	if err != nil {
-		return "", err
-	}
-
-	major, err := strconv.Atoi(strings.Split(osver, ".")[0])
-	if err != nil {
-		return "", err
-	}
-
-	if major >= 16 {
-		return usr.HomeDir + "/Library/Keychains/" + name + ".keychain-db", nil
-	} else {
-		return usr.HomeDir + "/Library/Keychains/" + name + ".keychain", nil
-	}
-}
-
 func init() {
 	supportedBackends[KeychainBackend] = opener(func(name string) (Keyring, error) {
 		if name == "" {
 			name = "login"
 		}
 
-		path, err := keychainPath(name)
+		usr, err := user.Current()
 		if err != nil {
 			return nil, err
 		}
-		return &keychain{Path: path, Service: name}, nil
+
+		return &keychain{Path: usr.HomeDir + "/Library/Keychains/" + name + ".keychain", Service: name}, nil
 	})
 
 	DefaultBackend = KeychainBackend

--- a/keyring/keychain_test.go
+++ b/keyring/keychain_test.go
@@ -32,7 +32,7 @@ func TestOSXKeychainKeyringSet(t *testing.T) {
 	file := tmpKeychain(t)
 	defer os.Remove(file)
 
-	k := &keychain{Path: file, Passphrase: "llamas", Service: "test"}
+	k := &keychain{path: file, passphrase: "llamas", service: "test"}
 	item := Item{
 		Key:         "llamas",
 		Label:       "Arbitrary label",
@@ -67,7 +67,7 @@ func TestOSXKeychainKeyringListKeys(t *testing.T) {
 	file := tmpKeychain(t)
 	defer os.Remove(file)
 
-	k := &keychain{Path: file, Passphrase: "llamas", Service: "test"}
+	k := &keychain{path: file, passphrase: "llamas", service: "test"}
 	keys := []string{"key1", "key2", "key3"}
 
 	for _, key := range keys {

--- a/keyring/keychain_test.go
+++ b/keyring/keychain_test.go
@@ -9,6 +9,25 @@ import (
 	"testing"
 )
 
+func TestOSXKeychainDoesntExist(t *testing.T) {
+	file := tmpKeychain(t)
+	defer os.Remove(file)
+
+	k, err := createKeychain(file, false, "llamas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseKeychain(k)
+
+	if exists, _ := keychainExists(file); !exists {
+		t.Fatalf("Expected existing keychain to be shown as existing")
+	}
+
+	if exists, _ := keychainExists("llamaspleasedontbeakeychainwiththisname"); exists {
+		t.Fatalf("Expected non-existing keychain to NOT be shown as existing")
+	}
+}
+
 func TestOSXKeychainKeyringSet(t *testing.T) {
 	file := tmpKeychain(t)
 	defer os.Remove(file)
@@ -74,5 +93,5 @@ func tmpKeychain(t *testing.T) (path string) {
 		return
 	}
 	os.Remove(file.Name())
-	return file.Name() + ".keychain"
+	return file.Name()
 }


### PR DESCRIPTION
This reverts #85, because it turns out to not actually work under macOS Sierra. 

This change uses the `SecKeychainGetStatus` to see if the keychain exists. I suspect we might also need to drop extensions from paths. 