### PR TITLE
Updates Makefile to generate darwin, linux and win32 bins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
+BIN=aws-vault
 OS=$(shell uname -s)
 ARCH=$(shell uname -m)
 PREFIX=github.com/99designs/aws-vault
 GOVERSION=$(shell go version)
 GOBIN=$(shell go env GOBIN)
 VERSION=$(shell git describe --tags --candidates=1 --dirty)
-FLAGS=-X main.Version=$(VERSION) -s
+FLAGS=-X main.Version=$(VERSION) -s -w
 CERT="3rd Party Mac Developer Application: 99designs Inc (NRM9HVJ62Z)"
+SRC=$(shell find . -name '*.go')
 
 build:
 	go build -o aws-vault -ldflags="$(FLAGS)" $(PREFIX)
@@ -13,6 +15,14 @@ build:
 sign:
 	codesign -s $(CERT) ./aws-vault
 
-release: build sign
-	cp aws-vault aws-vault-$(OS)-$(ARCH)
-	@echo Upload aws-vault-$(OS)-$(ARCH) as $(VERSION)
+$(BIN)-linux-amd64: $(SRC)
+	GOOS=linux GOARCH=amd64 go build -o $@ -ldflags="$(FLAGS)" *.go
+
+$(BIN)-darwin-amd64: $(SRC)
+	GOOS=darwin GOARCH=amd64 go build -o $@ -ldflags="$(FLAGS)" *.go
+
+$(BIN)-windows-386: $(SRC)
+	GOOS=windows GOARCH=386 go build -o $@ -ldflags="$(FLAGS)" *.go
+
+release: $(BIN)-linux-amd64 $(BIN)-darwin-amd64 $(BIN)-windows-386
+	codesign -s $(CERT) $(BIN)-darwin-amd64


### PR DESCRIPTION
This changes the `make release` target to build cross-compiled binaries for darwin, linux and win32. 

I thought this might be nice for people not on OSX. 