### PR TITLE
provider.go assumeRole: reassign, not redeclare, roleSessionName

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -221,7 +221,7 @@ func (p *VaultProvider) assumeRole(creds sts.Credentials, roleArn string, roleSe
 
 	if roleSessionName == "" {
 		// Try to work out a role name that will hopefully end up unique.
-		roleSessionName := fmt.Sprintf("%d", time.Now().UTC().UnixNano())
+		roleSessionName = fmt.Sprintf("%d", time.Now().UTC().UnixNano())
 	}
 
 	input := &sts.AssumeRoleInput{


### PR DESCRIPTION
Otherwise build fails on Go 1.6.2 with this error:

```
provider.go:224: roleSessionName declared and not used
```