### PR TITLE
Use iam credentials for login, allowing session expiry of 12h

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,6 +170,16 @@ func configureLoginCommand(app *kingpin.Application, ui Ui, g *globalFlags) {
 		Short('t').
 		StringVar(&input.MfaToken)
 
+	cmd.Flag("federation-token-ttl", "Expiration time for aws console session").
+		Default("12h").
+		OverrideDefaultFromEnvar("AWS_FEDERATION_TOKEN_TTL").
+		Short('f').
+		DurationVar(&input.FederationTokenDuration)
+
+	cmd.Flag("assume-role-ttl", "Expiration time for aws assumed role").
+		Default("15m").
+		DurationVar(&input.AssumeRoleDuration)
+
 	cmd.Flag("stdout", "Print login URL to stdout instead of opening in default browser").
 		Short('s').
 		BoolVar(&input.UseStdout)


### PR DESCRIPTION
Based on feedback in this [aws forum thread](https://forums.aws.amazon.com/thread.jspa?messageID=742905&#742905), it became obvious that the new longer federated session expiry could be used if IAM credentials were used to assume the role, vs our standard iam -> session token -> assume role -> federation tokens. 

I'm not sure why I never realized that the session token step was unneeded. I suspect it was because it adds complexity to the code, as you need to conditionally apply MFA to the AssumeRole call if there isn't a session with MFA already applied to it.

Regardless, this works, although I've been drinking a lot of wine, so I might be imagining it all. 