### PR TITLE
Issue #93 pointed out that cross-compiled binaries fail under linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CERT="Developer ID Application: 99designs Inc (NRM9HVJ62Z)"
 SRC=$(shell find . -name '*.go')
 
 test:
-	go test $(shell go list ./... | grep -v /vendor/)
+	go test -v $(shell go list ./... | grep -v /vendor/)
 
 build:
 	go build -o aws-vault -ldflags="$(FLAGS)" .

--- a/add_test.go
+++ b/add_test.go
@@ -8,6 +8,11 @@ func ExampleAddCommand() {
 	os.Setenv("AWS_VAULT_BACKEND", "file")
 	os.Setenv("AWS_VAULT_FILE_PASSPHRASE", "password")
 
+	defer os.Unsetenv("AWS_ACCESS_KEY_ID")
+	defer os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	defer os.Unsetenv("AWS_VAULT_BACKEND")
+	defer os.Unsetenv("AWS_VAULT_FILE_PASSPHRASE")
+
 	run([]string{"add", "--env", "foo"}, os.Exit)
 	// Output:
 	// Added credentials to profile "foo" in vault

--- a/add_test.go
+++ b/add_test.go
@@ -1,0 +1,14 @@
+package main
+
+import "os"
+
+func ExampleAddCommand() {
+	os.Setenv("AWS_ACCESS_KEY_ID", "llamas")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "rock")
+	os.Setenv("AWS_VAULT_BACKEND", "file")
+	os.Setenv("AWS_VAULT_FILE_PASSPHRASE", "password")
+
+	run([]string{"add", "--env", "foo"}, os.Exit)
+	// Output:
+	// Added credentials to profile "foo" in vault
+}

--- a/config.go
+++ b/config.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/user"
+	"path/filepath"
 	"strings"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/vaughan0/go-ini"
 )
 
@@ -23,11 +24,11 @@ type fileConfig struct {
 func newConfigFromEnv() (config, error) {
 	file := os.Getenv("AWS_CONFIG_FILE")
 	if file == "" {
-		usr, err := user.Current()
+		home, err := homedir.Dir()
 		if err != nil {
 			return nil, err
 		}
-		file = usr.HomeDir + "/.aws/config"
+		file = filepath.Join(home, "/.aws/config")
 	}
 	return &fileConfig{file: file}, nil
 }

--- a/config.go
+++ b/config.go
@@ -29,6 +29,9 @@ func newConfigFromEnv() (config, error) {
 			return nil, err
 		}
 		file = filepath.Join(home, "/.aws/config")
+		if _, err := os.Stat(file); os.IsNotExist(err) {
+			file = ""
+		}
 	}
 	return &fileConfig{file: file}, nil
 }

--- a/keyring/file.go
+++ b/keyring/file.go
@@ -16,6 +16,10 @@ import (
 type passwordFunc func(string) (string, error)
 
 func terminalPrompt(prompt string) (string, error) {
+	if password := os.Getenv("AWS_VAULT_FILE_PASSPHRASE"); password != "" {
+		return password, nil
+	}
+
 	fmt.Printf("%s: ", prompt)
 	b, err := terminal.ReadPassword(1)
 	if err != nil {

--- a/keyring/file.go
+++ b/keyring/file.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"time"
 
 	jose "github.com/dvsekhvalnov/jose2go"
+	"github.com/mitchellh/go-homedir"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -46,11 +46,11 @@ type fileKeyring struct {
 func (k *fileKeyring) dir() (string, error) {
 	dir := k.Dir
 	if dir == "" {
-		usr, err := user.Current()
+		home, err := homedir.Dir()
 		if err != nil {
-			return dir, err
+			return "", err
 		}
-		dir = usr.HomeDir + "/.awsvault/keys/"
+		dir = filepath.Join(home, "/.awsvault/keys/")
 	}
 
 	stat, err := os.Stat(dir)

--- a/keyring/keychain.go
+++ b/keyring/keychain.go
@@ -18,9 +18,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os/user"
+	"path/filepath"
 	"unicode/utf8"
 	"unsafe"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 type keychain struct {
@@ -35,12 +37,15 @@ func init() {
 			name = "login"
 		}
 
-		usr, err := user.Current()
+		home, err := homedir.Dir()
 		if err != nil {
 			return nil, err
 		}
 
-		return &keychain{path: usr.HomeDir + "/Library/Keychains/" + name + ".keychain", service: name}, nil
+		return &keychain{
+			path:    filepath.Join(home, "/Library/Keychains/"+name+".keychain"),
+			service: name,
+		}, nil
 	})
 
 	DefaultBackend = KeychainBackend

--- a/keyring/kwallet.go
+++ b/keyring/kwallet.go
@@ -3,41 +3,39 @@
 package keyring
 
 import (
-	"github.com/aulanov/go.dbus"
-	"fmt"
-	"os"
 	"encoding/json"
+
+	"github.com/aulanov/go.dbus"
 )
 
 const (
 	DBUS_SERVICE_NAME = "org.kde.kwalletd"
-	DBUS_PATH = "/modules/kwalletd"
-	APPID = "aws-vault"
-	FOLDER = "aws-vault"
+	DBUS_PATH         = "/modules/kwalletd"
+	APPID             = "aws-vault"
+	FOLDER            = "aws-vault"
 )
 
 func init() {
-	wallet, err := newKwallet()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Failed to connect to kwallet:", err)
-		return
-	}
-
 	supportedBackends[KWalletBackend] = opener(func(name string) (Keyring, error) {
 		if name == "" {
 			name = "kdewallet"
 		}
 
+		wallet, err := newKwallet()
+		if err != nil {
+			return nil, err
+		}
+
 		return &kwalletKeyring{
 			wallet: *wallet,
-			name: name,
+			name:   name,
 		}, nil
 	})
 }
 
 type kwalletKeyring struct {
 	wallet kwalletBinding
-	name string
+	name   string
 	handle int32
 }
 
@@ -63,7 +61,6 @@ func (k *kwalletKeyring) Get(key string) (Item, error) {
 	if err != nil {
 		return Item{}, err
 	}
-
 
 	data, err := k.wallet.ReadEntry(k.handle, FOLDER, key, APPID)
 	if err != nil {

--- a/vendor/github.com/mitchellh/go-homedir/LICENSE
+++ b/vendor/github.com/mitchellh/go-homedir/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/go-homedir/README.md
+++ b/vendor/github.com/mitchellh/go-homedir/README.md
@@ -1,0 +1,14 @@
+# go-homedir
+
+This is a Go library for detecting the user's home directory without
+the use of cgo, so the library can be used in cross-compilation environments.
+
+Usage is incredibly simple, just call `homedir.Dir()` to get the home directory
+for a user, and `homedir.Expand()` to expand the `~` in a path to the home
+directory.
+
+**Why not just use `os/user`?** The built-in `os/user` package requires
+cgo on Darwin systems. This means that any Go code that uses that package
+cannot cross compile. But 99% of the time the use for `os/user` is just to
+retrieve the home directory, which we can do for the current user without
+cgo. This library does that, enabling cross-compilation.

--- a/vendor/github.com/mitchellh/go-homedir/homedir.go
+++ b/vendor/github.com/mitchellh/go-homedir/homedir.go
@@ -1,0 +1,137 @@
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// DisableCache will disable caching of the home directory. Caching is enabled
+// by default.
+var DisableCache bool
+
+var homedirCache string
+var cacheLock sync.RWMutex
+
+// Dir returns the home directory for the executing user.
+//
+// This uses an OS-specific method for discovering the home directory.
+// An error is returned if a home directory cannot be detected.
+func Dir() (string, error) {
+	if !DisableCache {
+		cacheLock.RLock()
+		cached := homedirCache
+		cacheLock.RUnlock()
+		if cached != "" {
+			return cached, nil
+		}
+	}
+
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+
+	var result string
+	var err error
+	if runtime.GOOS == "windows" {
+		result, err = dirWindows()
+	} else {
+		// Unix-like system, so just assume Unix
+		result, err = dirUnix()
+	}
+
+	if err != nil {
+		return "", err
+	}
+	homedirCache = result
+	return result, nil
+}
+
+// Expand expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func Expand(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, path[1:]), nil
+}
+
+func dirUnix() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// If that fails, try getent
+	var stdout bytes.Buffer
+	cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		// If "getent" is missing, ignore it
+		if err == exec.ErrNotFound {
+			return "", err
+		}
+	} else {
+		if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
+			// username:password:uid:gid:gecos:home:shell
+			passwdParts := strings.SplitN(passwd, ":", 7)
+			if len(passwdParts) > 5 {
+				return passwdParts[5], nil
+			}
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+	cmd = exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}
+
+func dirWindows() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	if home == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
+	}
+
+	return home, nil
+}

--- a/vendor/github.com/mitchellh/go-homedir/homedir_test.go
+++ b/vendor/github.com/mitchellh/go-homedir/homedir_test.go
@@ -1,0 +1,112 @@
+package homedir
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+)
+
+func patchEnv(key, value string) func() {
+	bck := os.Getenv(key)
+	deferFunc := func() {
+		os.Setenv(key, bck)
+	}
+
+	os.Setenv(key, value)
+	return deferFunc
+}
+
+func BenchmarkDir(b *testing.B) {
+	// We do this for any "warmups"
+	for i := 0; i < 10; i++ {
+		Dir()
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Dir()
+	}
+}
+
+func TestDir(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if u.HomeDir != dir {
+		t.Fatalf("%#v != %#v", u.HomeDir, dir)
+	}
+}
+
+func TestExpand(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	cases := []struct {
+		Input  string
+		Output string
+		Err    bool
+	}{
+		{
+			"/foo",
+			"/foo",
+			false,
+		},
+
+		{
+			"~/foo",
+			filepath.Join(u.HomeDir, "foo"),
+			false,
+		},
+
+		{
+			"",
+			"",
+			false,
+		},
+
+		{
+			"~",
+			u.HomeDir,
+			false,
+		},
+
+		{
+			"~foo/foo",
+			"",
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		actual, err := Expand(tc.Input)
+		if (err != nil) != tc.Err {
+			t.Fatalf("Input: %#v\n\nErr: %s", tc.Input, err)
+		}
+
+		if actual != tc.Output {
+			t.Fatalf("Input: %#v\n\nOutput: %#v", tc.Input, actual)
+		}
+	}
+
+	DisableCache = true
+	defer func() { DisableCache = false }()
+	defer patchEnv("HOME", "/custom/path/")()
+	expected := filepath.Join("/", "custom", "path", "foo/bar")
+	actual, err := Expand("~/foo/bar")
+
+	if err != nil {
+		t.Errorf("No error is expected, got: %v", err)
+	} else if actual != expected {
+		t.Errorf("Expected: %v; actual: %v", expected, actual)
+	}
+}


### PR DESCRIPTION
This was mostly due to `user.Current()` requiring cgo code that fails in cross-compiled binaries. This PR uses an external library for getting the users home dir that works in a cross-compiled environment.