### PR TITLE
add.go, rm.go: use log.Printf vs fmt.Printf to ensure newline.

### DIFF
--- a/add.go
+++ b/add.go
@@ -48,7 +48,7 @@ func AddCommand(app *kingpin.Application, input AddCommandInput) {
 		return
 	}
 
-	fmt.Printf("Added credentials to profile %q in vault", input.Profile)
+	fmt.Printf("Added credentials to profile %q in vault\n", input.Profile)
 
 	profiles, err := awsConfigFile.Parse()
 	if err != nil {
@@ -63,6 +63,6 @@ func AddCommand(app *kingpin.Application, input AddCommandInput) {
 	}
 
 	if n, _ := sessions.Delete(input.Profile); n > 0 {
-		fmt.Printf("Deleted %d existing sessions.", n)
+		fmt.Printf("Deleted %d existing sessions.\n", n)
 	}
 }

--- a/rm.go
+++ b/rm.go
@@ -29,7 +29,7 @@ func RemoveCommand(app *kingpin.Application, input RemoveCommandInput) {
 			app.Fatalf(err.Error())
 			return
 		}
-		fmt.Printf("Deleted credentials.")
+		fmt.Printf("Deleted credentials.\n")
 	}
 
 	profiles, err := awsConfigFile.Parse()
@@ -49,5 +49,5 @@ func RemoveCommand(app *kingpin.Application, input RemoveCommandInput) {
 		app.Fatalf(err.Error())
 		return
 	}
-	fmt.Printf("Deleted %d sessions.", n)
+	fmt.Printf("Deleted %d sessions.\n", n)
 }


### PR DESCRIPTION
```
$ aws-vault rm --sessions-only redacted
Deleted 11 sessions.💀
```

The skull (if it renders properly here) is my shell saying there was no newline at the end of the command output.  `log.Println` and `log.Printf` seem to be used elsewhere, but `fmt.Printf` was used here; fixed.