### PR TITLE
Login to the correct region based on profile config

### DIFF
--- a/login.go
+++ b/login.go
@@ -118,9 +118,17 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 		return
 	}
 
+	destination := "https://console.aws.amazon.com/"
+	if region, ok := profiles[input.Profile]["region"]; ok {
+		destination = fmt.Sprintf(
+			"https://%s.console.aws.amazon.com/console/home?region=%s",
+			region, region,
+		)
+	}
+
 	loginUrl := fmt.Sprintf(
 		"https://signin.aws.amazon.com/federation?Action=login&Issuer=aws-vault&Destination=%s&SigninToken=%s",
-		url.QueryEscape("https://console.aws.amazon.com/"),
+		url.QueryEscape(destination),
 		url.QueryEscape(signinToken),
 	)
 


### PR DESCRIPTION
Previously, the login destination was https://console.aws.amazon.com/console/home. This meant that even if you had a specific region set in your `~/.aws/config` for the profile, it would use the last region you were in. Hilarity ensues. 