### PR TITLE
exec: Exit with exit code of subcommand

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -123,13 +123,13 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 
 	var waitStatus syscall.WaitStatus
 	if err := cmd.Run(); err != nil {
-		if err != nil {
-			app.Errorf("%v", err)
-			return
-		}
 		if exitError, ok := err.(*exec.ExitError); ok {
 			waitStatus = exitError.Sys().(syscall.WaitStatus)
 			os.Exit(waitStatus.ExitStatus())
+		}
+		if err != nil {
+			app.Errorf("%v", err)
+			return
 		}
 	}
 }


### PR DESCRIPTION
Code was already there but the order of if blocks made this block
unreachable.

Demo:

```
$ ~/go3d/bin/aws-vault exec mykey -- bash -c 'exit 2'
$ echo $?
2
$ /usr/local/bin/aws-vault exec mykey -- bash -c 'exit 2'
aws-vault: error: exit status 2
$ echo $?
0
```