### PR TITLE
Fix terminal input in windows

### DIFF
--- a/keyring/file.go
+++ b/keyring/file.go
@@ -55,12 +55,12 @@ func (k *fileKeyring) dir() (string, error) {
 
 	stat, err := os.Stat(dir)
 	if os.IsNotExist(err) {
-		os.MkdirAll(dir, 0700)
+		err = os.MkdirAll(dir, 0700)
 	} else if err != nil && !stat.IsDir() {
 		err = fmt.Errorf("%s is a file, not a directory", dir)
 	}
 
-	return dir, nil
+	return dir, err
 }
 
 func (k *fileKeyring) unlock() error {

--- a/keyring/file.go
+++ b/keyring/file.go
@@ -21,7 +21,7 @@ func terminalPrompt(prompt string) (string, error) {
 	}
 
 	fmt.Printf("%s: ", prompt)
-	b, err := terminal.ReadPassword(1)
+	b, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fix for #112 

The file descriptor passed to `terminal.ReadPassword` is hardcoded to `1` which works fine for UNIX systems but is not correct for a Windows environment. Setting this to the actual file descriptor of stdout fixes the problem.

```
C:\Users\shorty>aws-vault add test
Enter Access Key ID: AKIAAAAAAAAAAAAAAAAAAAAA
Enter Secret Access Key: zzzzzzzzzzzzzzzzzzzzzzz
Enter passphrase to unlock C:\Users\shorty\.awsvault\keys:
Added credentials to profile "test" in vault
```

Also fixed nearby code that did nothing with error values.