### PR TITLE
Update jose2go dep

### DIFF
--- a/vendor/github.com/dvsekhvalnov/jose2go/README.md
+++ b/vendor/github.com/dvsekhvalnov/jose2go/README.md
@@ -6,13 +6,16 @@ on standard library.
 Supports full suite of signing, encryption and compression algorithms defined by [JSON Web Algorithms](https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-31) as of July 4, 2014 version.
 
 Extensively unit tested and cross tested (100+ tests) for compatibility with [jose.4.j](https://bitbucket.org/b_c/jose4j/wiki/Home), [Nimbus-JOSE-JWT](https://bitbucket.org/nimbusds/nimbus-jose-jwt/wiki/Home), [json-jwt](https://github.com/nov/json-jwt) and
-[jose-jwt](https://github.com/dvsekhvalnov/jose-jwt) libraries. 
+[jose-jwt](https://github.com/dvsekhvalnov/jose-jwt) libraries.
 
 
 ## Status
-Used in production. GA ready. Current version is 1.2
+Used in production. GA ready. Current version is 1.3.
 
 ## Important
+v1.3 fixed potential Invalid Curve Attack on NIST curves within ECDH key management.
+Upgrade strongly recommended.
+
 v1.2 breaks `jose.Decode` interface by returning 3 values instead of 2.
 
 v1.2 deprecates `jose.Compress` method in favor of using configuration options to `jose.Encrypt`,
@@ -78,7 +81,7 @@ import (
 ```
 
 ## Usage
-#### Creating Plaintext (unprotected) Tokens	
+#### Creating Plaintext (unprotected) Tokens
 
 ```Go
 package main
@@ -127,7 +130,7 @@ func main() {
 	}
 }
 ```
-	
+
 #### RS-256, RS-384 and RS-512, PS-256, PS-384 and PS-512
 Signing with RS256, RS384, RS512, PS256, PS384, PS512 expecting `*rsa.PrivateKey` private key of corresponding length. **jose2go** [provides convinient utils](#dealing-with-keys) to construct `*rsa.PrivateKey` instance from PEM encoded PKCS1 or PKCS8 data: `Rsa.ReadPrivate([]byte)` under `jose2go/keys/rsa` package.
 
@@ -164,7 +167,7 @@ func main() {
 		fmt.Printf("\nRS256 = %v\n",token)
 	}
 }
-```	
+```
 
 #### ES-256, ES-384 and ES-512
 ES256, ES384, ES512 ECDSA signatures expecting `*ecdsa.PrivateKey` private elliptic curve key of corresponding length.  **jose2go** [provides convinient utils](#dealing-with-keys) to construct `*ecdsa.PrivateKey` instance from PEM encoded PKCS1 or PKCS8 data: `ecc.ReadPrivate([]byte)` or directly from `X,Y,D` parameters: `ecc.NewPrivate(x,y,d []byte)` under `jose2go/keys/ecc` package.
@@ -192,8 +195,8 @@ func main() {
         //go use token
         fmt.Printf("\ntoken = %v\n",token)
     }
-} 
-``` 
+}
+```
 
 ### Creating encrypted tokens
 #### RSA-OAEP-256, RSA-OAEP and RSA1\_5 key management algorithm
@@ -317,7 +320,7 @@ func main() {
 ```
 
 #### PBES2 using HMAC SHA with AES Key Wrap key management family of algorithms
-PBES2-HS256+A128KW, PBES2-HS384+A192KW, PBES2-HS512+A256KW key management requires `string` passphrase from which actual key will be derived 
+PBES2-HS256+A128KW, PBES2-HS384+A192KW, PBES2-HS512+A256KW key management requires `string` passphrase from which actual key will be derived
 
 ```Go
 package main
@@ -366,8 +369,8 @@ func main() {
 		fmt.Printf("\nDIR A128GCM = %v\n",token)
 	}
 }
-```	
-	
+```
+
 ### Creating compressed & encrypted tokens
 #### DEFLATE compression
 **jose2go** supports optional DEFLATE compression of payload before encrypting, can be used with all supported encryption and key management algorithms:
@@ -394,7 +397,7 @@ func main() {
 	}
 }
 ```
-	
+
 ### Verifying, Decoding and Decompressing tokens
 Decoding json web tokens is fully symmetric to creating signed or encrypted tokens (with respect to public/private cryptography), decompressing deflated payloads is handled automatically:
 
@@ -421,8 +424,8 @@ func main() {
 	if(err==nil) {
 		//go use token
 		fmt.Printf("\npayload = %v\n",payload)
-        
-        //and/or use headers 
+
+        //and/or use headers
         fmt.Printf("\nheaders = %v\n",headers)        
 	}
 }
@@ -461,8 +464,8 @@ func main() {
     if(err==nil) {
         //go use token
         fmt.Printf("\npayload = %v\n",payload)
-        
-        //and/or use headers 
+
+        //and/or use headers
         fmt.Printf("\nheaders = %v\n",headers)                
     }
 }  
@@ -501,8 +504,8 @@ func main() {
     if(err==nil) {
         //go use payload
         fmt.Printf("\npayload = %v\n",payload)
-        
-        //and/or use headers 
+
+        //and/or use headers
         fmt.Printf("\nheaders = %v\n",headers)                
     }
 }  
@@ -529,8 +532,8 @@ func main() {
 	if(err==nil) {
 		//go use token
 		fmt.Printf("\npayload = %v\n",payload)
-        
-        //and/or use headers 
+
+        //and/or use headers
         fmt.Printf("\nheaders = %v\n",headers)                
 	}
 }
@@ -559,13 +562,13 @@ func main() {
     if(err==nil) {
         //go use token
         fmt.Printf("\npayload = %v\n",payload)
-        
-        //and/or use headers 
+
+        //and/or use headers
         fmt.Printf("\nheaders = %v\n",headers)                
     }
 }
 ```
-	
+
 **ECDH-ES** and **ECDH-ES+A128KW**, **ECDH-ES+A192KW**, **ECDH-ES+A256KW** key management expecting `*ecdsa.PrivateKey` private elliptic curve key of corresponding length.  **jose2go** [provides convinient utils](#dealing-with-keys) to construct `*ecdsa.PrivateKey` instance from PEM encoded PKCS1 or PKCS8 data: `ecc.ReadPrivate([]byte)` or directly from `X,Y,D` parameters: `ecc.NewPrivate(x,y,d []byte)` under `jose2go/keys/ecc` package:
 
 ```Go
@@ -590,15 +593,15 @@ func main() {
     if(err==nil) {
         //go use token
         fmt.Printf("\npayload = %v\n",payload)
-        
-        //and/or use headers 
+
+        //and/or use headers
         fmt.Printf("\nheaders = %v\n",headers)                
     }
-}	
+}
 ```
-	
+
 ### Adding extra headers    
-It's possible to pass additional headers while encoding token. **jose2go** provides convenience configuration helpers: `Header(name string, value interface{})` and `Headers(headers map[string]interface{})` that can be passed to `Sign(..)` and `Encrypt(..)` calls. 
+It's possible to pass additional headers while encoding token. **jose2go** provides convenience configuration helpers: `Header(name string, value interface{})` and `Headers(headers map[string]interface{})` that can be passed to `Sign(..)` and `Encrypt(..)` calls.
 
 Note: **jose2go** do not allow to override `alg`, `enc` and `zip` headers.
 
@@ -614,11 +617,11 @@ Encryption with extra headers:
 token, err := jose.Encrypt(payload, jose.DIR, jose.A128GCM, sharedKey,
                     jose.Headers(map[string]interface{}{"keyid": "111-22-33", "cty": "text/plain"}))
 ```
-    
+
 ### Two phase validation
 In some cases validation (decoding) key can be unknown prior to examining token content. For instance one can use different keys per token issuer or rely on headers information to determine which key to use, do logging or other things.
 
-**jose2go** allows to pass `func(headers map[string]interface{}, payload string) key interface{}` callback instead of key to `jose.Decode(..)`. Callback will be executed prior to decoding and integrity validation and will recieve parsed headers and payload as is (for encrypted tokens it will be cipher text). Callback should return key to be used for actual decoding process.    
+**jose2go** allows to pass `func(headers map[string]interface{}, payload string) key interface{}` callback instead of key to `jose.Decode(..)`. Callback will be executed prior to decoding and integrity validation and will recieve parsed headers and payload as is (for encrypted tokens it will be cipher text). Callback should return key to be used for actual decoding process or `error` if decoding should be stopped, given error object will be returned from `jose.Decode(..)` call.
 
 Example of decoding token with callback:
 
@@ -631,6 +634,7 @@ import (
 	"github.com/dvsekhvalnov/jose2go"
 	"github.com/dvsekhvalnov/jose2go/keys/rsa"
 	"io/ioutil"
+    "errors"
 )
 
 func main() {
@@ -644,8 +648,14 @@ func main() {
 			fmt.Printf("\nPayload before decoding: %v\n", payload)
 
             //lookup key based on keyid header as en example
-            //or lookup based on something from payload, e.g. 'iss' claim for instance
-			return FindKey(headers['keyid'])
+            //or lookup based on something from payload, e.g. 'iss' claim for instance                        
+            key := FindKey(headers['keyid'])
+
+            if(key==nil) {
+                return errors.New("Key not found")
+            }
+
+            return key;
 		})
 
 	if err == nil {
@@ -654,9 +664,108 @@ func main() {
 	}
 }
 ```
-    
-### Dealing with keys	
-**jose2go** provides several helper methods to simplify loading & importing of elliptic and rsa keys. Import `jose2go/keys/rsa` or `jose2go/keys/ecc` respectively: 
+
+### Working with binary payload
+In addition to work with string payloads (typical use-case) `jose2go` supports
+encoding and decoding of raw binary data. `jose.DecodeBytes`, `jose.SignBytes`
+and `jose.EncryptBytes` functions provides similar interface but accepting
+`[]byte` payloads.
+
+Examples:
+
+```Go
+package main
+
+import (
+	"github.com/dvsekhvalnov/jose2go"
+)
+
+func main() {
+
+	token :=  `eyJhbGciOiJQQkVTMi1IUzI1NitBMTI4S1ciLCJlbmMiOiJBMjU2R0NNIiwicDJjIjo4MTkyLCJwMnMiOiJlZWpFZTF0YmJVbU5XV2s2In0.J2HTgltxH3p7A2zDgQWpZPgA2CHTSnDmMhlZWeSOMoZ0YvhphCeg-w.FzYG5AOptknu7jsG.L8jAxfxZhDNIqb0T96YWoznQ.yNeOfQWUbm8KuDGZ_5lL_g`
+
+	passphrase := `top secret`
+
+	payload, headers, err := jose.DecodeBytes(token,passphrase)
+
+	if(err==nil) {
+		//go use token
+		//payload = []byte{....}              
+	}
+}
+```
+
+```Go
+package main
+
+import (
+    "fmt"
+    "io/ioutil"
+    "github.com/dvsekhvalnov/jose2go/keys/rsa"
+    "github.com/dvsekhvalnov/jose2go"
+)
+
+func main() {
+
+    payload :=  []byte {0x01, 0x02, 0x03, 0x04}
+
+    keyBytes,err := ioutil.ReadFile("private.key")
+
+    if(err!=nil) {
+        panic("invalid key file")
+    }
+
+    privateKey,e:=Rsa.ReadPrivate(keyBytes)
+
+    if(e!=nil) {
+        panic("invalid key format")
+    }
+
+    token,err := jose.SignBytes(payload,jose.RS256, privateKey)
+
+    if(err==nil) {
+        //go use token
+        fmt.Printf("\nRS256 = %v\n",token)
+    }
+}
+```
+
+```Go
+package main
+
+import (
+    "fmt"
+    "io/ioutil"
+    "github.com/dvsekhvalnov/jose2go/keys/rsa"
+    "github.com/dvsekhvalnov/jose2go"
+)
+
+func main() {
+
+    payload :=  []byte {0x01, 0x02, 0x03, 0x04}
+
+    keyBytes,err := ioutil.ReadFile("public.key")
+
+    if(err!=nil) {
+        panic("invalid key file")
+    }
+
+    publicKey,e:=Rsa.ReadPublic(keyBytes)
+
+    if(e!=nil) {
+        panic("invalid key format")
+    }
+
+    token,err := jose.EncryptBytes(payload, jose.RSA_OAEP, jose.A256GCM, publicKey)
+
+    if(err==nil) {
+        //go use token
+        fmt.Printf("\ntoken = %v\n",token)
+    }
+}  
+```
+### Dealing with keys
+**jose2go** provides several helper methods to simplify loading & importing of elliptic and rsa keys. Import `jose2go/keys/rsa` or `jose2go/keys/ecc` respectively:
 
 #### RSA keys
 1. `Rsa.ReadPrivate(raw []byte) (key *rsa.PrivateKey,err error)` attempts to parse RSA private key from PKCS1 or PKCS8 format (`BEGIN RSA PRIVATE KEY` and `BEGIN PRIVATE KEY` headers)
@@ -686,7 +795,7 @@ func main() {
 
 2. `Rsa.ReadPublic(raw []byte) (key *rsa.PublicKey,err error)` attempts to parse RSA public key from PKIX key format or PKCS1 X509 certificate (`BEGIN PUBLIC KEY` and `BEGIN CERTIFICATE` headers)
 
-```Go 
+```Go
 package main
 
 import (
@@ -708,7 +817,7 @@ func main() {
 	fmt.Printf("publicKey = %v\n",publicKey)
 }
 ```
- 
+
 #### ECC keys
 1. `ecc.ReadPrivate(raw []byte) (key *ecdsa.PrivateKey,err error)` attemps to parse elliptic curve private key from PKCS1 or PKCS8 format (`BEGIN EC PRIVATE KEY` and `BEGIN PRIVATE KEY` headers)
 
@@ -800,16 +909,16 @@ func main() {
 ```
 
 ### More examples
-Checkout `jose_test.go` for more examples.	
+Checkout `jose_test.go` for more examples.
 
 ##Changelog
 ### 1.2
-- interface to access token headers after decoding 
+- interface to access token headers after decoding
 - interface to provide extra headers for token encoding
 - two-phase validation support
-    
+
 ### 1.1
 - security and bug fixes
 
 ### 1.0
-- initial stable version with full suite JOSE spec support 
+- initial stable version with full suite JOSE spec support

--- a/vendor/github.com/dvsekhvalnov/jose2go/ecdh.go
+++ b/vendor/github.com/dvsekhvalnov/jose2go/ecdh.go
@@ -1,26 +1,26 @@
 package jose
 
 import (
-	"errors"
-	"crypto/ecdsa"	
+	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"errors"
 	"fmt"
-	"math/big"
-	"github.com/dvsekhvalnov/jose2go/base64url"	
-	"github.com/dvsekhvalnov/jose2go/arrays"		
-	"github.com/dvsekhvalnov/jose2go/keys/ecc"		
-	"github.com/dvsekhvalnov/jose2go/kdf"		
+	"github.com/dvsekhvalnov/jose2go/arrays"
+	"github.com/dvsekhvalnov/jose2go/base64url"
+	"github.com/dvsekhvalnov/jose2go/kdf"
+	"github.com/dvsekhvalnov/jose2go/keys/ecc"
 	"github.com/dvsekhvalnov/jose2go/padding"
+	"math/big"
 )
 
 func init() {
-	RegisterJwa(&Ecdh{directAgreement:true})
+	RegisterJwa(&Ecdh{directAgreement: true})
 }
 
 // Elliptic curve Diffie–Hellman key management (key agreement) algorithm implementation
-type Ecdh struct{
+type Ecdh struct {
 	directAgreement bool
 }
 
@@ -29,123 +29,129 @@ func (alg *Ecdh) Name() string {
 }
 
 func (alg *Ecdh) WrapNewKey(cekSizeBits int, key interface{}, header map[string]interface{}) (cek []byte, encryptedCek []byte, err error) {
-	
-	if pubKey,ok := key.(*ecdsa.PublicKey);ok {
 
-		if _,ok := header[alg.idHeader()].(string);!ok {
-			return nil, nil, errors.New(fmt.Sprintf("Ecdh.WrapNewKey(): expected '%v' param in JWT header, but was not found.",alg.idHeader()))
+	if pubKey, ok := key.(*ecdsa.PublicKey); ok {
+
+		if _, ok := header[alg.idHeader()].(string); !ok {
+			return nil, nil, errors.New(fmt.Sprintf("Ecdh.WrapNewKey(): expected '%v' param in JWT header, but was not found.", alg.idHeader()))
 		}
 
 		var d []byte
 		var x, y *big.Int
 
-		if d, x, y, err=elliptic.GenerateKey(pubKey.Curve,rand.Reader); err!=nil {
-			return nil,nil,err
+		if d, x, y, err = elliptic.GenerateKey(pubKey.Curve, rand.Reader); err != nil {
+			return nil, nil, err
 		}
 
-		ephemeral:=ecc.NewPrivate(x.Bytes(),y.Bytes(),d)
+		ephemeral := ecc.NewPrivate(x.Bytes(), y.Bytes(), d)
 
-		xBytes:=padding.Align(x.Bytes(), pubKey.Curve.Params().BitSize)
-		yBytes:=padding.Align(y.Bytes(), pubKey.Curve.Params().BitSize)
+		xBytes := padding.Align(x.Bytes(), pubKey.Curve.Params().BitSize)
+		yBytes := padding.Align(y.Bytes(), pubKey.Curve.Params().BitSize)
 
-		epk:= map[string]string {
+		epk := map[string]string{
 			"kty": "EC",
-			"x": base64url.Encode(xBytes),
-			"y": base64url.Encode(yBytes),
+			"x":   base64url.Encode(xBytes),
+			"y":   base64url.Encode(yBytes),
 			"crv": name(pubKey.Curve),
 		}
 
-		header["epk"]=epk
+		header["epk"] = epk
 
-		return alg.deriveKey(pubKey,ephemeral,cekSizeBits,header),nil,nil
+		return alg.deriveKey(pubKey, ephemeral, cekSizeBits, header), nil, nil
 	}
 
-	return nil,nil,errors.New("Ecdh.WrapNewKey(): expected key to be '*ecdsa.PublicKey'")
+	return nil, nil, errors.New("Ecdh.WrapNewKey(): expected key to be '*ecdsa.PublicKey'")
 }
 
 func (alg *Ecdh) Unwrap(encryptedCek []byte, key interface{}, cekSizeBits int, header map[string]interface{}) (cek []byte, err error) {
 
-	if privKey,ok := key.(*ecdsa.PrivateKey);ok {
-		
+	if privKey, ok := key.(*ecdsa.PrivateKey); ok {
+
 		var epk map[string]interface{}
-	
-		if epk,ok = header["epk"].(map[string]interface{});!ok {
-			return nil,errors.New("Ecdh.Unwrap(): expected 'epk' param in JWT header, but was not found.")
+
+		if epk, ok = header["epk"].(map[string]interface{}); !ok {
+			return nil, errors.New("Ecdh.Unwrap(): expected 'epk' param in JWT header, but was not found.")
 		}
-	
-		if _,ok := header[alg.idHeader()].(string);!ok {
-			return nil,errors.New(fmt.Sprintf("Ecdh.Unwrap(): expected '%v' param in JWT header, but was not found.",alg.idHeader()))
+
+		if _, ok := header[alg.idHeader()].(string); !ok {
+			return nil, errors.New(fmt.Sprintf("Ecdh.Unwrap(): expected '%v' param in JWT header, but was not found.", alg.idHeader()))
 		}
-		
-		var x,y,crv string
+
+		var x, y, crv string
 		var xBytes, yBytes []byte
-				
-		if x,ok=epk["x"].(string);!ok {
-			return nil,errors.New("Ecdh.Unwrap(): expects 'epk' key to contain 'x','y' and 'crv' fields, but 'x' was not found.")
+
+		if x, ok = epk["x"].(string); !ok {
+			return nil, errors.New("Ecdh.Unwrap(): expects 'epk' key to contain 'x','y' and 'crv' fields, but 'x' was not found.")
 		}
-		
-		if y,ok=epk["y"].(string);!ok {
-			return nil,errors.New("Ecdh.Unwrap(): expects 'epk' key to contain 'x','y' and 'crv' fields, but 'y' was not found.")
+
+		if y, ok = epk["y"].(string); !ok {
+			return nil, errors.New("Ecdh.Unwrap(): expects 'epk' key to contain 'x','y' and 'crv' fields, but 'y' was not found.")
 		}
-		
-		if crv,ok=epk["crv"].(string);!ok {
-			return nil,errors.New("Ecdh.Unwrap(): expects 'epk' key to contain 'x','y' and 'crv' fields, but 'crv' was not found.")
+
+		if crv, ok = epk["crv"].(string); !ok {
+			return nil, errors.New("Ecdh.Unwrap(): expects 'epk' key to contain 'x','y' and 'crv' fields, but 'crv' was not found.")
 		}
-		
-		if crv!="P-256" && crv!="P-384" && crv!="P-521" {
-			return nil,errors.New(fmt.Sprintf("Ecdh.Unwrap(): unknown or unsupported curve %v",crv))
+
+		if crv != "P-256" && crv != "P-384" && crv != "P-521" {
+			return nil, errors.New(fmt.Sprintf("Ecdh.Unwrap(): unknown or unsupported curve %v", crv))
 		}
-		
-		if xBytes,err=base64url.Decode(x);err!=nil {
-			return nil,err
+
+		if xBytes, err = base64url.Decode(x); err != nil {
+			return nil, err
 		}
-		if yBytes,err=base64url.Decode(y);err!=nil {
-			return nil,err
-		}		
-		
-		pubKey := ecc.NewPublic(xBytes,yBytes)
-	
-		return alg.deriveKey(pubKey,privKey,cekSizeBits,header),nil
+		if yBytes, err = base64url.Decode(y); err != nil {
+			return nil, err
+		}
+
+		pubKey := ecc.NewPublic(xBytes, yBytes)
+
+		if !privKey.Curve.IsOnCurve(pubKey.X, pubKey.Y) {
+			return nil, errors.New(fmt.Sprintf("Ephemeral public key received in header is invalid for reciever's private key."))
+		}
+
+		return alg.deriveKey(pubKey, privKey, cekSizeBits, header), nil
 	}
 
-	return nil,errors.New("Ecdh.Unwrap(): expected key to be '*ecdsa.PrivateKey'")
+	return nil, errors.New("Ecdh.Unwrap(): expected key to be '*ecdsa.PrivateKey'")
 }
 
 func (alg *Ecdh) deriveKey(pubKey *ecdsa.PublicKey, privKey *ecdsa.PrivateKey, keySizeBits int, header map[string]interface{}) []byte {
-	
-	var enc,apv,apu []byte
+
+	var enc, apv, apu []byte
 	var err error
-	
-	enc=[]byte(header[alg.idHeader()].(string))		
-	
-	if a,ok:=header["apv"].(string);!ok {
-		if apv,err=base64url.Decode(a);err!=nil {
+
+	enc = []byte(header[alg.idHeader()].(string))
+
+	if a, ok := header["apv"].(string); !ok {
+		if apv, err = base64url.Decode(a); err != nil {
 			apv = nil
 		}
 	}
 
-	if a,ok:=header["apu"].(string);!ok {
-		if apu,err=base64url.Decode(a);err!=nil {
+	if a, ok := header["apu"].(string); !ok {
+		if apu, err = base64url.Decode(a); err != nil {
 			apu = nil
 		}
-	}		
-	
-	z, _ := pubKey.Curve.ScalarMult(pubKey.X, pubKey.Y, privKey.D.Bytes())			
-	zBytes := padding.Align(z.Bytes(), privKey.Curve.Params().BitSize)	
-	
-	return kdf.DeriveConcatKDF(keySizeBits,zBytes, prependDatalen(enc), prependDatalen(apu), prependDatalen(apv),arrays.UInt32ToBytes(uint32(keySizeBits)),nil,sha256.New())
+	}
+
+	z, _ := pubKey.Curve.ScalarMult(pubKey.X, pubKey.Y, privKey.D.Bytes())
+	zBytes := padding.Align(z.Bytes(), privKey.Curve.Params().BitSize)
+
+	return kdf.DeriveConcatKDF(keySizeBits, zBytes, prependDatalen(enc), prependDatalen(apu), prependDatalen(apv), arrays.UInt32ToBytes(uint32(keySizeBits)), nil, sha256.New())
 }
 
-func(alg *Ecdh) idHeader() string {
-	if alg.directAgreement { return "enc" }
-	
+func (alg *Ecdh) idHeader() string {
+	if alg.directAgreement {
+		return "enc"
+	}
+
 	return "alg"
 }
 
 func name(curve elliptic.Curve) string {
-	return fmt.Sprintf("P-%v",curve.Params().BitSize)
+	return fmt.Sprintf("P-%v", curve.Params().BitSize)
 }
 
 func prependDatalen(bytes []byte) []byte {
-	return arrays.Concat(arrays.UInt32ToBytes(uint32(len(bytes))),bytes)
+	return arrays.Concat(arrays.UInt32ToBytes(uint32(len(bytes))), bytes)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -171,10 +171,10 @@
 			"revisionTime": "2016-09-29T23:03:56Z"
 		},
 		{
-			"checksumSHA1": "3TujGA+BBh89yCW+88qGNWXxIAU=",
+			"checksumSHA1": "rSFw3D9mMLfFx4GuETt5aWGWi64=",
 			"path": "github.com/dvsekhvalnov/jose2go",
-			"revision": "6387d3c1f5abd8443b223577d5a7e0f4e0e5731f",
-			"revisionTime": "2015-08-16T20:43:22Z"
+			"revision": "f21a8cedbbae609f623613ec8f81125c243212e6",
+			"revisionTime": "2017-02-16T13:13:08Z"
 		},
 		{
 			"checksumSHA1": "X38qrRzL+rPyO4xZhm16ftyLkXs=",


### PR DESCRIPTION
Update the jose2go dep based on http://blogs.adobe.com/security/2017/03/critical-vulnerability-uncovered-in-json-encryption.html

Not sure if Elliptic Curve cryptography is actually used, but better safe than sorry.

```shell
go get -u github.com/dvsekhvalnov/jose2go
govendor update github.com/dvsekhvalnov/jose2go
```
