### PR TITLE
Support linux for exec --server

### DIFF
--- a/alias_darwin.go
+++ b/alias_darwin.go
@@ -1,0 +1,9 @@
+// build: darwin
+
+package main
+
+import "os/exec"
+
+func installNetworkAlias() ([]byte, error) {
+	return exec.Command("ifconfig", "lo0", "alias", "169.254.169.254").CombinedOutput()
+}

--- a/alias_linux.go
+++ b/alias_linux.go
@@ -5,5 +5,5 @@ package main
 import "os/exec"
 
 func installNetworkAlias() ([]byte, error) {
-	return exec.Command("ifconfig", "lo:0", "169.254.169.254").CombinedOutput()
+	return exec.Command("ip", "addr", "add", "169.254.169.254/24", "dev", "lo", "label", "lo:0").CombinedOutput()
 }

--- a/alias_linux.go
+++ b/alias_linux.go
@@ -1,0 +1,9 @@
+// build: linux
+
+package main
+
+import "os/exec"
+
+func installNetworkAlias() ([]byte, error) {
+	return exec.Command("ifconfig", "lo:0", "169.254.169.254").CombinedOutput()
+}

--- a/alias_windows.go
+++ b/alias_windows.go
@@ -1,0 +1,9 @@
+// build: windows
+
+package main
+
+import "fmt"
+
+func installNetworkAlias() ([]byte, error) {
+	return make([]byte, 0, fmt.Errorf("Server mode is unsupported on windows.")
+}

--- a/alias_windows.go
+++ b/alias_windows.go
@@ -5,5 +5,5 @@ package main
 import "fmt"
 
 func installNetworkAlias() ([]byte, error) {
-	return make([]byte, 0, fmt.Errorf("Server mode is unsupported on windows.")
+	return make([]byte, 0), fmt.Errorf("Server mode is unsupported on windows.")
 }

--- a/server.go
+++ b/server.go
@@ -69,10 +69,6 @@ func credentialsHandler(w http.ResponseWriter, r *http.Request) {
 	io.Copy(w, resp.Body)
 }
 
-func installNetworkAlias() ([]byte, error) {
-	return exec.Command("ifconfig", "lo0", "alias", "169.254.169.254").CombinedOutput()
-}
-
 func checkServerRunning(bind string) bool {
 	_, err := net.DialTimeout("tcp", bind, time.Millisecond*10)
 	return err == nil


### PR DESCRIPTION
Hello!

This PR makes `exec`'s server mode compatible with linux. The syntax for the alias installation is different on this platform.
To do so, I extracted the `installNetworkAlias` function in platform specific files. I also added an explicit error message on windows.

Best,
