### PR TITLE
Adds some better error messages

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/99designs/aws-vault/keyring"
 	"github.com/99designs/aws-vault/prompt"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -61,11 +60,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 
 	val, err := creds.Get()
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
-			app.Fatalf("No credentials found for profile %q", input.Profile)
-		} else {
-			app.Fatalf("Failed to get credentials: %v", err)
-		}
+		app.Fatalf(formatCredentialError(input.Profile, profiles, err))
 	}
 
 	if input.StartServer {

--- a/login.go
+++ b/login.go
@@ -61,7 +61,7 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 	val, err := creds.Get()
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
-			app.Fatalf("No credentials found for profile %q", input.Profile)
+			app.Fatalf("No credentials found for profile %q.\nUse `aws-vault add %s` to set up credentials", input.Profile, input.Profile)
 			return
 		}
 		app.Fatalf("Failed to get credentials: %v", err)

--- a/login.go
+++ b/login.go
@@ -12,7 +12,6 @@ import (
 	"github.com/99designs/aws-vault/keyring"
 	"github.com/99designs/aws-vault/prompt"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -60,11 +59,7 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 	creds := credentials.NewCredentials(provider)
 	val, err := creds.Get()
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
-			app.Fatalf("No credentials found for profile %q.\nUse `aws-vault add %s` to set up credentials", input.Profile, input.Profile)
-			return
-		}
-		app.Fatalf("Failed to get credentials: %v", err)
+		app.Fatalf(formatCredentialError(input.Profile, profiles, err))
 	}
 
 	var isFederated bool

--- a/login.go
+++ b/login.go
@@ -70,7 +70,8 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 		log.Printf("No session token found, calling GetFederationToken")
 		stsCreds, err := getFederationToken(val, input.FederationTokenDuration)
 		if err != nil {
-			app.Fatalf("Failed to call GetFederationToken: %v", err)
+			app.Fatalf("Failed to call GetFederationToken: %v\n"+
+				"Login for non-assumed roles depends on permission to call sts:GetFederationToken", err)
 			return
 		}
 

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func configureAddCommand(app *kingpin.Application, g *globalFlags) {
 func configureListCommand(app *kingpin.Application, g *globalFlags) {
 	input := LsCommandInput{}
 
-	cmd := app.Command("list", "List profiles")
+	cmd := app.Command("list", "List all credentials and sessions")
 	cmd.Alias("ls")
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		input.Keyring = keyringImpl


### PR DESCRIPTION
Primarily:

```bash
aws-vault login llamas
aws-vault: error: No credentials found for profile llamas.
Use 'aws-vault add llamas' to set up credentials or 'aws-vault list' to see what credentials exist
```

/cc @toolmantim