### PR TITLE
Add configurable ENV support for assume-role-ttl

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ func configureExecCommand(app *kingpin.Application, g *globalFlags) {
 
 	cmd.Flag("assume-role-ttl", "Expiration time for aws assumed role").
 		Default("15m").
+		OverrideDefaultFromEnvar("AWS_ASSUME_ROLE_TTL").
 		DurationVar(&input.RoleDuration)
 
 	cmd.Flag("mfa-token", "The mfa token to use").


### PR DESCRIPTION
I used aws-vault heavily with Terraform. Some operations (especially RDS-related) can take in excess of 15m to execute. It would be useful to be able to set this as an environment variable rather than remember to pass it as a flag for each run.