### PR TITLE
WIP: Support macos touchid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 
+osx_image: xcode8.3
 install: ./scripts/ci_install.sh
 
 go:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ $(BIN)-windows-386.exe: $(SRC)
 	GOOS=windows GOARCH=386 go build -o $@ -ldflags="$(FLAGS)" .
 
 release: $(BIN)-linux-amd64 $(BIN)-darwin-amd64 $(BIN)-windows-386.exe
-	codesign -s $(CERT) $(BIN)-darwin-amd64
+	codesign -s "$(CERT)" $(BIN)-darwin-amd64
 
 clean:
 	rm -f $(BIN)-*-*

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ Developed with golang, to install run:
 go get github.com/99designs/aws-vault
 ```
 
+## Self-signing your binary
+
+Binaries that call Keychain need to be signed, otherwise they always show the "allow access" prompt. Releases are signed by 99designs certificates, but if you are actively developing and want to mimic the behaviour of a signed release you can generate a self-signed code signing certificate.
+
+Check out Apple's guide on it [here](http://web.archive.org/web/20090119080759/http://developer.apple.com/documentation/Security/Conceptual/CodeSigningGuide/Procedures/chapter_3_section_2.html), or find it in `Keychain Access > Certificate Assistant > Create Certificate > Code Signing Certificate`.  
+
+You can then sign your binary like this:
+
+```bash
+make build
+codesign -s "Name of my certificate" ./aws-vault
+```
+
 ## References and Inspiration
 
  * https://github.com/pda/aws-keychain

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -112,6 +112,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 	val, err := creds.Get()
 	if err != nil {
 		app.Fatalf(vault.FormatCredentialError(input.Profile, profiles, err))
+		return
 	}
 
 	if input.StartServer {

--- a/cli/global.go
+++ b/cli/global.go
@@ -26,6 +26,7 @@ var GlobalFlags struct {
 	Debug        bool
 	Backend      string
 	PromptDriver string
+	Biometrics   bool
 }
 
 func ConfigureGlobals(app *kingpin.Application) {
@@ -42,12 +43,18 @@ func ConfigureGlobals(app *kingpin.Application) {
 		OverrideDefaultFromEnvar("AWS_VAULT_PROMPT").
 		EnumVar(&GlobalFlags.PromptDriver, promptsAvailable...)
 
+	app.Flag("biometrics", "Use biometric authentication if supported").
+		BoolVar(&GlobalFlags.Biometrics)
+
 	app.PreAction(func(c *kingpin.ParseContext) (err error) {
 		if !GlobalFlags.Debug {
 			log.SetOutput(ioutil.Discard)
 		}
 		if keyringImpl == nil {
 			keyringImpl, err = keyring.Open(KeyringName, GlobalFlags.Backend)
+		}
+		if globals.Biometrics {
+			keyring.UseBiometricsIfAvailable = true
 		}
 		if awsConfigFile == nil {
 			awsConfigFile, err = vault.NewConfigFromEnv()

--- a/cli/global.go
+++ b/cli/global.go
@@ -54,7 +54,7 @@ func ConfigureGlobals(app *kingpin.Application) {
 			keyringImpl, err = keyring.Open(KeyringName, GlobalFlags.Backend)
 		}
 		if globals.Biometrics {
-			keyring.UseBiometricsIfAvailable = true
+			keyring.Config.UseBiometrics = true
 		}
 		if awsConfigFile == nil {
 			awsConfigFile, err = vault.NewConfigFromEnv()

--- a/cli/global.go
+++ b/cli/global.go
@@ -44,6 +44,7 @@ func ConfigureGlobals(app *kingpin.Application) {
 		EnumVar(&GlobalFlags.PromptDriver, promptsAvailable...)
 
 	app.Flag("biometrics", "Use biometric authentication if supported").
+		OverrideDefaultFromEnvar("AWS_VAULT_BIOMETRICS").
 		BoolVar(&GlobalFlags.Biometrics)
 
 	app.PreAction(func(c *kingpin.ParseContext) (err error) {
@@ -61,5 +62,4 @@ func ConfigureGlobals(app *kingpin.Application) {
 		}
 		return err
 	})
-
 }

--- a/vendor/github.com/99designs/keyring/keychain.go
+++ b/vendor/github.com/99designs/keyring/keychain.go
@@ -15,10 +15,9 @@ import (
 )
 
 const (
-	keychainAccessGroup = "ACE1234DEF.com.99designs.aws-vault"
-	biometricsAccount   = "com.99designs.aws-vault.biometrics"
-	biometricsService   = "aws-vault"
-	biometricsLabel     = "Passphrase for %s"
+	biometricsAccount = "com.99designs.aws-vault.biometrics"
+	biometricsService = "aws-vault"
+	biometricsLabel   = "Passphrase for %s"
 )
 
 type keychain struct {

--- a/vendor/github.com/99designs/keyring/keyring.go
+++ b/vendor/github.com/99designs/keyring/keyring.go
@@ -3,11 +3,13 @@ package keyring
 import "errors"
 
 const (
-	SecretServiceBackend  string = "secret-service"
-	KeychainBackend       string = "keychain"
-	KWalletBackend        string = "kwallet"
-	FileBackend           string = "file"
+	SecretServiceBackend string = "secret-service"
+	KeychainBackend      string = "keychain"
+	KWalletBackend       string = "kwallet"
+	FileBackend          string = "file"
 )
+
+var UseBiometricsIfAvailable bool
 
 var DefaultBackend = FileBackend
 

--- a/vendor/github.com/99designs/keyring/keyring.go
+++ b/vendor/github.com/99designs/keyring/keyring.go
@@ -9,7 +9,9 @@ const (
 	FileBackend          string = "file"
 )
 
-var UseBiometricsIfAvailable bool
+var Config struct {
+	UseBiometrics bool
+}
 
 var DefaultBackend = FileBackend
 

--- a/vendor/github.com/lox/go-touchid/README.md
+++ b/vendor/github.com/lox/go-touchid/README.md
@@ -1,0 +1,26 @@
+# Authenticating with TouchID
+
+```golang
+package main
+
+import (
+  "log"
+
+  touchid "github.com/lox/go-touchid"
+)
+
+func main() {
+  ok, err := touchid.Authenticate("access llamas")
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  if ok {
+    log.Printf("Authenticated")
+  } else {
+    log.Fatal("Failed to authenticate")
+  }
+}
+```
+
+![Screenshot](https://lachlan.me/s/9TMZWTYGikXoeCHm8RBgi8Bb0o4R1Bz6uI.png)

--- a/vendor/github.com/lox/go-touchid/touchid.go
+++ b/vendor/github.com/lox/go-touchid/touchid.go
@@ -1,0 +1,56 @@
+package touchid
+
+/*
+#cgo CFLAGS: -x objective-c -fmodules -fblocks
+#cgo LDFLAGS: -framework CoreFoundation -framework LocalAuthentication -framework Foundation
+#include <stdlib.h>
+#include <stdio.h>
+#import <LocalAuthentication/LocalAuthentication.h>
+
+int Authenticate(char const* reason) {
+  LAContext *myContext = [[LAContext alloc] init];
+  NSError *authError = nil;
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  NSString *nsReason = [NSString stringWithUTF8String:reason];
+  __block int result = 0;
+
+  if ([myContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError]) {
+    [myContext evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+      localizedReason:nsReason
+      reply:^(BOOL success, NSError *error) {
+        if (success) {
+          result = 1;
+        } else {
+          result = 2;
+        }
+        dispatch_semaphore_signal(sema);
+      }];
+  }
+
+  dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+  dispatch_release(sema);
+  return result;
+}
+*/
+import (
+	"C"
+)
+import (
+	"errors"
+	"unsafe"
+)
+
+func Authenticate(reason string) (bool, error) {
+	reasonStr := C.CString(reason)
+	defer C.free(unsafe.Pointer(reasonStr))
+
+	result := C.Authenticate(reasonStr)
+	switch result {
+	case 1:
+		return true, nil
+	case 2:
+		return false, nil
+	}
+
+	return false, errors.New("Error occurred accessing biometrics")
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -258,6 +258,12 @@
 			"revisionTime": "2017-08-10T04:31:23Z"
 		},
 		{
+			"checksumSHA1": "kEyCzFEzVLWWRauNn0Nzxg2pg6Q=",
+			"path": "github.com/lox/go-touchid",
+			"revision": "619cc8e578d0ef916aa29c806117c370f9d621cb",
+			"revisionTime": "2017-07-12T10:52:33Z"
+		},
+		{
 			"checksumSHA1": "AXacfEchaUqT5RGmPmMXsOWRhv8=",
 			"path": "github.com/mitchellh/go-homedir",
 			"revision": "756f7b183b7ab78acdbbee5c7f392838ed459dda",


### PR DESCRIPTION
This is my first pass at touchid support. Passing in the `--biometrics` flag will use touchid on compatible macOS hosts. The first time you do this we prompt for the master passphrase and then store it in the login keychain, along with the rights to access that item in future. Subsequent access is blocked by touch id, but after that we lookup the keychain password and use it to unlock the aws-vault keychain. 

I don't love the approach, but it closely matches 1password. Need to implement the extra security bits that they [do too](https://support.1password.com/touch-id-security-mac/):

 * [ ] When your fingerprint isn’t recognized three times in a row
 * [ ] Encrypt the stored master password with locally stored random key to ensure that it only works on your current host. Alternately with hardware id?

Also depends on #130. 