### PR TITLE
Support profiles in rotate

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -33,6 +33,7 @@ type VaultOptions struct {
 	MfaPrompt          prompt.PromptFunc
 	NoSession          bool
 	Profiles           profiles
+	MasterCreds        *credentials.Value
 }
 
 func (o VaultOptions) Validate() error {
@@ -170,6 +171,10 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 }
 
 func (p *VaultProvider) getMasterCreds() (credentials.Value, error) {
+	if p.MasterCreds != nil {
+		return *p.MasterCreds, nil
+	}
+
 	source := sourceProfile(p.profile, p.profiles)
 
 	creds, ok := p.creds[source]

--- a/rotate.go
+++ b/rotate.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/99designs/aws-vault/keyring"
@@ -43,13 +42,14 @@ func RotateCommand(app *kingpin.Application, input RotateCommandInput) {
 		MfaToken:  input.MfaToken,
 		MfaPrompt: input.MfaPrompt,
 		Profiles:  profiles,
+		NoSession: true,
 	})
 	if err != nil {
 		app.Fatalf(err.Error())
 		return
 	}
 
-	fmt.Println("Using old credentials to create a new access key")
+	log.Println("Using old credentials to create a new access key")
 
 	oldVal, err := oldSessionCreds.Get()
 	if err != nil {
@@ -101,6 +101,7 @@ func RotateCommand(app *kingpin.Application, input RotateCommandInput) {
 		MfaToken:  input.MfaToken,
 		MfaPrompt: input.MfaPrompt,
 		Profiles:  profiles,
+		NoSession: true,
 	})
 	if err != nil {
 		app.Fatalf(err.Error())


### PR DESCRIPTION
Based on #132 and #133, key rotation was broken in a number of ways:

* It used a session, which means IAM calls are only possible if there is an MFA
* It didn't support profiles, so if your master creds didn't have permission to do IAM stuff and you needed to assume a role to do so it wouldn't work
* It dumped your creds to the console on error

This fixes all of the above as well as reducing the amount of prompts you get from Keychain. 

Damn you for nerd sniping me just before I fell asleep @pda.  