### PR TITLE
Fixed regression that prompted for keychain access for sessions

### DIFF
--- a/config.go
+++ b/config.go
@@ -83,5 +83,5 @@ func formatCredentialError(p string, from profiles, err error) string {
 			sourceDescr, source)
 	}
 
-	return fmt.Sprintf("Failed to get credentials for %s: %v", err, sourceDescr)
+	return fmt.Sprintf("Failed to get credentials for %s: %v", sourceDescr, err)
 }

--- a/keyring/keychain.go
+++ b/keyring/keychain.go
@@ -79,9 +79,12 @@ func (k *keychain) Set(item Item) error {
 	kcItem.SetSynchronizable(gokeychain.SynchronizableNo)
 	kcItem.SetAccessible(gokeychain.AccessibleWhenUnlocked)
 	kcItem.UseKeychain(kc)
-	kcItem.SetAccess(gokeychain.NoApplicationsTrusted)
 
-	log.Printf("Adding service=%q, account=%q to osx keychain %s", k.service, item.Key, k.path)
+	if !item.TrustSelf {
+		kcItem.SetAccess(gokeychain.NoApplicationsTrusted)
+	}
+
+	log.Printf("Adding service=%q, label=%q, account=%q to osx keychain %s", k.service, item.Key, item.Label, k.path)
 	return gokeychain.AddItem(kcItem)
 }
 

--- a/keyring/keychain.go
+++ b/keyring/keychain.go
@@ -42,7 +42,7 @@ func (k *keychain) Get(key string) (Item, error) {
 	query.SetMatchLimit(gokeychain.MatchLimitOne)
 	query.SetReturnAttributes(true)
 	query.SetReturnData(true)
-	query.UseKeychain(kc)
+	query.SetMatchSearchList(kc)
 
 	results, err := gokeychain.QueryItem(query)
 	if err == gokeychain.ErrorItemNotFound || len(results) == 0 {
@@ -79,12 +79,9 @@ func (k *keychain) Set(item Item) error {
 	kcItem.SetSynchronizable(gokeychain.SynchronizableNo)
 	kcItem.SetAccessible(gokeychain.AccessibleWhenUnlocked)
 	kcItem.UseKeychain(kc)
+	kcItem.SetAccess(&gokeychain.Access{SelfUntrusted: !item.TrustSelf})
 
-	if !item.TrustSelf {
-		kcItem.SetAccess(gokeychain.NoApplicationsTrusted)
-	}
-
-	log.Printf("Adding service=%q, label=%q, account=%q to osx keychain %s", k.service, item.Key, item.Label, k.path)
+	log.Printf("Adding service=%q, label=%q, account=%q to osx keychain %s", k.service, item.Label, item.Key, k.path)
 	return gokeychain.AddItem(kcItem)
 }
 
@@ -99,6 +96,7 @@ func (k *keychain) Remove(key string) error {
 	item.SetSecClass(gokeychain.SecClassGenericPassword)
 	item.SetService(k.service)
 	item.SetAccount(key)
+	item.SetMatchSearchList(kc)
 
 	log.Printf("Removing keychain item service=%q, account=%q from osx keychain %q", k.service, key, k.path)
 	return gokeychain.DeleteItem(item)
@@ -116,7 +114,7 @@ func (k *keychain) Keys() ([]string, error) {
 	query.SetService(k.service)
 	query.SetMatchLimit(gokeychain.MatchLimitAll)
 	query.SetReturnAttributes(true)
-	query.UseKeychain(kc)
+	query.SetMatchSearchList(kc)
 
 	results, err := gokeychain.QueryItem(query)
 	if err != nil {

--- a/keyring/keychain_test.go
+++ b/keyring/keychain_test.go
@@ -87,14 +87,12 @@ func TestOSXKeychainKeyringListKeys(t *testing.T) {
 
 func deleteKeychain(path string, t *testing.T) {
 	if _, err := os.Stat(path); os.IsExist(err) {
-		t.Logf("Deleting %s", path)
 		os.Remove(path)
 	}
 
 	// Sierra introduced a -db suffix
 	dbPath := path + "-db"
 	if _, err := os.Stat(dbPath); os.IsExist(err) {
-		t.Logf("Deleting %s", dbPath)
 		os.Remove(dbPath)
 	}
 }

--- a/provider.go
+++ b/provider.go
@@ -86,42 +86,12 @@ func NewVaultProvider(k keyring.Keyring, profile string, opts VaultOptions) (*Va
 	}, nil
 }
 
+// Retrieve returns credentials protected by a GetSessionToken. If there is an associated
+// role in the profile then AssumeRole is applied. The benefit of a session is that it doesn't
+// require MFA or a user prompt to access the keychain item, much like sudo.
 func (p *VaultProvider) Retrieve() (credentials.Value, error) {
-	creds, err := p.getMasterCreds()
-	if err != nil {
-		return credentials.Value{}, err
-	}
-
-	window := p.ExpiryWindow
-	if window == 0 {
-		window = time.Minute * 5
-	}
-
 	if p.NoSession {
-		if role, ok := p.profiles[p.profile]["role_arn"]; ok {
-			session, err := p.assumeRole(creds, role)
-			if err != nil {
-				return credentials.Value{}, err
-			}
-
-			log.Printf("Using role ****************%s, expires in %s",
-				(*session.AccessKeyId)[len(*session.AccessKeyId)-4:],
-				session.Expiration.Sub(time.Now()).String())
-
-			p.SetExpiration(*session.Expiration, window)
-			p.expires = *session.Expiration
-
-			value := credentials.Value{
-				AccessKeyID:     *session.AccessKeyId,
-				SecretAccessKey: *session.SecretAccessKey,
-				SessionToken:    *session.SessionToken,
-			}
-
-			return value, nil
-		}
-
-		// no role, exposes master credentials which don't expire
-		return creds, nil
+		return p.RetrieveWithoutSessionToken()
 	}
 
 	session, err := p.sessions.Retrieve(p.profile, p.SessionDuration)
@@ -130,6 +100,12 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 			log.Println("Session not found in keyring")
 		} else {
 			log.Println(err)
+		}
+
+		// session lookup missed, we need to create a new one
+		creds, err := p.getMasterCreds()
+		if err != nil {
+			return credentials.Value{}, err
 		}
 
 		session, err = p.getSessionToken(&creds)
@@ -157,6 +133,11 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 			session.Expiration.Sub(time.Now()).String())
 	}
 
+	window := p.ExpiryWindow
+	if window == 0 {
+		window = time.Minute * 5
+	}
+
 	p.SetExpiration(*session.Expiration, window)
 	p.expires = *session.Expiration
 
@@ -167,6 +148,46 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 	}
 
 	return value, nil
+}
+
+// RetrieveWithoutSessionToken returns credentials that are either the master credentials or
+// a session created with AssumeRole. This allows for usecases where a token created with AssumeRole
+// wouldn't work.
+func (p *VaultProvider) RetrieveWithoutSessionToken() (credentials.Value, error) {
+	creds, err := p.getMasterCreds()
+	if err != nil {
+		return credentials.Value{}, err
+	}
+
+	if role, ok := p.profiles[p.profile]["role_arn"]; ok {
+		session, err := p.assumeRole(creds, role)
+		if err != nil {
+			return credentials.Value{}, err
+		}
+
+		log.Printf("Using role ****************%s, expires in %s",
+			(*session.AccessKeyId)[len(*session.AccessKeyId)-4:],
+			session.Expiration.Sub(time.Now()).String())
+
+		window := p.ExpiryWindow
+		if window == 0 {
+			window = time.Minute * 5
+		}
+
+		p.SetExpiration(*session.Expiration, window)
+		p.expires = *session.Expiration
+
+		value := credentials.Value{
+			AccessKeyID:     *session.AccessKeyId,
+			SecretAccessKey: *session.SecretAccessKey,
+			SessionToken:    *session.SessionToken,
+		}
+
+		return value, nil
+	}
+
+	// no role, exposes master credentials which don't expire
+	return creds, nil
 }
 
 func (p *VaultProvider) getMasterCreds() (credentials.Value, error) {

--- a/provider.go
+++ b/provider.go
@@ -154,6 +154,8 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 // a session created with AssumeRole. This allows for usecases where a token created with AssumeRole
 // wouldn't work.
 func (p *VaultProvider) RetrieveWithoutSessionToken() (credentials.Value, error) {
+	log.Println("Skipping session token and using master credentials directly")
+
 	creds, err := p.getMasterCreds()
 	if err != nil {
 		return credentials.Value{}, err
@@ -193,24 +195,20 @@ func (p *VaultProvider) RetrieveWithoutSessionToken() (credentials.Value, error)
 func (p *VaultProvider) getMasterCreds() (credentials.Value, error) {
 	source := sourceProfile(p.profile, p.profiles)
 
-	creds, ok := p.creds[source]
+	val, ok := p.creds[source]
 	if !ok {
-		provider := credentials.NewChainCredentials([]credentials.Provider{
-			&credentials.EnvProvider{},
-			&credentials.SharedCredentialsProvider{Filename: "", Profile: p.profile},
-			&KeyringProvider{Keyring: p.keyring, Profile: source},
-		})
+		creds := credentials.NewCredentials(&KeyringProvider{Keyring: p.keyring, Profile: source})
 
 		var err error
-		if creds, err = provider.Get(); err != nil {
+		if val, err = creds.Get(); err != nil {
 			log.Printf("Failed to find credentials for profile %q in keyring", source)
-			return creds, err
+			return val, err
 		}
 
-		p.creds[source] = creds
+		p.creds[source] = val
 	}
 
-	return creds, nil
+	return val, nil
 }
 
 func (p *VaultProvider) getSessionToken(creds *credentials.Value) (sts.Credentials, error) {

--- a/sessions.go
+++ b/sessions.go
@@ -64,10 +64,11 @@ func (s *KeyringSessions) Store(profile string, session sts.Credentials, duratio
 
 	log.Printf("Writing session for %s to keyring", profile)
 	s.Keyring.Set(keyring.Item{
-		Key:       s.key(profile, duration),
-		Label:     "aws-vault session for " + profile,
-		Data:      bytes,
-		TrustSelf: true,
+		Key:         s.key(profile, duration),
+		Label:       "aws-vault session for " + profile,
+		Description: "aws-vault session for " + profile,
+		Data:        bytes,
+		TrustSelf:   true,
 	})
 
 	return nil

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -248,8 +248,8 @@
 			"checksumSHA1": "VGkGZuxgsZinkFJjqkk4gpS0104=",
 			"origin": "github.com/lox/go-keychain",
 			"path": "github.com/keybase/go-keychain",
-			"revision": "72a96c565a7db66ce371cfe062100b4b8482f310",
-			"revisionTime": "2017-08-05T04:40:36Z"
+			"revision": "efeae48c0b272ac15a6c0b53129285b2b0ed828d",
+			"revisionTime": "2017-08-10T04:31:23Z"
 		},
 		{
 			"checksumSHA1": "AXacfEchaUqT5RGmPmMXsOWRhv8=",


### PR DESCRIPTION
I noticed that we were back to displaying three prompts for every access, even when there is a session. Should only prompt once now and not at all if there is an active session. 