### PR TITLE
Refactor order in which access to keychain is requested

### DIFF
--- a/vault/config.go
+++ b/vault/config.go
@@ -83,5 +83,5 @@ func FormatCredentialError(profileKey string, from Profiles, err error) string {
 			sourceDescr, source)
 	}
 
-	return fmt.Sprintf("Failed to get credentials for %s: %v", err, sourceDescr)
+	return fmt.Sprintf("Failed to get credentials for %s: %v", sourceDescr, err)
 }

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -87,42 +87,12 @@ func NewVaultProvider(k keyring.Keyring, profile string, opts VaultOptions) (*Va
 	}, nil
 }
 
+// Retrieve returns credentials protected by a GetSessionToken. If there is an associated
+// role in the profile then AssumeRole is applied. The benefit of a session is that it doesn't
+// require MFA or a user prompt to access the keychain item, much like sudo.
 func (p *VaultProvider) Retrieve() (credentials.Value, error) {
-	creds, err := p.getMasterCreds()
-	if err != nil {
-		return credentials.Value{}, err
-	}
-
-	window := p.ExpiryWindow
-	if window == 0 {
-		window = time.Minute * 5
-	}
-
 	if p.NoSession {
-		if role, ok := p.profiles[p.profile]["role_arn"]; ok {
-			session, err := p.assumeRole(creds, role)
-			if err != nil {
-				return credentials.Value{}, err
-			}
-
-			log.Printf("Using role ****************%s, expires in %s",
-				(*session.AccessKeyId)[len(*session.AccessKeyId)-4:],
-				session.Expiration.Sub(time.Now()).String())
-
-			p.SetExpiration(*session.Expiration, window)
-			p.expires = *session.Expiration
-
-			value := credentials.Value{
-				AccessKeyID:     *session.AccessKeyId,
-				SecretAccessKey: *session.SecretAccessKey,
-				SessionToken:    *session.SessionToken,
-			}
-
-			return value, nil
-		}
-
-		// no role, exposes master credentials which don't expire
-		return creds, nil
+		return p.RetrieveWithoutSessionToken()
 	}
 
 	session, err := p.sessions.Retrieve(p.profile, p.SessionDuration)
@@ -131,6 +101,12 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 			log.Println("Session not found in keyring")
 		} else {
 			log.Println(err)
+		}
+
+		// session lookup missed, we need to create a new one
+		creds, err := p.getMasterCreds()
+		if err != nil {
+			return credentials.Value{}, err
 		}
 
 		session, err = p.getSessionToken(&creds)
@@ -156,6 +132,11 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 		log.Printf("Using role ****************%s (from session token), expires in %s",
 			(*session.AccessKeyId)[len(*session.AccessKeyId)-4:],
 			session.Expiration.Sub(time.Now()).String())
+	}
+
+	window := p.ExpiryWindow
+	if window == 0 {
+		window = time.Minute * 5
 	}
 
 	p.SetExpiration(*session.Expiration, window)

--- a/vault/sessions.go
+++ b/vault/sessions.go
@@ -68,7 +68,7 @@ func (s *KeyringSessions) Store(profile string, session sts.Credentials, duratio
 		Label:       "aws-vault session for " + profile,
 		Description: "aws-vault session for " + profile,
 		Data:        bytes,
-		TrustSelf:   true,
+		TrustSelf:   false,
 	})
 
 	return nil

--- a/vault/sessions.go
+++ b/vault/sessions.go
@@ -64,10 +64,11 @@ func (s *KeyringSessions) Store(profile string, session sts.Credentials, duratio
 
 	log.Printf("Writing session for %s to keyring", profile)
 	s.Keyring.Set(keyring.Item{
-		Key:       s.key(profile, duration),
-		Label:     "aws-vault session for " + profile,
-		Data:      bytes,
-		TrustSelf: true,
+		Key:         s.key(profile, duration),
+		Label:       "aws-vault session for " + profile,
+		Description: "aws-vault session for " + profile,
+		Data:        bytes,
+		TrustSelf:   true,
 	})
 
 	return nil


### PR DESCRIPTION
When a session is requested from the keychain, the master credentials shouldn't be requested. Instead we should be prompting for access to the session keychain item.

The net effect is the same, requesting master credentials pops a prompt, and then the next time you request access to a session it pops a prompt, but it's the correct prompt, for the correct item, the session. 

I guess the downside of this, and it's probably a sizeable downside is that you can't hit "Always trust" the second time and never see a prompt again. You might be able to do that for the master credentials, but you would need to do it for every new session key that is stored.

Bug, feature, regression, improvement, not sure. Maybe all?