### PR TITLE
Drop support for the env and shared credentials provider

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -172,24 +172,20 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 func (p *VaultProvider) getMasterCreds() (credentials.Value, error) {
 	source := sourceProfile(p.profile, p.profiles)
 
-	creds, ok := p.creds[source]
+	val, ok := p.creds[source]
 	if !ok {
-		provider := credentials.NewChainCredentials([]credentials.Provider{
-			&credentials.EnvProvider{},
-			&credentials.SharedCredentialsProvider{Filename: "", Profile: p.profile},
-			&KeyringProvider{Keyring: p.keyring, Profile: source},
-		})
+		creds := credentials.NewCredentials(&KeyringProvider{Keyring: p.keyring, Profile: source})
 
 		var err error
-		if creds, err = provider.Get(); err != nil {
+		if val, err = creds.Get(); err != nil {
 			log.Printf("Failed to find credentials for profile %q in keyring", source)
-			return creds, err
+			return val, err
 		}
 
-		p.creds[source] = creds
+		p.creds[source] = val
 	}
 
-	return creds, nil
+	return val, nil
 }
 
 func (p *VaultProvider) getSessionToken(creds *credentials.Value) (sts.Credentials, error) {


### PR DESCRIPTION
Previously we used `NewChainCredentials` to try in order the AWS env vars, then `~/.aws/credentials` and then finally our vault provider. The idea was if you started out with old school credentials it would kind of work. It was a bad idea, and the end result is that errors from our vault provider show up as "No credentials found" rather than useful errors. This has (in part) led to #49 by masking the underlying errors. 