### PR TITLE
Fallback to Arn when Username doesn't exist

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/99designs/aws-vault/prompt"
@@ -200,18 +201,15 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 }
 
 func getFederationToken(creds credentials.Value, d time.Duration) (*sts.Credentials, error) {
-	client := sts.New(session.New(&aws.Config{
+	sess := session.New(&aws.Config{
 		Credentials: credentials.NewCredentials(&credentials.StaticProvider{Value: creds}),
-	}))
+	})
+	client := sts.New(sess)
 
 	params := &sts.GetFederationTokenInput{
-		Name:            aws.String("federated-user"),
+		Name:            aws.String(getFederatedUserName(sess)),
 		DurationSeconds: aws.Int64(int64(d.Seconds())),
 		Policy:          aws.String(allowAllIAMPolicy),
-	}
-
-	if username, _ := getUserName(creds); username != "" {
-		params.Name = aws.String(username)
 	}
 
 	resp, err := client.GetFederationToken(params)
@@ -222,15 +220,20 @@ func getFederationToken(creds credentials.Value, d time.Duration) (*sts.Credenti
 	return resp.Credentials, nil
 }
 
-func getUserName(creds credentials.Value) (string, error) {
-	client := iam.New(session.New(&aws.Config{
-		Credentials: credentials.NewCredentials(&credentials.StaticProvider{Value: creds}),
-	}))
+func getFederatedUserName(sess *session.Session) string {
+	client := iam.New(sess)
 
 	resp, err := client.GetUser(&iam.GetUserInput{})
-	if err != nil {
-		return "", err
+	if err == nil {
+		if resp.User.UserName != nil {
+			return *resp.User.UserName
+		}
+
+		if resp.User.Arn != nil {
+			arnParts := strings.Split(*resp.User.Arn, ":")
+			return arnParts[len(arnParts)-1]
+		}
 	}
 
-	return *resp.User.UserName, nil
+	return "aws-vault"
 }


### PR DESCRIPTION
It seems `User.UserName` isn't always present in a [`GetUser`](http://docs.aws.amazon.com/IAM/latest/APIReference/API_GetUser.html) response. I experienced this while using aws-vault with root credentials

So this now falls back to parsing the `User.Arn`.

Fixes https://github.com/99designs/aws-vault/issues/114
