### PR TITLE
Fix data race

### DIFF
--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -13,7 +13,7 @@ func ExampleExecCommand() {
 		{Key: "llamas", Data: []byte(`{"AccessKeyID":"ABC","SecretAccessKey":"XYZ"}`)},
 	})
 
-	app := kingpin.New(`aws-vault`, ``)
+	app := kingpin.New("aws-vault", "")
 	ConfigureGlobals(app)
 	ConfigureExecCommand(app)
 	kingpin.MustParse(app.Parse([]string{


### PR DESCRIPTION
We try to read cmd.Process in the thread that handles incoming
signals, but there's no synchronization between that goroutine and the
one that sets cmd.Process to a non-nil value.

This might be overkill, e.g. there may be a way to write this with
less code, but I confirmed that this patch addresses the
race when shutting down the program.

Fixes #158.