### PR TITLE
Use app.Fatal instead of app.Error

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -150,8 +150,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Start(); err != nil {
-		app.Errorf("%v", err)
-		return
+		app.Fatalf("%v", err)
 	}
 	// wait for the command to finish
 	waitCh := make(chan error, 1)
@@ -174,8 +173,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 				os.Exit(waitStatus.ExitStatus())
 			}
 			if err != nil {
-				app.Errorf("%v", err)
-				return
+				app.Fatalf("%v", err)
 			}
 			return
 		}


### PR DESCRIPTION
app.Error merely logs, instead of quitting the program with a non-zero
return code. This means some subset of programs fail to exec the
underlying binary and then exit 0, which might incorrectly indicate to
a caller (like me) that they exited successfully.

Fixes #167.