### PR TITLE
Add entry to aws config file in add command

### DIFF
--- a/cli/add_test.go
+++ b/cli/add_test.go
@@ -1,12 +1,21 @@
 package cli
 
 import (
+	"io/ioutil"
+	"log"
 	"os"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 func ExampleAddCommand() {
+	f, err := ioutil.TempFile("", "aws-config")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	os.Setenv("AWS_CONFIG_FILE", f.Name())
 	os.Setenv("AWS_ACCESS_KEY_ID", "llamas")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "rock")
 	os.Setenv("AWS_VAULT_BACKEND", "file")


### PR DESCRIPTION
This adds a profile (if one doesn't exist) to `~/.aws/config` when you add a profile with `aws-vault add`. 

This helps keep your config aligned with your credentials in your keychain.