### PR TITLE
Metadata server running on windows

### DIFF
--- a/server/alias_windows.go
+++ b/server/alias_windows.go
@@ -2,8 +2,22 @@
 
 package server
 
-import "fmt"
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
 
 func installNetworkAlias() ([]byte, error) {
-	return make([]byte, 0), fmt.Errorf("Server mode is unsupported on windows.")
+	out, err := exec.Command("netsh", "interface", "ipv4", "add", "address", "Loopback Pseudo-Interface 1", "169.254.169.254", "255.255.0.0").CombinedOutput()
+
+	if err == nil || strings.Contains(string(out), "The object already exists") {
+		return []byte{}, nil
+	}
+
+	if strings.Contains(string(out), "Run as administrator") {
+		fmt.Println("Creation of network alias for server mode requires elevated permissions (Run as administrator).")
+	}
+
+	return out, err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -85,6 +86,10 @@ func StartCredentialsServer(creds *vault.VaultCredentials) error {
 			cmd.Stderr = os.Stderr
 			if err := cmd.Start(); err != nil {
 				return err
+			}
+			time.Sleep(time.Second * 1)
+			if !checkServerRunning(metadataBind) {
+				return errors.New("The credential proxy server isn't running. Run aws-vault server as Administrator in the background and then try this command again")
 			}
 		} else {
 			log.Printf("Starting `aws-vault server` as root in the background")

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"time"
 
 	"github.com/99designs/aws-vault/vault"
@@ -76,13 +77,24 @@ func checkServerRunning(bind string) bool {
 
 func StartCredentialsServer(creds *vault.VaultCredentials) error {
 	if !checkServerRunning(metadataBind) {
-		log.Printf("Starting `aws-vault server` as root in the background")
-		cmd := exec.Command("sudo", "-b", os.Args[0], "server")
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return err
+		if runtime.GOOS == "windows" {
+			log.Printf("Starting `aws-vault server` in the background")
+			cmd := exec.Command(os.Args[0], "server")
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Start(); err != nil {
+				return err
+			}
+		} else {
+			log.Printf("Starting `aws-vault server` as root in the background")
+			cmd := exec.Command("sudo", "-b", os.Args[0], "server")
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Issue https://github.com/99designs/aws-vault/issues/166 describes whats going on here

This is a breaking change for the way the metadata server is started

```sh
aws-vault exec <environment> --server
```

is now

```sh
aws-vault exec <environment> -s -- aws-vault server
```
