### PR TITLE
Add docs for rotate and clearer errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,31 @@ Then when you use the `admin` profile, `aws-vault` will look in the `read-only` 
 
 **Note:** When assuming roles, `mfa_serial` will not be inherited from the profile designated in `source_profile` -- you must include a reference to `mfa_serial` in every profile you wish to use it with.
 
+## Rotating Credentials
+
+Regularly rotating your access keys is a critical part of credential management. You can do this with the `aws-vault rotate <profile>` command as often as you like.
+
+The minimal IAM policy required to rotate your own credentials is:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateAccessKey",
+                "iam:DeleteAccessKey",
+                "iam:GetUser"
+            ],
+            "Resource": [
+                "arn:aws:iam::*:user/${aws:username}"
+            ]
+        }
+    ]
+}
+```
+
 ## Development
 
 Developed with golang, to install run:

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -44,7 +44,7 @@ func RotateCommand(app *kingpin.Application, input RotateCommandInput) {
 		Config:    awsConfig,
 	}
 
-	fmt.Printf("Rotating credentials for profile %q\n", input.Profile)
+	fmt.Printf("Rotating credentials for profile %q (takes 10-20 seconds)\n", input.Profile)
 
 	if err := rotator.Rotate(input.Profile); err != nil {
 		app.Fatalf(awsConfig.FormatCredentialError(err, input.Profile))

--- a/vault/rotator.go
+++ b/vault/rotator.go
@@ -80,7 +80,7 @@ func (r *Rotator) Rotate(profile string) error {
 	var iamUserName *string
 
 	// A username is needed for some IAM calls if the credentials have assumed a role
-	if oldSessionVal.SessionToken != "" {
+	if oldSessionVal.SessionToken != "" || currentUserName != "root" {
 		iamUserName = aws.String(currentUserName)
 	}
 


### PR DESCRIPTION
Key rotations is complicated and there are lots of edge cases, this adds some documentation on what IAM permissions are required, along with making some of the AWS error messages clearer (use a username when one exists, rather than relying on a null user).

Closes #178.