### PR TITLE
Import and Export commands

### DIFF
--- a/cli/export.go
+++ b/cli/export.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/99designs/aws-vault/prompt"
+	"github.com/99designs/aws-vault/vault"
+	"github.com/99designs/keyring"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type ExportCommandInput struct {
+	Profile     string
+	AllProfiles bool
+	Keyring     keyring.Keyring
+	MfaToken    string
+	MfaPrompt   prompt.PromptFunc
+}
+
+func ConfigureExportCommand(app *kingpin.Application) {
+	input := ExportCommandInput{}
+
+	cmd := app.Command("export", "Export a profile's credentials to ~/.aws/credentials in plain text")
+	cmd.Arg("profile", "Name of the profile").
+		StringVar(&input.Profile)
+
+	cmd.Flag("mfa-token", "The mfa token to use").
+		Short('t').
+		StringVar(&input.MfaToken)
+
+	cmd.Flag("all", "Export all profiles").
+		Short('a').
+		BoolVar(&input.AllProfiles)
+
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		input.MfaPrompt = prompt.Method(GlobalFlags.PromptDriver)
+		input.Keyring = keyringImpl
+		ExportCommand(app, input)
+		return nil
+	})
+}
+
+func ExportCommand(app *kingpin.Application, input ExportCommandInput) {
+	if (input.Profile == "" && !input.AllProfiles) || (input.Profile != "" && input.AllProfiles) {
+		app.Fatalf("Either a profile or --all must be provided")
+	}
+
+	credentials, err := input.Keyring.Keys()
+	if err != nil {
+		app.Fatalf(err.Error())
+		return
+	}
+
+	var profiles = []string{}
+	for _, profile := range credentials {
+		if !vault.IsSessionKey(profile) {
+			if input.AllProfiles || input.Profile == profile {
+				profiles = append(profiles, profile)
+			}
+		}
+	}
+
+	if len(profiles) == 0 {
+		app.Fatalf("No profiles found to export")
+	}
+
+	for _, profile := range profiles {
+		provider := vault.KeyringProvider{
+			Profile: profile,
+			Keyring: input.Keyring,
+		}
+
+		val, err := provider.Retrieve()
+		if err != nil {
+			app.Fatalf("Failed to retrieve credentials for %q: %v", profile, err)
+		}
+
+		f, err := vault.GetSharedCredentialsFile()
+		if err != nil {
+			app.Fatalf("%v", err)
+		}
+
+		if err = vault.WriteCredentialsToFile(f, profile, val); err != nil {
+			app.Fatalf("%v", err)
+		}
+
+		fmt.Printf("Wrote credentials for profile %q to %s\n", profile, f)
+	}
+}

--- a/cli/import.go
+++ b/cli/import.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/99designs/aws-vault/vault"
+	"github.com/99designs/keyring"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type ImportCommandInput struct {
+	Profile   string
+	Keyring   keyring.Keyring
+	AddConfig bool
+}
+
+func ConfigureImportCommand(app *kingpin.Application) {
+	input := ImportCommandInput{}
+
+	cmd := app.Command("import", "Import all credentials from ~/.aws/credentials")
+	cmd.Arg("profile", "Name of the profile").
+		Required().
+		StringVar(&input.Profile)
+
+	cmd.Flag("add-config", "Add a profile to ~/.aws/config if one doesn't exist").
+		Default("true").
+		BoolVar(&input.AddConfig)
+
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		input.Keyring = keyringImpl
+		ImportCommand(app, input)
+		return nil
+	})
+}
+
+func ImportCommand(app *kingpin.Application, input ImportCommandInput) {
+	file, err := vault.GetSharedCredentialsFile()
+	if err != nil {
+		app.Fatalf(err.Error())
+		return
+	}
+
+	cred, err := vault.ReadCredentialsFromFile(file, input.Profile)
+	if err != nil {
+		app.Fatalf(err.Error())
+		return
+	}
+
+	err = addCredentialsToVault(input.Profile, input.Keyring, credentials.Value{
+		AccessKeyID:     cred.AccessKeyID,
+		SecretAccessKey: cred.SecretAccessKey,
+	})
+	if err != nil {
+		app.Fatalf(err.Error())
+		return
+	}
+
+	if input.AddConfig {
+		if err = addProfileToConfig(input.Profile); err != nil {
+			app.Fatalf(err.Error())
+			return
+		}
+	}
+
+	fmt.Printf(
+		"Done! You should consider rotating these credentials with `aws-vault rotate %s`\n",
+		input.Profile,
+	)
+}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ func run(args []string, exit func(int)) {
 	cli.ConfigureRemoveCommand(app)
 	cli.ConfigureLoginCommand(app)
 	cli.ConfigureServerCommand(app)
+	cli.ConfigureExportCommand(app)
+	cli.ConfigureImportCommand(app)
 
 	kingpin.MustParse(app.Parse(args))
 }

--- a/vault/credentials.go
+++ b/vault/credentials.go
@@ -1,0 +1,77 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/go-ini/ini"
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+type SharedCredentials struct {
+	AccessKeyID     string `ini:"aws_access_key_id"`
+	SecretAccessKey string `ini:"aws_secret_access_key"`
+}
+
+func GetSharedCredentialsFile() (string, error) {
+	file := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if file == "" {
+		home, err := homedir.Dir()
+		if err != nil {
+			return "", err
+		}
+		file = filepath.Join(home, "/.aws/credentials")
+	}
+	return file, nil
+}
+
+func ReadCredentialsFromFile(file string, profile string) (cred SharedCredentials, err error) {
+	log.Printf("Parsing credential file %s", file)
+	iniFile, err := ini.Load(file)
+	if err != nil {
+		return cred, fmt.Errorf("Error parsing credential file %q: %v", file, err)
+	}
+	for _, sectionName := range iniFile.SectionStrings() {
+		if sectionName == profile {
+			section, err := iniFile.GetSection(sectionName)
+			if err != nil {
+				return cred, err
+			}
+			if err = section.MapTo(&cred); err != nil {
+				return cred, err
+			}
+			return cred, nil
+		}
+	}
+
+	return cred, fmt.Errorf("Failed to find profile %q", profile)
+}
+
+func WriteCredentialsToFile(file string, profile string, creds credentials.Value) error {
+	var cfg *ini.File
+	var err error
+
+	if _, statErr := os.Stat(file); os.IsNotExist(statErr) {
+		cfg = ini.Empty()
+	} else {
+		cfg, err = ini.Load(file)
+		if err != nil {
+			return err
+		}
+	}
+
+	section := cfg.Section(profile)
+	_, err = section.NewKey("aws_access_key_id", creds.AccessKeyID)
+	if err != nil {
+		return err
+	}
+	_, err = section.NewKey("aws_secret_access_key", creds.SecretAccessKey)
+	if err != nil {
+		return err
+	}
+
+	return cfg.SaveTo(file)
+}


### PR DESCRIPTION
This adds a command for importing plain text credentials from `~/.aws/credentials`, and a command to export credentials to plain text credentials. 

This is useful for migrating between vaults, or migrating from other tools to aws-vault.