### PR TITLE
set AWS_SECRET_KEY

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -132,9 +132,10 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 	}
 
 	if setEnv {
-		log.Println("Setting subprocess env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY")
+		log.Println("Setting subprocess env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SECRET_KEY")
 		env.Set("AWS_ACCESS_KEY_ID", val.AccessKeyID)
 		env.Set("AWS_SECRET_ACCESS_KEY", val.SecretAccessKey)
+		env.Set("AWS_SECRET_KEY", val.SecretAccessKey)
 
 		if val.SessionToken != "" {
 			log.Println("Setting subprocess env: AWS_SESSION_TOKEN, AWS_SECURITY_TOKEN")


### PR DESCRIPTION
Support AWS's inconsistent naming convention by setting a `AWS_SECRET_KEY` variable in addition to `AWS_SECRET_ACCESS_KEY`.

![giphy 21](https://user-images.githubusercontent.com/409251/32881426-162f093c-cb16-11e7-884b-a03951d45580.gif)
