### PR TITLE
Allow for different macOS Keychain to be used

### DIFF
--- a/cli/global.go
+++ b/cli/global.go
@@ -48,7 +48,7 @@ func ConfigureGlobals(app *kingpin.Application) {
 		OverrideDefaultFromEnvar("AWS_VAULT_PROMPT").
 		EnumVar(&GlobalFlags.PromptDriver, promptsAvailable...)
 
-	app.Flag("keychain", "Name of macOS keychain to use, blank means the default keychain (usually login)").
+	app.Flag("keychain", "Name of macOS keychain to use, if it doesn't exist it will be created").
 		Default("aws-vault").
 		OverrideDefaultFromEnvar("AWS_VAULT_KEYCHAIN_NAME").
 		StringVar(&GlobalFlags.KeychainName)

--- a/cli/global.go
+++ b/cli/global.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	KeyringName = "aws-vault"
+	DefaultKeyringName = "aws-vault"
 )
 
 var (
@@ -27,6 +27,7 @@ var GlobalFlags struct {
 	Debug        bool
 	Backend      string
 	PromptDriver string
+	KeychainName string
 }
 
 func ConfigureGlobals(app *kingpin.Application) {
@@ -47,6 +48,11 @@ func ConfigureGlobals(app *kingpin.Application) {
 		OverrideDefaultFromEnvar("AWS_VAULT_PROMPT").
 		EnumVar(&GlobalFlags.PromptDriver, promptsAvailable...)
 
+	app.Flag("keychain", "Name of macOS keychain to use, blank means the default keychain (usually login)").
+		Default("aws-vault").
+		OverrideDefaultFromEnvar("AWS_VAULT_KEYCHAIN_NAME").
+		StringVar(&GlobalFlags.KeychainName)
+
 	app.PreAction(func(c *kingpin.ParseContext) (err error) {
 		if !GlobalFlags.Debug {
 			log.SetOutput(ioutil.Discard)
@@ -62,7 +68,7 @@ func ConfigureGlobals(app *kingpin.Application) {
 			keyringImpl, err = keyring.Open(keyring.Config{
 				ServiceName:      "aws-vault",
 				AllowedBackends:  allowedBackends,
-				KeychainName:     "aws-vault",
+				KeychainName:     GlobalFlags.KeychainName,
 				FileDir:          "~/.awsvault/keys/",
 				FilePasswordFunc: fileKeyringPassphrasePrompt,
 				KWalletAppID:     "aws-vault",


### PR DESCRIPTION
This supersedes #144. It allows for a specific macOS keychain to be used, which means that either the default/ login keychain can be used rather than the previous `aws-vault.keychain` that was created. 

The default remains `aws-vault`, so it's backwards compatible. 
