### PR TITLE
Add expiry data to session

### DIFF
--- a/cli/global.go
+++ b/cli/global.go
@@ -48,7 +48,7 @@ func ConfigureGlobals(app *kingpin.Application) {
 		OverrideDefaultFromEnvar("AWS_VAULT_PROMPT").
 		EnumVar(&GlobalFlags.PromptDriver, promptsAvailable...)
 
-	app.Flag("keychain", "Name of macOS keychain to use, blank means the default keychain (usually login)").
+	app.Flag("keychain", "Name of macOS keychain to use, if it doesn't exist it will be created").
 		Default("aws-vault").
 		OverrideDefaultFromEnvar("AWS_VAULT_KEYCHAIN_NAME").
 		StringVar(&GlobalFlags.KeychainName)

--- a/cli/global.go
+++ b/cli/global.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	KeyringName = "aws-vault"
+	DefaultKeyringName = "aws-vault"
 )
 
 var (
@@ -27,6 +27,7 @@ var GlobalFlags struct {
 	Debug        bool
 	Backend      string
 	PromptDriver string
+	KeychainName string
 }
 
 func ConfigureGlobals(app *kingpin.Application) {
@@ -47,6 +48,11 @@ func ConfigureGlobals(app *kingpin.Application) {
 		OverrideDefaultFromEnvar("AWS_VAULT_PROMPT").
 		EnumVar(&GlobalFlags.PromptDriver, promptsAvailable...)
 
+	app.Flag("keychain", "Name of macOS keychain to use, blank means the default keychain (usually login)").
+		Default("aws-vault").
+		OverrideDefaultFromEnvar("AWS_VAULT_KEYCHAIN_NAME").
+		StringVar(&GlobalFlags.KeychainName)
+
 	app.PreAction(func(c *kingpin.ParseContext) (err error) {
 		if !GlobalFlags.Debug {
 			log.SetOutput(ioutil.Discard)
@@ -62,7 +68,7 @@ func ConfigureGlobals(app *kingpin.Application) {
 			keyringImpl, err = keyring.Open(keyring.Config{
 				ServiceName:      "aws-vault",
 				AllowedBackends:  allowedBackends,
-				KeychainName:     "aws-vault",
+				KeychainName:     GlobalFlags.KeychainName,
 				FileDir:          "~/.awsvault/keys/",
 				FilePasswordFunc: fileKeyringPassphrasePrompt,
 				KWalletAppID:     "aws-vault",

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -87,6 +87,12 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 		return
 	}
 
+	sessions, err := krs.Sessions()
+	if err != nil {
+		app.Fatalf(err.Error())
+		return
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 25, 4, 2, ' ', 0)
 	fmt.Fprintln(w, "Profile\tCredentials\tSessions\t")
 	fmt.Fprintln(w, "=======\t===========\t========\t")
@@ -102,15 +108,14 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 			fmt.Fprintf(w, "-\t")
 		}
 
-		sessions, err := krs.Sessions(profile.Name)
-		if err != nil {
-			app.Fatalf(err.Error())
-			return
-		} else if len(sessions) > 0 {
-			var sessionIDs []string
-			for _, sess := range sessions {
+		var sessionIDs []string
+		for _, sess := range sessions {
+			if profile.Name == sess.Profile.Name {
 				sessionIDs = append(sessionIDs, sess.SessionID)
 			}
+		}
+
+		if len(sessions) > 0 {
 			fmt.Fprintf(w, "%s\t\n", strings.Join(sessionIDs, ", "))
 		} else {
 			fmt.Fprintf(w, "-\t\n")

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -96,10 +96,13 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 		return p.RetrieveWithoutSessionToken()
 	}
 
-	session, err := p.sessions.Retrieve(p.profile, p.SessionDuration)
+	// sessions get stored by source profile
+	source, _ := p.config.SourceProfile(p.profile)
+
+	session, err := p.sessions.Retrieve(source.Name)
 	if err != nil {
 		if err == keyring.ErrKeyNotFound {
-			log.Println("Session not found in keyring")
+			log.Printf("Session not found in keyring for %s", source.Name)
 		} else {
 			log.Println(err)
 		}
@@ -115,7 +118,7 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 			return credentials.Value{}, err
 		}
 
-		if err = p.sessions.Store(p.profile, session, p.SessionDuration); err != nil {
+		if err = p.sessions.Store(source.Name, session, time.Now().Add(p.SessionDuration)); err != nil {
 			return credentials.Value{}, err
 		}
 	}

--- a/vault/sessions.go
+++ b/vault/sessions.go
@@ -74,7 +74,10 @@ func (s *KeyringSessions) Sessions() ([]KeyringSession, error) {
 			log.Printf("%s is a session", k)
 			ks, _ := parseKeyringSession(k, s.Config)
 			if ks.IsExpired() {
-				log.Printf("Session %s is expired", ks.Name)
+				log.Printf("Session %s is expired, deleting", k)
+				if err := s.Keyring.Remove(k); err != nil {
+					return nil, err
+				}
 				continue
 			}
 
@@ -155,7 +158,7 @@ func (s *KeyringSessions) Delete(profile string) (n int, err error) {
 	for _, session := range sessions {
 		if session.Profile.Name == profile {
 			log.Printf("Session %q matches profile %q", session.Name, profile)
-			if err = s.Keyring.Remove(session.Profile.Name); err != nil {
+			if err = s.Keyring.Remove(session.Name); err != nil {
 				return n, err
 			}
 			n++


### PR DESCRIPTION
This can be merged after #197.

It adds the expiry time for a session into the item description that is stored unencrypted. This means we can skip expired sessions and avoid lots of prompts.

Closes #188 (hopefully).