### PR TITLE
Prevent local network segment from accessing credential server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -122,6 +122,20 @@ func StartCredentialsServer(creds *vault.VaultCredentials) error {
 
 	log.Printf("Local instance role server running on %s", l.Addr())
 	go http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// Must make sure the remote ip is localhost, otherwise clients on the same network segment could
+		// potentially route traffic via 169.254.169.254:80
+		if ip != `127.0.0.1` {
+			http.Error(w, "Access denied from non-localhost address", http.StatusUnauthorized)
+			return
+		}
+
+		log.Printf("RemoteAddr = %v", r.RemoteAddr)
 		log.Printf("Credentials.IsExpired() = %#v", creds.IsExpired())
 
 		val, err := creds.Get()

--- a/server/server.go
+++ b/server/server.go
@@ -128,9 +128,10 @@ func StartCredentialsServer(creds *vault.VaultCredentials) error {
 			return
 		}
 
-		// Must make sure the remote ip is localhost, otherwise clients on the same network segment could
+		// Must make sure the remote ip is from the loopback, otherwise clients on the same network segment could
 		// potentially route traffic via 169.254.169.254:80
-		if ip != `127.0.0.1` {
+		// See https://developer.apple.com/library/content/qa/qa1357/_index.html
+		if !net.ParseIP(ip).IsLoopback() {
 			http.Error(w, "Access denied from non-localhost address", http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
Via #198 we were made aware that it was possible to route traffic to `169.254.169.254:80` even if it is aliased to `lo0`. This means anyone on the same network segment could access the credential server whilst an `aws-vault exec --server blah` command was running. 

This adds a check for a `RemoteAddr` of `127.0.0.1`. I don't love this approach, would much prefer something lower down, but it seems like a pragmatic mitigation in the short term. Any thoughts @mtibben @clintoncampbell?