### PR TITLE
Remove server subcommand from `--help`

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -11,7 +11,9 @@ type ServerCommandInput struct {
 func ConfigureServerCommand(app *kingpin.Application) {
 	input := ServerCommandInput{}
 
-	cmd := app.Command("server", "Run an ec2 instance role server locally")
+	cmd := app.Command("server", "Run an ec2 instance role server locally").
+		Hidden()
+
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		ServerCommand(app, input)
 		return nil


### PR DESCRIPTION
Some notes:

> The "proxy" server starts up in the background and binds to 169.254.169.254:80, which is what the aws tooling connects to. It needs root permissions to create the iface and bind to a port < 1024. This is what is triggered by aws-vault server. It's meant to be pretty useless on it's own, and simply proxies requests to localhost:9099 if it exists.
> 
> The "credential" server is started at the beginning of an aws-vault exec --server invocation and it only runs for the duration of that command. It's the one with the keys to the kingdom, so it binds to localhost:9099.
https://github.com/99designs/aws-vault/pull/174#issuecomment-340921440

Closes #207.