### PR TITLE
Metadata endpoints for dotnet aws clients

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -118,10 +118,12 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 	env.Unset("AWS_DEFAULT_PROFILE")
 	env.Unset("AWS_PROFILE")
 
+	serverRegion := "us-east-1"
 	if profile, _ := awsConfig.Profile(input.Profile); profile.Region != "" {
 		log.Printf("Setting subprocess env: AWS_DEFAULT_REGION=%s, AWS_REGION=%s", profile.Region, profile.Region)
 		env.Set("AWS_DEFAULT_REGION", profile.Region)
 		env.Set("AWS_REGION", profile.Region)
+		serverRegion = profile.Region
 	}
 
 	if setEnv {
@@ -137,7 +139,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 	}
 
 	if input.StartServer {
-		if err := server.StartCredentialsServer(creds); err != nil {
+		if err := server.StartCredentialsServer(creds, serverRegion); err != nil {
 			app.Fatalf("Failed to start credential server: %v", err)
 		} else {
 			setEnv = false

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -109,14 +109,6 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 		app.Fatalf(awsConfig.FormatCredentialError(err, input.Profile))
 	}
 
-	if input.StartServer {
-		if err := server.StartCredentialsServer(creds); err != nil {
-			app.Fatalf("Failed to start credential server: %v", err)
-		} else {
-			setEnv = false
-		}
-	}
-
 	env := environ(os.Environ())
 	env.Set("AWS_VAULT", input.Profile)
 
@@ -141,6 +133,14 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 			log.Println("Setting subprocess env: AWS_SESSION_TOKEN, AWS_SECURITY_TOKEN")
 			env.Set("AWS_SESSION_TOKEN", val.SessionToken)
 			env.Set("AWS_SECURITY_TOKEN", val.SessionToken)
+		}
+	}
+
+	if input.StartServer {
+		if err := server.StartCredentialsServer(creds); err != nil {
+			app.Fatalf("Failed to start credential server: %v", err)
+		} else {
+			setEnv = false
 		}
 	}
 

--- a/cli/server.go
+++ b/cli/server.go
@@ -6,12 +6,18 @@ import (
 )
 
 type ServerCommandInput struct {
+	Region string
 }
 
 func ConfigureServerCommand(app *kingpin.Application) {
 	input := ServerCommandInput{}
 
 	cmd := app.Command("server", "Run an ec2 instance role server locally")
+
+	cmd.Arg("region", "The AWS Region (eg: us-east-1) that the metadata server should report").
+		Default("us-east-1").
+		StringVar(&input.Region)
+
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		ServerCommand(app, input)
 		return nil
@@ -19,7 +25,7 @@ func ConfigureServerCommand(app *kingpin.Application) {
 }
 
 func ServerCommand(app *kingpin.Application, input ServerCommandInput) {
-	if err := server.StartMetadataServer(); err != nil {
+	if err := server.StartMetadataServer(input.Region); err != nil {
 		app.Fatalf("Server failed: %v", err)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -23,10 +23,15 @@ const (
 	localServerBind = "127.0.0.1:9099"
 )
 
-func StartMetadataServer() error {
+var (
+	metadataRegion string
+)
+
+func StartMetadataServer(region string) error {
 	if _, err := installNetworkAlias(); err != nil {
 		return err
 	}
+	metadataRegion = region
 
 	router := http.NewServeMux()
 	router.HandleFunc("/latest/meta-data/iam/security-credentials/", indexHandler)
@@ -76,9 +81,8 @@ func instanceIdHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func regionDiscoveryHandler(w http.ResponseWriter, r *http.Request) {
-	//the config source profile has a region defined, this should be used here
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"region": "us-west-2",
+		"region": metadataRegion,
 	})
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,8 @@ func StartMetadataServer() error {
 	router.HandleFunc("/latest/meta-data/iam/security-credentials/local-credentials", credentialsHandler)
 	// The AWS Go SDK checks the instance-id endpoint to validate the existence of EC2 Metadata
 	router.HandleFunc("/latest/meta-data/instance-id/", instanceIdHandler)
+	// The AWS DotNet SDK checks the instance-id endpoint to validate the existence of EC2 Metadata
+	router.HandleFunc("/latest/meta-data/iam/info", iamInfoHandler)
 
 	l, err := net.Listen("tcp", metadataBind)
 	if err != nil {
@@ -69,6 +71,14 @@ func credentialsHandler(w http.ResponseWriter, r *http.Request) {
 
 func instanceIdHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "aws-vault")
+}
+
+func iamInfoHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"LastUpdated":        time.Now().UTC().Format(awsTimeFormat),
+		"InstanceProfileArn": nil,
+		"InstanceProfileId":  nil,
+	})
 }
 
 func checkServerRunning(bind string) bool {

--- a/server/server.go
+++ b/server/server.go
@@ -101,7 +101,7 @@ func checkServerRunning(bind string) bool {
 
 func StartCredentialProxyOnWindows() error {
 	log.Printf("Starting `aws-vault server` in the background")
-	cmd := exec.Command(os.Args[0], "server")
+	cmd := exec.Command(os.Args[0], "server", metadataRegion)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -117,7 +117,7 @@ func StartCredentialProxyOnWindows() error {
 
 func StartCredentialProxyWithSudo() error {
 	log.Printf("Starting `aws-vault server` as root in the background")
-	cmd := exec.Command("sudo", "-b", os.Args[0], "server")
+	cmd := exec.Command("sudo", "-b", os.Args[0], "server", metadataRegion)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -131,7 +131,8 @@ func StartCredentialProxy() error {
 	return StartCredentialProxyWithSudo()
 }
 
-func StartCredentialsServer(creds *vault.VaultCredentials) error {
+func StartCredentialsServer(creds *vault.VaultCredentials, region string) error {
+	metadataRegion = region
 	if !checkServerRunning(metadataBind) {
 		if err := StartCredentialProxy(); err != nil {
 			return err

--- a/server/server.go
+++ b/server/server.go
@@ -35,6 +35,8 @@ func StartMetadataServer() error {
 	router.HandleFunc("/latest/meta-data/instance-id/", instanceIdHandler)
 	// The AWS DotNet SDK checks the instance-id endpoint to validate the existence of EC2 Metadata
 	router.HandleFunc("/latest/meta-data/iam/info", iamInfoHandler)
+	// The AWS DotNet SDK checks the /dynamic/instance-identity/document endpoint to determine the region when configuring clients (eg the SQSClient)
+	router.HandleFunc("/latest/dynamic/instance-identity/document", regionDiscoveryHandler)
 
 	l, err := net.Listen("tcp", metadataBind)
 	if err != nil {
@@ -71,6 +73,13 @@ func credentialsHandler(w http.ResponseWriter, r *http.Request) {
 
 func instanceIdHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "aws-vault")
+}
+
+func regionDiscoveryHandler(w http.ResponseWriter, r *http.Request) {
+	//the config source profile has a region defined, this should be used here
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"region": "us-west-2",
+	})
 }
 
 func iamInfoHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
My current project is working with SQS Queues, i have found that these two additional metadata endpoints are required to allow the SQSClient to configure itself correctly when using the metadata endpoint.