### PR TITLE
Make secret-service use collection 'awsvault'

### DIFF
--- a/cli/global.go
+++ b/cli/global.go
@@ -65,13 +65,14 @@ func ConfigureGlobals(app *kingpin.Application) {
 				allowedBackends = append(allowedBackends, keyring.BackendType(GlobalFlags.Backend))
 			}
 			keyringImpl, err = keyring.Open(keyring.Config{
-				ServiceName:      "aws-vault",
-				AllowedBackends:  allowedBackends,
-				KeychainName:     GlobalFlags.KeychainName,
-				FileDir:          "~/.awsvault/keys/",
-				FilePasswordFunc: fileKeyringPassphrasePrompt,
-				KWalletAppID:     "aws-vault",
-				KWalletFolder:    "aws-vault",
+				ServiceName:             "aws-vault",
+				AllowedBackends:         allowedBackends,
+				KeychainName:            GlobalFlags.KeychainName,
+				FileDir:                 "~/.awsvault/keys/",
+				FilePasswordFunc:        fileKeyringPassphrasePrompt,
+				LibSecretCollectionName: "awsvault",
+				KWalletAppID:            "aws-vault",
+				KWalletFolder:           "aws-vault",
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
This fixes a regression from v4.1.0 to v4.2.0, where collection
was renamed to 'aws-vault'

This is caused by that github.com/99designs/keyring previously
used the collection name 'awsvault' by default.
This was changed in commit 5a0d04e 'Add backend specific config'.