### PR TITLE
Add a HintAction to exec to let KingPin autocomplete profile names.

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -59,6 +59,7 @@ func ConfigureExecCommand(app *kingpin.Application) {
 
 	cmd.Arg("profile", "Name of the profile").
 		Required().
+		HintAction(ProfileNames).
 		StringVar(&input.Profile)
 
 	cmd.Arg("cmd", "Command to execute").
@@ -198,4 +199,13 @@ func (e *environ) Unset(key string) {
 func (e *environ) Set(key, val string) {
 	e.Unset(key)
 	*e = append(*e, key+"="+val)
+}
+
+// ProfileNames returns a slice of profile names from the AWS config
+func ProfileNames() []string {
+	var profileNames []string
+	for _, profile := range awsConfig.Profiles() {
+		profileNames = append(profileNames, profile.Name)
+	}
+	return profileNames
 }


### PR DESCRIPTION
KingPin can provide dynamic values to it's bash-completion with the HintAction() API
https://github.com/alecthomas/kingpin#additional-api

Using this, you can have auto-completion on the profile names in ~/.aws/config when running:
```
aws-vault exec <tab>
```

You can see what will be fed to bash autocompletion with:
```
aws-vault --completion-bash exec
```

I tried to add a test in exec_test.go, but ran into trouble trying to generate a test config like in config_test.go. Some help here would be appreciated.