### PR TITLE
Move the signal setup closer to cmd.Start()

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -73,7 +73,6 @@ func ConfigureExecCommand(app *kingpin.Application) {
 		input.Keyring = keyringImpl
 		input.MfaPrompt = prompt.Method(GlobalFlags.PromptDriver)
 		input.Signals = make(chan os.Signal)
-		signal.Notify(input.Signals, os.Interrupt, os.Kill)
 		ExecCommand(app, input)
 		return nil
 	})
@@ -149,6 +148,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	signal.Notify(input.Signals, os.Interrupt, os.Kill)
 
 	if err := cmd.Start(); err != nil {
 		app.Fatalf("%v", err)


### PR DESCRIPTION
aws-vault captures SIGINT in order to forward it to the spawned process.

Since the signal capturing is set up way before the child process is
spawned, in particular before getting the credentials, the signals are
captured at the mfa device prompt making it impossible to exit the CLI
using Ctrl-C at that point.

This moves the signal set up closer to when the child process is spawned,
making it possible to exit using Ctrl-C at the mfa prompt.

Tested on linux/KDE/kdewallet backend