### PR TITLE
Increase MaxAssumeRoleDuration to 12 hours

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -20,7 +20,7 @@ const (
 	MaxSessionDuration    = time.Hour * 36
 	MinSessionDuration    = time.Minute * 15
 	MinAssumeRoleDuration = time.Minute * 15
-	MaxAssumeRoleDuration = time.Hour
+	MaxAssumeRoleDuration = time.Hour * 12
 
 	DefaultSessionDuration    = time.Hour * 4
 	DefaultAssumeRoleDuration = time.Minute * 15


### PR DESCRIPTION
Now allowed

https://aws.amazon.com/blogs/security/enable-federated-api-access-to-your-aws-resources-for-up-to-12-hours-using-iam-roles/