### PR TITLE
Allow exposing master credentials if asked

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -27,7 +27,14 @@ $ aws-vault exec work -- aws s3 ls
 another_bucket
 ```
 
+## Using master credentials
+In case you have a long living application and the server solution could
+not work for you, you can use master credentials. 
 
+It reduces security level as it exposes permanent credentials so we recommend using it only if needed and rotating the keys on a regular basis. 
+```bash
+$ aws-vault exec work --use-master-keys -- <long living application, ie: rails s >
+```
 ## Overriding the aws CLI to use aws-vault
 
 You can create an overriding script (make it higher precedence in your PATH) that looks like the below:

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -385,6 +385,18 @@ type VaultCredentials struct {
 	provider *VaultProvider
 }
 
+
+func MasterCreds(k keyring.Keyring, profile string, opts VaultOptions) (*credentials.Value, error) {
+	provider, err := NewVaultProvider(k, profile, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	master_creds, _ := provider.getMasterCreds()
+
+	return &master_creds, nil
+}
+
 func NewVaultCredentials(k keyring.Keyring, profile string, opts VaultOptions) (*VaultCredentials, error) {
 	provider, err := NewVaultProvider(k, profile, opts)
 	if err != nil {


### PR DESCRIPTION
### Description
Add the option `--use-master-keys` to use master keys.

### Why ?
I know that this is not a good security practice. 

But we are going to use `aws-vault` withing server for long living application. 
For long living application we need to provide ec2 metadata so the aws sdk can refresh itself the credentials.
The way to provide these ec2 metadata is to use the option --server. To correctly integrates everything in our infrastructure, we need to be able to run this server within a container but this does not work today.

As it will takes times to fix all these issues, I add this workaround so we could even use `aws-vault` right now and have a smoothly migration in the future. 

I will open an issue about the several current issues using `aws-vault exec --server` inside docker