### PR TITLE
include endpoints in other AWS partitions

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -122,16 +122,16 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 
 	loginUrlPrefix := "https://signin.aws.amazon.com/federation"
 	destination := "https://console.aws.amazon.com/"
+
 	if profile, _ := awsConfig.Profile(input.Profile); profile.Region != "" {
+		destinationDomain := "console.aws.amazon.com"
 		switch {
 		case strings.HasPrefix(profile.Region, "cn-"):
 			loginUrlPrefix = "https://signin.amazonaws.cn/federation"
-			destinationDomain := "console.amazonaws.cn"
+			destinationDomain = "console.amazonaws.cn"
 		case strings.HasPrefix(profile.Region, "us-gov-"):
 			loginUrlPrefix = "https://signin.amazonaws-us-gov.com/federation"
-			destinationDomain := "console.amazonaws.cn"
-		default:
-			destinationDomain := "console.amazonaws.com"
+			destinationDomain = "console.amazonaws.cn"
 		}
 		destination = fmt.Sprintf(
 			"https://%s.%s/console/home?region=%s",

--- a/cli/login.go
+++ b/cli/login.go
@@ -131,7 +131,7 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 			destinationDomain = "console.amazonaws.cn"
 		case strings.HasPrefix(profile.Region, "us-gov-"):
 			loginUrlPrefix = "https://signin.amazonaws-us-gov.com/federation"
-			destinationDomain = "console.amazonaws.cn"
+			destinationDomain = "console.amazonaws-us-gov.com"
 		}
 		destination = fmt.Sprintf(
 			"https://%s.%s/console/home?region=%s",


### PR DESCRIPTION
If profile's region is in China or GovCloud, change the federation and destionation URLs appropriately. Fixes https://github.com/99designs/aws-vault/issues/258.