### PR TITLE
Always use a session to rotate AWS keys

### DIFF
--- a/vault/rotator.go
+++ b/vault/rotator.go
@@ -61,7 +61,7 @@ func (r *Rotator) Rotate(profile string) error {
 		MfaToken:    r.MfaToken,
 		MfaPrompt:   r.MfaPrompt,
 		Config:      r.Config,
-		NoSession:   true,
+		NoSession:   false,
 		MasterCreds: &oldMasterCreds,
 	})
 	if err != nil {
@@ -117,7 +117,7 @@ func (r *Rotator) Rotate(profile string) error {
 		MfaToken:    r.MfaToken,
 		MfaPrompt:   r.MfaPrompt,
 		Config:      r.Config,
-		NoSession:   true,
+		NoSession:   false,
 		MasterCreds: &newMasterCreds,
 	})
 	if err != nil {


### PR DESCRIPTION
This addresses: https://github.com/99designs/aws-vault/issues/182

```
✔ ~/work/go/src/github.com/99designs/aws-vault [bugfix/rotate-with-mfa|✔]
14:34 $ aws-vault rotate -t $(mfa otp devtestnate)  devtestnate
Rotating credentials for profile "devtestnate" (takes 10-20 seconds)
aws-vault: error: Failed to get credentials for devtestnate: AccessDenied: User: arn:aws:iam::1234567890:user/devtestnate is not authorized to perform: iam:CreateAccessKey on resource: user devtestnate
        status code: 403, request id: a74b63f9-6f51-11e8-945c-5308d718cb58
```

I spend some time trying to figure out why `NoSession` was hardcoded to `true` but couldn't figure it out.  As far as I can tell, I need to use a session in order to use MFA.  It's more secure to restrict CreateAccessKey to those with MFA present.

Is there something I'm missing?

I can't use an assume-role, as suggested by @lox, to create access keys because I can't restrict the role to only create for my users.  Maybe I'm doing it wrong?

```
aws-vault: error: Failed to get credentials for devtestnate (source profile for devtestnate-rotate): AccessDenied: User: arn:aws:sts::1234567890:assumed-role/rotate-access-key/1528921743113268348 is not authorized to perform: iam:CreateAccessKey on resource: user devtestnate
```

With this change, I can rotate devtestnate.

```
✔ ~/work/go/src/github.com/99designs/aws-vault [master|✚ 1]
14:19 $ ./aws-vault rotate -t $(mfa otp devtestnate)  devtestnate
Rotating credentials for profile "devtestnate" (takes 10-20 seconds)
Done!
```

With this profile:

```
[profile devtestnate]
region=us-west-2
mfa_serial=arn:aws:iam::1234567890:mfa/devtestnate
```

I'm a big fan of aws-vault and am working to roll it out to entire org.  This issue would have caused lots of headaches the first time I requested folks to rotate.