### PR TITLE
Update go-keychain to resolve Go 1.11 compilation issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: go
+go_import_path: github.com/99designs/aws-vault
 
 install:
   - go get -u github.com/kardianos/govendor
   - govendor status
 
 go:
-  - "1.8"
-  - "1.9"
-  - "1.10"
+  - "1.8.x"
+  - "1.9.x"
+  - "1.10.x"
+  - "master"
 
 os:
   - linux
   - osx
-  
+
 osx_image: xcode7.3

--- a/vendor/github.com/keybase/go-keychain/corefoundation_1.10.go
+++ b/vendor/github.com/keybase/go-keychain/corefoundation_1.10.go
@@ -52,7 +52,7 @@ func BytesToCFData(b []byte) (C.CFDataRef, error) {
 	if len(b) > 0 {
 		p = (*C.UInt8)(&b[0])
 	}
-	cfData := C.CFDataCreate(nil, p, C.CFIndex(len(b)))
+	cfData := C.CFDataCreate(C.kCFAllocatorDefault, p, C.CFIndex(len(b)))
 	if cfData == 0 {
 		return 0, fmt.Errorf("CFDataCreate failed")
 	}
@@ -78,7 +78,7 @@ func MapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) (C.CFDictionaryRef, error)
 		keysPointer = &keys[0]
 		valuesPointer = &values[0]
 	}
-	cfDict := C.CFDictionaryCreateSafe2(nil, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
+	cfDict := C.CFDictionaryCreateSafe2(C.kCFAllocatorDefault, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
 	if cfDict == 0 {
 		return 0, fmt.Errorf("CFDictionaryCreate failed")
 	}
@@ -115,7 +115,7 @@ func StringToCFString(s string) (C.CFStringRef, error) {
 	if len(bytes) > 0 {
 		p = (*C.UInt8)(&bytes[0])
 	}
-	return C.CFStringCreateWithBytes(nil, p, C.CFIndex(len(s)), C.kCFStringEncodingUTF8, C.false), nil
+	return C.CFStringCreateWithBytes(C.kCFAllocatorDefault, p, C.CFIndex(len(s)), C.kCFStringEncodingUTF8, C.false), nil
 }
 
 // CFStringToString converts a CFStringRef to a string.
@@ -150,7 +150,7 @@ func ArrayToCFArray(a []C.CFTypeRef) C.CFArrayRef {
 	if numValues > 0 {
 		valuesPointer = &values[0]
 	}
-	return C.CFArrayCreateSafe2(nil, valuesPointer, C.CFIndex(numValues), &C.kCFTypeArrayCallBacks)
+	return C.CFArrayCreateSafe2(C.kCFAllocatorDefault, valuesPointer, C.CFIndex(numValues), &C.kCFTypeArrayCallBacks)
 }
 
 // CFArrayToArray converts a CFArrayRef to an array of CFTypes.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -252,9 +252,9 @@
 			"revisionTime": "2016-09-29T23:03:56Z"
 		},
 		{
-			"checksumSHA1": "9KGH+mjtBmc7T089X/OwDjtypao=",
+			"checksumSHA1": "SDnp6hhfnz8PkCZh1emnNz0ZVWA=",
 			"path": "github.com/keybase/go-keychain",
-			"revision": "70b98e9c8d754db775c5bd3b2de3670cc76f1825",
+			"revision": "15d3657f24fc7e290714ab795239c5bb33b091ea",
 			"revisionTime": "2018-03-06T22:15:04Z"
 		},
 		{


### PR DESCRIPTION
Previously compiling aws-vault on Go 1.11 beta 2 would fail with a
compilation error. For more information see:

https://github.com/golang/go/commit/94076feef
https://github.com/golang/go/issues/26721
https://github.com/keybase/go-keychain/pull/30

Also, add tip to the Travis CI build matrix. And run tests on the latest point
release for Go 1.8, 1.9, and 1.10, so 1.10.3 instead of 1.10 for example.