### PR TITLE
log when login command ignores MFA

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -196,6 +196,16 @@ func (p *VaultProvider) RetrieveWithoutSessionToken() (credentials.Value, error)
 	return creds, nil
 }
 
+func (p *VaultProvider) HasRole() bool {
+	profile, exists := p.config.Profile(p.profile)
+	return exists && profile.RoleARN != ""
+}
+
+func (p *VaultProvider) HasMfa() bool {
+	profile, exists := p.Config.Profile(p.profile)
+	return exists && profile.MFASerial != ""
+}
+
 func (p VaultProvider) awsConfig() *aws.Config {
 	if region := os.Getenv("AWS_REGION"); region != "" {
 		log.Printf("Using region %q from AWS_REGION", region)


### PR DESCRIPTION
Hi!

First, this might just be me being completely dense. If so I will not be at all offended if this is simply closed. I am putting this out for your thoughts because it took me more time than I would like to admit to figure out why the login command cannot support MFA without assuming a role. Something closer to a warning actually feels more appropriate to me, since I assumed profiles configured for MFA would use it unless `--no-session` is specified, but I can also understand if that would be useless noise for others.

Thanks for looking.