### PR TITLE
Travis CI on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,14 @@ os:
   - windows
 
 before_install:
+  # install gcc to work around https://github.com/golang/go/issues/28065
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install mingw && which gcc ; fi
   - go get -u github.com/kardianos/govendor
 
 script:
-  - govendor status
-  - diff -u <(echo -n) <(gofmt -d $(git ls-files '*.go' | grep -v ^vendor/))
+  # govendor linting: skip on windows to work around https://github.com/kardianos/govendor/issues/233
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then govendor status ; fi
+  # gofmt linting: skip on windows to work around line ending differences
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then diff -u <(echo -n) <(gofmt -d $(git ls-files '*.go' | grep -v ^vendor/)) ; fi
   - go vet ./...
   - go test -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
 os:
   - linux
   - osx
+  - windows
 
 before_install:
   - go get -u github.com/kardianos/govendor

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -211,9 +211,14 @@ func TestAddProfileToExistingNestedConfig(t *testing.T) {
 	)...)
 
 	b, _ := ioutil.ReadFile(f)
+	actual := normaliseLineEndings(b)
 
-	if !bytes.Equal(expected, b) {
-		t.Fatalf("Expected:\n%q\nGot:\n%q", expected, b)
+	if !bytes.Equal(expected, actual) {
+		t.Fatalf("Expected:\n%q\nGot:\n%q", expected, actual)
 	}
 
+}
+
+func normaliseLineEndings(b []byte) []byte {
+	return bytes.Replace(b, []byte("\r\n"), []byte("\n"), -1)
 }


### PR DESCRIPTION
Travis CI [announced](https://blog.travis-ci.com/2018-10-11-windows-early-release) support for Windows today.

Tried to get this working, but looks like we're getting stung by https://github.com/golang/go/issues/28065