### PR TITLE
Add debug statement if using AWS_CONFIG_FILE

### DIFF
--- a/vault/config.go
+++ b/vault/config.go
@@ -34,6 +34,8 @@ func ConfigPath() (string, error) {
 			return "", err
 		}
 		file = filepath.Join(home, "/.aws/config")
+	} else {
+		log.Printf("Using AWS_CONFIG_FILE value: %s", file)
 	}
 	return file, nil
 }


### PR DESCRIPTION
I had a stray `$AWS_CONFIG_FILE` variable in my environment and didn't understand why `aws-vault` refused to work well. This just adds a log line to highlight what is going on