### PR TITLE
 Default to trusting sessions, but not root credentials to address #219

### DIFF
--- a/cli/global.go
+++ b/cli/global.go
@@ -80,17 +80,18 @@ func ConfigureGlobals(app *kingpin.Application) {
 				allowedBackends = append(allowedBackends, keyring.BackendType(GlobalFlags.Backend))
 			}
 			keyringImpl, err = keyring.Open(keyring.Config{
-				ServiceName:             "aws-vault",
-				AllowedBackends:         allowedBackends,
-				KeychainName:            GlobalFlags.KeychainName,
-				FileDir:                 "~/.awsvault/keys/",
-				FilePasswordFunc:        fileKeyringPassphrasePrompt,
-				PassDir:                 GlobalFlags.PassDir,
-				PassCmd:                 GlobalFlags.PassCmd,
-				PassPrefix:              GlobalFlags.PassPrefix,
-				LibSecretCollectionName: "awsvault",
-				KWalletAppID:            "aws-vault",
-				KWalletFolder:           "aws-vault",
+				ServiceName:              "aws-vault",
+				AllowedBackends:          allowedBackends,
+				KeychainName:             GlobalFlags.KeychainName,
+				FileDir:                  "~/.awsvault/keys/",
+				FilePasswordFunc:         fileKeyringPassphrasePrompt,
+				PassDir:                  GlobalFlags.PassDir,
+				PassCmd:                  GlobalFlags.PassCmd,
+				PassPrefix:               GlobalFlags.PassPrefix,
+				LibSecretCollectionName:  "awsvault",
+				KWalletAppID:             "aws-vault",
+				KWalletFolder:            "aws-vault",
+				KeychainTrustApplication: true,
 			})
 			if err != nil {
 				return err

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -384,6 +384,9 @@ func (p *KeyringProvider) Store(val credentials.Value) error {
 		Key:   p.Profile,
 		Label: fmt.Sprintf("aws-vault (%s)", p.Profile),
 		Data:  bytes,
+
+		// specific Keychain settings
+		KeychainNotTrustApplication: true,
 	})
 }
 

--- a/vault/sessions.go
+++ b/vault/sessions.go
@@ -139,7 +139,7 @@ func (s *KeyringSessions) Store(profile string, session sts.Credentials, expires
 		Data:        bytes,
 
 		// specific Keychain settings
-		KeychainNotTrustApplication: true,
+		KeychainNotTrustApplication: false,
 	})
 }
 


### PR DESCRIPTION
Address #219 as follow up to 99designs/keyring#16

 Default to trusting sessions, but not root credentials. This reduces the need to re-enter password and click "Allow" (or "Always Allow").

Users would not be prompted for passwords for session access/modification, but they would still need to be prompted when the root credentials were accessed. This change in behavior is likely welcome by all, but might warrant a release note in the next release.