### PR TITLE
Add keyring pass backend options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Securely store and access credentials for AWS. AWS Vault stores IAM credentials 
 
 Currently the supported backends are:
 
+* Pass - the standard unix password manager
 * macOS Keychain
 * KWallet
 * freedesktop.org Secret Service
@@ -27,6 +28,7 @@ The macOS release is code-signed, and you can verify this with `codesign`:
     Authority=Developer ID Certification Authority
     Authority=Apple Root CA
 
+On Archlinux, `aws-vault` is available in the AUR.
 
 ## Usage
 

--- a/cli/global.go
+++ b/cli/global.go
@@ -28,6 +28,9 @@ var GlobalFlags struct {
 	Backend      string
 	PromptDriver string
 	KeychainName string
+	PassDir      string
+	PassCmd      string
+	PassPrefix   string
 }
 
 func ConfigureGlobals(app *kingpin.Application) {
@@ -53,6 +56,18 @@ func ConfigureGlobals(app *kingpin.Application) {
 		OverrideDefaultFromEnvar("AWS_VAULT_KEYCHAIN_NAME").
 		StringVar(&GlobalFlags.KeychainName)
 
+	app.Flag("pass-dir", "Pass password store directory").
+		OverrideDefaultFromEnvar("AWS_VAULT_PASS_PASSWORD_STORE_DIR").
+		StringVar(&GlobalFlags.PassDir)
+
+	app.Flag("pass-cmd", "Name of the pass executable").
+		OverrideDefaultFromEnvar("AWS_VAULT_PASS_CMD").
+		StringVar(&GlobalFlags.PassCmd)
+
+	app.Flag("pass-prefix", "Prefix to prepend to the item path stored in pass").
+		OverrideDefaultFromEnvar("AWS_VAULT_PASS_PREFIX").
+		StringVar(&GlobalFlags.PassPrefix)
+
 	app.PreAction(func(c *kingpin.ParseContext) (err error) {
 		if !GlobalFlags.Debug {
 			log.SetOutput(ioutil.Discard)
@@ -70,6 +85,9 @@ func ConfigureGlobals(app *kingpin.Application) {
 				KeychainName:            GlobalFlags.KeychainName,
 				FileDir:                 "~/.awsvault/keys/",
 				FilePasswordFunc:        fileKeyringPassphrasePrompt,
+				PassDir:                 GlobalFlags.PassDir,
+				PassCmd:                 GlobalFlags.PassCmd,
+				PassPrefix:              GlobalFlags.PassPrefix,
 				LibSecretCollectionName: "awsvault",
 				KWalletAppID:            "aws-vault",
 				KWalletFolder:           "aws-vault",

--- a/vendor/github.com/99designs/keyring/README.md
+++ b/vendor/github.com/99designs/keyring/README.md
@@ -1,10 +1,14 @@
-Keyring [![Build Status](https://travis-ci.org/99designs/keyring.svg?branch=master)](https://travis-ci.org/99designs/keyring)
+Keyring
 =======
+[![Build Status](https://travis-ci.org/99designs/keyring.svg?branch=master)](https://travis-ci.org/99designs/keyring)
+[![Documentation](https://godoc.org/github.com/99designs/keyring?status.svg)](https://godoc.org/github.com/99designs/keyring)
 
 Keyring provides utility functions for and a common interface to a range of secure credential storage services. Originally developed as part of [AWS Vault](https://github.com/99designs/aws-vault), a command line tool for securely managing AWS access from developer workstations.
 
 Currently Keyring supports the following backends
   * macOS/OSX Keychain
+  * Windows credential store
+  * [Pass](https://www.passwordstore.org/)
   * [Secret Service](https://github.com/99designs/aws-vault/pull/98)
   * [KDE Wallet](https://github.com/99designs/aws-vault/pull/27)
   * [Encrypted File](https://github.com/99designs/aws-vault/pull/63)
@@ -38,7 +42,7 @@ For more detail on the API please check [the keyring godocs](https://godoc.org/g
 
 Contributions to the keyring package are most welcome from engineers of all backgrounds and skill levels. In particular the addition of extra backends across popular operating systems would be appreciated.
 
-This project will adhere to the [Go Community Code of Conduct](https://golang.org/conduct) in the github provided discussion spaces, with the moderators being the 99designs engineering leadership team, currently lead by [John Barton](mailto:john.barton@99designs.com).
+This project will adhere to the [Go Community Code of Conduct](https://golang.org/conduct) in the github provided discussion spaces, with the moderators being the 99designs engineering team.
 
 To make a contribution:
 

--- a/vendor/github.com/99designs/keyring/config.go
+++ b/vendor/github.com/99designs/keyring/config.go
@@ -36,4 +36,13 @@ type Config struct {
 
 	// LibSecretCollectionName is the name collection in secret-service
 	LibSecretCollectionName string
+
+	// PassDir is the pass password-store directory
+	PassDir string
+
+	// PassCmd is the name of the pass executable
+	PassCmd string
+
+	// PassPrefix is a string prefix to prepend to the item path stored in pass
+	PassPrefix string
 }

--- a/vendor/github.com/99designs/keyring/keychain.go
+++ b/vendor/github.com/99designs/keyring/keychain.go
@@ -1,4 +1,4 @@
-// +build darwin
+// +build darwin,cgo
 
 package keyring
 

--- a/vendor/github.com/99designs/keyring/keyring.go
+++ b/vendor/github.com/99designs/keyring/keyring.go
@@ -16,6 +16,7 @@ const (
 	KWalletBackend       BackendType = "kwallet"
 	WinCredBackend       BackendType = "wincred"
 	FileBackend          BackendType = "file"
+	PassBackend          BackendType = "pass"
 )
 
 type BackendType string

--- a/vendor/github.com/99designs/keyring/pass.go
+++ b/vendor/github.com/99designs/keyring/pass.go
@@ -1,0 +1,130 @@
+package keyring
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func init() {
+	supportedBackends[PassBackend] = opener(func(cfg Config) (Keyring, error) {
+		pass := &passKeyring{
+			passcmd: cfg.PassCmd,
+			dir:     cfg.PassDir,
+			prefix:  cfg.PassPrefix,
+		}
+		if cfg.PassCmd == "" {
+			pass.passcmd = "pass"
+		}
+		if cfg.PassDir == "" {
+			pass.dir = filepath.Join(os.Getenv("HOME"), ".password-store")
+		}
+		return pass, nil
+	})
+}
+
+type passKeyring struct {
+	dir     string
+	passcmd string
+	prefix  string
+}
+
+func (k *passKeyring) pass(args ...string) (*exec.Cmd, error) {
+	cmd := exec.Command(k.passcmd, args...)
+	if k.dir != "" {
+		cmd.Env = append(os.Environ(), fmt.Sprintf("PASSWORD_STORE_DIR=%s", k.dir))
+	}
+	cmd.Stderr = os.Stderr
+
+	return cmd, nil
+}
+
+func (k *passKeyring) Get(key string) (Item, error) {
+	name := filepath.Join(k.prefix, key)
+	cmd, err := k.pass("show", name)
+	if err != nil {
+		return Item{}, err
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		return Item{}, err
+	}
+
+	var decoded Item
+	err = json.Unmarshal(output, &decoded)
+
+	return decoded, err
+}
+
+func (k *passKeyring) Set(i Item) error {
+	bytes, err := json.Marshal(i)
+	if err != nil {
+		return err
+	}
+
+	name := filepath.Join(k.prefix, i.Key)
+	cmd, err := k.pass("insert", "-m", "-f", name)
+	if err != nil {
+		return err
+	}
+
+	cmd.Stdin = strings.NewReader(string(bytes))
+
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *passKeyring) Remove(key string) error {
+	name := filepath.Join(k.prefix, key)
+	cmd, err := k.pass("rm", "-f", name)
+	if err != nil {
+		return err
+	}
+
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *passKeyring) Keys() ([]string, error) {
+	var keys = []string{}
+	var path = filepath.Join(k.dir, k.prefix)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return keys, nil
+		}
+		return keys, err
+	}
+	if !info.IsDir() {
+		return keys, fmt.Errorf("%s is not a directory", path)
+	}
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return keys, err
+	}
+
+	for _, f := range files {
+		if filepath.Ext(f.Name()) == ".gpg" {
+			name := filepath.Base(f.Name())
+			keys = append(keys, name[:len(name)-4])
+
+		}
+	}
+
+	return keys, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "9wLOSn9IjNKpyYRYVvR59MHrtBI=",
+			"checksumSHA1": "WhQPUMYs1QpqkiIDgCBGMNCMzWU=",
 			"path": "github.com/99designs/keyring",
-			"revision": "998b86358ae9d7c8bbbb1d57080a8eaca7ffc47b",
-			"revisionTime": "2018-08-02T12:37:33Z"
+			"revision": "370e8873a8dda4cecfe45812156f80c00d3601c2",
+			"revisionTime": "2018-12-21T23:44:55Z"
 		},
 		{
 			"checksumSHA1": "KmjnydoAbofMieIWm+it5OWERaM=",


### PR DESCRIPTION
Given the pass backend for keyring is ready (https://github.com/99designs/keyring/pull/33), this adds command line options and variables for its configuration.

`--pass-dir` and `AWS_VAULT_PASS_DIR`
`--pass-cmd` and `AWS_VAULT_PASS_CMD`
`--pass-prefix` and `AWS_VAULT_PASS_PREFIX`