### PR TITLE
Update govendor - Ensure passcmd is on the callers PATH

### DIFF
--- a/vendor/github.com/99designs/keyring/pass.go
+++ b/vendor/github.com/99designs/keyring/pass.go
@@ -2,6 +2,7 @@ package keyring
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -23,6 +24,13 @@ func init() {
 		if cfg.PassDir == "" {
 			pass.dir = filepath.Join(os.Getenv("HOME"), ".password-store")
 		}
+
+		// fail if the pass program is not available
+		_, err := exec.LookPath(pass.passcmd)
+		if err != nil {
+			return nil, errors.New("The pass program is not available")
+		}
+
 		return pass, nil
 	})
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "WhQPUMYs1QpqkiIDgCBGMNCMzWU=",
+			"checksumSHA1": "oxlVyal6L7ZF/C7oceKlDwCCg4Y=",
 			"path": "github.com/99designs/keyring",
-			"revision": "370e8873a8dda4cecfe45812156f80c00d3601c2",
-			"revisionTime": "2018-12-21T23:44:55Z"
+			"revision": "e5b70c3b37f32c7c22a7941b0f438826dfaabcb0",
+			"revisionTime": "2019-01-10T11:13:04Z"
 		},
 		{
 			"checksumSHA1": "KmjnydoAbofMieIWm+it5OWERaM=",


### PR DESCRIPTION
Update govendor with resolution to issue https://github.com/99designs/aws-vault/issues/321 where the pass backend was being selecting instead of file, and then failing because the pass executable was not available. 

See: https://github.com/99designs/keyring/pull/34.