### PR TITLE
Fix typo in USAGE document

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -91,7 +91,7 @@ By default, Linux uses an encrypted file but you may prefer to use the secret-se
 
 ## Removing stored sessions
 
-If you want to remove sessions managed by `aws-vault` before they expire, you can do this with the `--session-only` flag.
+If you want to remove sessions managed by `aws-vault` before they expire, you can do this with the `--sessions-only` flag.
 
 ```bash
 aws-vault remove <profile> --sessions-only


### PR DESCRIPTION
Tiny tweak:
```diff
-If you want to remove sessions … do this with the `--session-only` flag.
+If you want to remove sessions … do this with the `--sessions-only` flag.
```

From the code, the canonical form of this option is `--sessions-only` (_plural_).

**NB** I can open an issue for this if you like; let me know if I should.