### PR TITLE
Make the MFA prompt configurable and add ykman support

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -61,11 +61,11 @@ func AddCommand(app *kingpin.Application, input AddCommandInput) {
 		}
 	} else {
 		var err error
-		if accessKeyId, err = prompt.TerminalPrompt("Enter Access Key ID: "); err != nil {
+		if accessKeyId, err = prompt.TerminalPrompt("Enter Access Key ID: ", ""); err != nil {
 			app.Fatalf(err.Error())
 			return
 		}
-		if secretKey, err = prompt.TerminalPrompt("Enter Secret Access Key: "); err != nil {
+		if secretKey, err = prompt.TerminalPrompt("Enter Secret Access Key: ", ""); err != nil {
 			app.Fatalf(err.Error())
 			return
 		}

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -39,7 +39,7 @@ func ConfigureRemoveCommand(app *kingpin.Application) {
 func RemoveCommand(app *kingpin.Application, input RemoveCommandInput) {
 	if !input.SessionsOnly {
 		provider := &vault.KeyringProvider{Keyring: input.Keyring, Profile: input.Profile}
-		r, err := prompt.TerminalPrompt(fmt.Sprintf("Delete credentials for profile %q? (Y|n)", input.Profile))
+		r, err := prompt.TerminalPrompt(fmt.Sprintf("Delete credentials for profile %q? (Y|n)", input.Profile), "")
 		if err != nil {
 			app.Fatalf(err.Error())
 			return

--- a/prompt/osascript.go
+++ b/prompt/osascript.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func OSAScriptPrompt(prompt string, _profile string) (string, error) {
+func OSAScriptPrompt(prompt string, _ string) (string, error) {
 	cmd := exec.Command("osascript", "-e", fmt.Sprintf(`
 		display dialog "%s" default answer "" buttons {"OK", "Cancel"} default button 1
         text returned of the result

--- a/prompt/osascript.go
+++ b/prompt/osascript.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func OSAScriptPrompt(prompt string) (string, error) {
+func OSAScriptPrompt(prompt string, _profile string) (string, error) {
 	cmd := exec.Command("osascript", "-e", fmt.Sprintf(`
 		display dialog "%s" default answer "" buttons {"OK", "Cancel"} default button 1
         text returned of the result

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -1,11 +1,14 @@
 package prompt
 
-import "fmt"
+import (
+	"fmt"
+)
 
-type PromptFunc func(string) (string, error)
+type PromptFunc func(string, string) (string, error)
 
 var Methods = map[string]PromptFunc{
 	"terminal": TerminalPrompt,
+	"ykman":    YkmanPrompt,
 }
 
 func Available() []string {

--- a/prompt/terminal.go
+++ b/prompt/terminal.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func TerminalPrompt(prompt string, _profile string) (string, error) {
+func TerminalPrompt(prompt string, _ string) (string, error) {
 	fmt.Fprint(os.Stderr, prompt)
 
 	reader := bufio.NewReader(os.Stdin)

--- a/prompt/terminal.go
+++ b/prompt/terminal.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func TerminalPrompt(prompt string) (string, error) {
+func TerminalPrompt(prompt string, _profile string) (string, error) {
 	fmt.Fprint(os.Stderr, prompt)
 
 	reader := bufio.NewReader(os.Stdin)

--- a/prompt/ykman.go
+++ b/prompt/ykman.go
@@ -2,15 +2,13 @@ package prompt
 
 import (
 	"os/exec"
-	"strings"
 )
 
 func YkmanPrompt(_prompt string, mfa_serial string) (string, error) {
-	cmd := exec.Command("ykman", "oath", "code", mfa_serial)
+	cmd := exec.Command("ykman", "oath", "code", "-s", mfa_serial)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
-	parts := strings.Split(string(out), " ")
-	return parts[len(parts)-1], nil
+	return string(out[:len(out)-1]), nil
 }

--- a/prompt/ykman.go
+++ b/prompt/ykman.go
@@ -1,0 +1,16 @@
+package prompt
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func YkmanPrompt(_prompt string, profile string) (string, error) {
+	cmd := exec.Command("ykman", "oath", "code", profile)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(string(out), " ")
+	return parts[len(parts)-1], nil
+}

--- a/prompt/ykman.go
+++ b/prompt/ykman.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-func YkmanPrompt(_prompt string, profile string) (string, error) {
-	cmd := exec.Command("ykman", "oath", "code", profile)
+func YkmanPrompt(_prompt string, mfa_serial string) (string, error) {
+	cmd := exec.Command("ykman", "oath", "code", mfa_serial)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/prompt/zenity.go
+++ b/prompt/zenity.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func ZenityPrompt(prompt string) (string, error) {
+func ZenityPrompt(prompt string, _profile string) (string, error) {
 	cmd := exec.Command("zenity", "--entry", "--title=aws-vault", fmt.Sprintf(`--text=%s`, prompt))
 
 	out, err := cmd.Output()

--- a/prompt/zenity.go
+++ b/prompt/zenity.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func ZenityPrompt(prompt string, _profile string) (string, error) {
+func ZenityPrompt(prompt string, _ string) (string, error) {
 	cmd := exec.Command("zenity", "--entry", "--title=aws-vault", fmt.Sprintf(`--text=%s`, prompt))
 
 	out, err := cmd.Output()

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -249,7 +249,7 @@ func (p *VaultProvider) getSessionToken(creds *credentials.Value) (sts.Credentia
 	if profile, _ := p.Config.Profile(p.profile); profile.MFASerial != "" {
 		params.SerialNumber = aws.String(profile.MFASerial)
 		if p.MfaToken == "" {
-			token, err := p.MfaPrompt(fmt.Sprintf("Enter token for %s: ", profile.MFASerial), profile.Name)
+			token, err := p.MfaPrompt(fmt.Sprintf("Enter token for %s: ", profile.MFASerial), profile.MFASerial)
 			if err != nil {
 				return sts.Credentials{}, err
 			}
@@ -332,7 +332,7 @@ func (p *VaultProvider) assumeRole(creds credentials.Value, profile Profile) (st
 	if profile.MFASerial != "" {
 		input.SerialNumber = aws.String(profile.MFASerial)
 		if p.MfaToken == "" {
-			token, err := p.MfaPrompt(fmt.Sprintf("Enter token for %s: ", profile.MFASerial), profile.Name)
+			token, err := p.MfaPrompt(fmt.Sprintf("Enter token for %s: ", profile.MFASerial), profile.MFASerial)
 			if err != nil {
 				return sts.Credentials{}, err
 			}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -249,7 +249,7 @@ func (p *VaultProvider) getSessionToken(creds *credentials.Value) (sts.Credentia
 	if profile, _ := p.Config.Profile(p.profile); profile.MFASerial != "" {
 		params.SerialNumber = aws.String(profile.MFASerial)
 		if p.MfaToken == "" {
-			token, err := p.MfaPrompt(fmt.Sprintf("Enter token for %s: ", profile.MFASerial))
+			token, err := p.MfaPrompt(fmt.Sprintf("Enter token for %s: ", profile.MFASerial), profile.Name)
 			if err != nil {
 				return sts.Credentials{}, err
 			}
@@ -332,7 +332,7 @@ func (p *VaultProvider) assumeRole(creds credentials.Value, profile Profile) (st
 	if profile.MFASerial != "" {
 		input.SerialNumber = aws.String(profile.MFASerial)
 		if p.MfaToken == "" {
-			token, err := p.MfaPrompt(fmt.Sprintf("Enter token for %s: ", profile.MFASerial))
+			token, err := p.MfaPrompt(fmt.Sprintf("Enter token for %s: ", profile.MFASerial), profile.Name)
 			if err != nil {
 				return sts.Credentials{}, err
 			}


### PR DESCRIPTION
When using a hardware key capable of totp, it's useful to configure it permanently. It's annoying to specify the command in a parameter and having different parameters for login and exec just adds to that.

This PR adds a configurable MFA prompt and passes the `mfa_serial` to the handler. This allows to use (for example) `ykman` to automatically retrieve the correct code.