### PR TITLE
Fix login flag behavior to match that of identical flags on exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /aws-vault
 /aws-vault-*
+
+# IDE
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 /aws-vault
 /aws-vault-*
-
-# IDE
-.idea

--- a/USAGE.md
+++ b/USAGE.md
@@ -140,6 +140,7 @@ For the `aws-vault exec` subcommand:
 
 For the `aws-vault login` subcommand:
 
+* `AWS_ASSUME_ROLE_TTL`: Expiration time for aws assumed role console session when not using --no-session (see the flag `--assume-role-ttl`)
 * `AWS_FEDERATION_TOKEN_TTL`: Expiration time for aws console session (see the flag `--federation-token-ttl`)
 
 

--- a/cli/login.go
+++ b/cli/login.go
@@ -46,6 +46,7 @@ func ConfigureLoginCommand(app *kingpin.Application) {
 
 	cmd.Arg("profile", "Name of the profile").
 		Required().
+		HintAction(ProfileNames).
 		StringVar(&input.Profile)
 
 	cmd.Flag("mfa-token", "The mfa token to use").
@@ -63,6 +64,7 @@ func ConfigureLoginCommand(app *kingpin.Application) {
 
 	cmd.Flag("assume-role-ttl", "Expiration time for aws assumed role").
 		Default("15m").
+		OverrideDefaultFromEnvar("AWS_ASSUME_ROLE_TTL").
 		DurationVar(&input.AssumeRoleDuration)
 
 	cmd.Flag("stdout", "Print login URL to stdout instead of opening in default browser").


### PR DESCRIPTION
- `--assume-role-ttl` on exec honored the environment variable `AWS_ASSUME_ROLE_TTL`. This has been fixed for login command
- `--profile` on exec has a hint if not passed in, added this to login command