### PR TITLE
Added MFA Override option

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -27,6 +27,7 @@ type ExecCommandInput struct {
 	RoleDuration     time.Duration
 	MfaToken         string
 	MfaPrompt        prompt.PromptFunc
+	MfaSerial        string
 	StartServer      bool
 	CredentialHelper bool
 	Signals          chan os.Signal
@@ -64,6 +65,10 @@ func ConfigureExecCommand(app *kingpin.Application) {
 	cmd.Flag("mfa-token", "The mfa token to use").
 		Short('m').
 		StringVar(&input.MfaToken)
+
+	cmd.Flag("mfa-serial-override", "Override the MFA Serial defined in AWS Profile").
+		OverrideDefaultFromEnvar("AWS_MFA_SERIAL").
+		StringVar(&input.MfaSerial)
 
 	cmd.Flag("json", "AWS credential helper. Ref: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes").
 		Short('j').
@@ -110,6 +115,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 	creds, err := vault.NewVaultCredentials(input.Keyring, input.Profile, vault.VaultOptions{
 		SessionDuration:    input.Duration,
 		AssumeRoleDuration: input.RoleDuration,
+		MfaSerial:          input.MfaSerial,
 		MfaToken:           input.MfaToken,
 		MfaPrompt:          input.MfaPrompt,
 		NoSession:          input.NoSession,


### PR DESCRIPTION
This addition allows you to override MFA from the exec command. This would be useful for times when you want change between MFA serials without modifying your `.aws/config` file. It would also help with being able to set a forced override of MFA serial with an environment variable.

How to test:

1. `AWS_MFA_SERIAL=some:fake:arn aws-vault exec my-profile -- ls`
2. `aws-vault exec --mfa-serial-override=arn:aws:iam::<aws-acct-id>:mfa/fake my-profile`