### PR TITLE
Document that aws-vault is available via Homebrew on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Check out the [announcement blog post](https://99designs.com.au/tech-blog/blog/2
 
 You can install aws-vault:
 - by downloading the [latest release](https://github.com/99designs/aws-vault/releases)
-- on macOS via [homebrew](https://github.com/caskroom/homebrew-cask) with `brew cask install aws-vault`
+- on MacOS via [Homebrew Cask](https://github.com/caskroom/homebrew-cask) with `brew cask install aws-vault`
+- on Linux via [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux) with `brew install linuxbrew/extra/aws-vault`
 - on Windows via [choco](https://chocolatey.org/packages/aws-vault) with `choco install aws-vault`
 - on Archlinux via the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository)
 - by compiling with `go get github.com/99designs/aws-vault`


### PR DESCRIPTION
- There's now a formula for `aws-vault` in Homebrew on Linux
  (https://github.com/Linuxbrew/homebrew-extra/blob/master/Formula/aws-vault.rb),
  because Casks don't work on Linux. This change shows that users can
  `brew tap linuxbrew/extra` and `brew install aws-vault`, or `brew
  install linuxbrew/extra/aws-vault` (the documentation I've gone with).