### PR TITLE
Add ecs-server command

### DIFF
--- a/cli/server_ecs.go
+++ b/cli/server_ecs.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/99designs/aws-vault/prompt"
+	"github.com/99designs/aws-vault/vault"
+	"github.com/99designs/keyring"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+const kEcsCredsPrefix = "/creds/"
+
+type EcsServerCommandInput struct {
+	ServerPort   int
+	AuthToken    string
+	Duration     time.Duration
+	RoleDuration time.Duration
+	Keyring      keyring.Keyring
+	MfaPrompt    prompt.PromptFunc
+}
+
+func ConfigureEcsServerCommand(app *kingpin.Application) {
+	input := EcsServerCommandInput{}
+
+	cmd := app.Command("ecs-server", "Run a local ECS credentials server")
+
+	cmd.Flag("port", "Port to listen on for the credentials server").
+		Default("9999").
+		Short('p').
+		IntVar(&input.ServerPort)
+
+	cmd.Flag("session-ttl", "Expiration time for aws session").
+		Default("4h").
+		Envar("AWS_SESSION_TTL").
+		Short('t').
+		DurationVar(&input.Duration)
+
+	cmd.Flag("assume-role-ttl", "Expiration time for aws assumed role").
+		Default("15m").
+		Envar("AWS_ASSUME_ROLE_TTL").
+		DurationVar(&input.RoleDuration)
+
+	cmd.Flag("auth-token", "Require an Authentication token when requesting credentials").
+		Default("").
+		Envar("AWS_VAULT_AUTH_TOKEN").
+		StringVar(&input.AuthToken)
+
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		input.Keyring = keyringImpl
+		input.MfaPrompt = prompt.Method(GlobalFlags.PromptDriver)
+		EcsServerCommand(app, input)
+		return nil
+	})
+}
+
+func EcsServerCommand(app *kingpin.Application, input EcsServerCommandInput) {
+	sess, err := session.NewSession()
+	app.FatalIfError(err, "Creating AWS session")
+
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", input.ServerPort))
+	app.FatalIfError(err, "Binding port %d", input.ServerPort)
+
+	fmt.Printf("Local ECS credentials server running on %s\n", l.Addr())
+	fmt.Printf("Use AWS_CONTAINER_CREDENTIALS_FULL_URI=http://%s%s{profile_id}[/{role_arn}]\n", l.Addr(), kEcsCredsPrefix)
+
+	if input.AuthToken != "" {
+		fmt.Printf("Authorization token required! Remember to also set AWS_CONTAINER_AUTHORIZATION_TOKEN to its value\n")
+	}
+
+	app.FatalIfError(http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ecsServerError(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		// Must make sure the remote ip is from the loopback, otherwise clients on the same network segment could
+		// potentially route traffic via 169.254.169.254:80
+		// See https://developer.apple.com/library/content/qa/qa1357/_index.html
+		if !net.ParseIP(ip).IsLoopback() {
+			ecsServerError(w, errors.New("Access denied from non-localhost address"), http.StatusUnauthorized)
+			return
+		}
+
+		if r.Header.Get("Authorization") != input.AuthToken {
+			ecsServerError(w, errors.New("Invalid Authorization token"), http.StatusUnauthorized)
+			return
+		}
+
+		if r.Method != http.MethodGet {
+			ecsServerError(w, errors.New("Only GET requests are supported"), http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Simple way to protect the credentials from being queried from a browser
+		if r.Header.Get("Origin") != "" {
+			ecsServerError(w, errors.New("CORS access from a browser is not allowed"), http.StatusUnauthorized)
+			return
+		}
+
+		log.Printf("Received credentials request from RemoteAddr = %v", r.RemoteAddr)
+
+		if !strings.HasPrefix(r.URL.Path, kEcsCredsPrefix) {
+			ecsServerError(w, errors.New("404 page not found"), http.StatusNotFound)
+			return
+		}
+
+		pathSpl := strings.SplitN(strings.TrimPrefix(r.URL.Path, kEcsCredsPrefix), "/", 2)
+		if pathSpl == nil {
+			ecsServerError(w, errors.New("404 page not found"), http.StatusNotFound)
+			return
+		}
+
+		vaultProvider, err := vault.NewVaultProvider(input.Keyring, pathSpl[0], vault.VaultOptions{
+			SessionDuration:    input.Duration,
+			AssumeRoleDuration: input.RoleDuration,
+			MfaPrompt:          input.MfaPrompt,
+			Config:             awsConfig,
+		})
+		if err != nil {
+			ecsServerError(w, err, http.StatusUnauthorized)
+			return
+		}
+
+		assumedCreds := credentials.NewCredentials(vaultProvider)
+
+		if len(pathSpl) == 2 {
+			// We've got another role to chain with
+			roleArn, err := arn.Parse(pathSpl[1])
+			if err != nil {
+				ecsServerError(w, err, http.StatusBadRequest)
+				return
+			}
+
+			log.Printf("Assuming role %s using '%s' profile credentials", roleArn, pathSpl[0])
+			assumedCreds = stscreds.NewCredentials(sess.Copy(&aws.Config{Credentials: assumedCreds}), roleArn.String())
+		}
+
+		creds, err := assumedCreds.Get()
+		if err != nil {
+			ecsServerError(w, err, http.StatusUnauthorized)
+			return
+		}
+
+		expiration, err := assumedCreds.ExpiresAt()
+		if err != nil {
+			ecsServerError(w, err, http.StatusUnauthorized)
+			return
+		}
+
+		log.Printf("Serving credentials via http ****************%s, expiration of %s (%s)",
+			creds.AccessKeyID[len(creds.AccessKeyID)-4:],
+			expiration.Format("2006-01-02T15:04:05Z"),
+			expiration.Sub(time.Now()))
+
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(map[string]interface{}{
+			"AccessKeyId":     creds.AccessKeyID,
+			"SecretAccessKey": creds.SecretAccessKey,
+			"Token":           creds.SessionToken,
+			"Expiration":      expiration.Format("2006-01-02T15:04:05Z"),
+		})
+		if err != nil {
+			ecsServerError(w, err, http.StatusInternalServerError)
+			return
+		}
+	})), "Error starting credential server")
+}
+
+func ecsServerError(w http.ResponseWriter, err error, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	response := map[string]string{}
+	if awsErr, ok := err.(awserr.Error); ok {
+		response["code"] = awsErr.Code()
+		response["message"] = awsErr.Message()
+		if origErr := awsErr.OrigErr(); origErr != nil {
+			response["cause"] = origErr.Error()
+		}
+	} else {
+		response["code"] = strings.ReplaceAll(http.StatusText(status), " ", "")
+		response["message"] = err.Error()
+	}
+
+	log.Printf("Error: %s", err.Error())
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("Error writing HTTP error response: %s", err.Error())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func run(args []string, exit func(int)) {
 	cli.ConfigureRemoveCommand(app)
 	cli.ConfigureLoginCommand(app)
 	cli.ConfigureServerCommand(app)
+	cli.ConfigureEcsServerCommand(app)
 
 	kingpin.MustParse(app.Parse(args))
 }

--- a/server/alias_bsd.go
+++ b/server/alias_bsd.go
@@ -4,6 +4,6 @@ package server
 
 import "os/exec"
 
-func installNetworkAlias() ([]byte, error) {
-	return exec.Command("ifconfig", "lo0", "alias", "169.254.169.254").CombinedOutput()
+func InstallNetworkAlias(ip string) ([]byte, error) {
+	return exec.Command("ifconfig", "lo0", "alias", ip).CombinedOutput()
 }

--- a/server/alias_linux.go
+++ b/server/alias_linux.go
@@ -2,8 +2,11 @@
 
 package server
 
-import "os/exec"
+import (
+	"fmt"
+	"os/exec"
+)
 
-func installNetworkAlias() ([]byte, error) {
-	return exec.Command("ip", "addr", "add", "169.254.169.254/24", "dev", "lo", "label", "lo:0").CombinedOutput()
+func InstallNetworkAlias(ip string) ([]byte, error) {
+	return exec.Command("ip", "addr", "add", fmt.Sprintf("%s/24", ip), "dev", "lo", "label", "lo:0").CombinedOutput()
 }

--- a/server/alias_windows.go
+++ b/server/alias_windows.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 )
 
-func installNetworkAlias() ([]byte, error) {
-	out, err := exec.Command("netsh", "interface", "ipv4", "add", "address", "Loopback Pseudo-Interface 1", "169.254.169.254", "255.255.0.0").CombinedOutput()
+func InstallNetworkAlias(ip string) ([]byte, error) {
+	out, err := exec.Command("netsh", "interface", "ipv4", "add", "address", "Loopback Pseudo-Interface 1", ip, "255.255.0.0").CombinedOutput()
 
 	if err == nil || strings.Contains(string(out), "The object already exists") {
 		return []byte{}, nil

--- a/server/server.go
+++ b/server/server.go
@@ -24,7 +24,7 @@ const (
 )
 
 func StartMetadataServer() error {
-	if _, err := installNetworkAlias(); err != nil {
+	if _, err := InstallNetworkAlias("169.254.169.254"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds a new command to aws-vault: `ecs-server`

The purpose of this command is to start a local credential server daemon that follows the ECS task metadata service format, so other applications can request STS credentials by setting the proper environment variables. Unlike the `--server` option of the `exec` command, this is not meant to start another program with given AWS credentials but to run as a daemon in the background.

The goal is to allow developers to easily assume multiple roles at the same time, by simply adding a new environment variable to their program runs. This is especially useful for micro-service development, as there is a need to assume multiple roles for different services at the same time, while the EC2 metadata service can only provide one role at a time.


## Features:

The command starts an HTTP server on port 9999 (this default can be changed with the `--port` argument). This server provides an endpoint that assumes the requested role(s) and returns the credentials using the ECS task metadata format.

The enpoint is `/creds/{aws-vault profile}[/{optional role ARN}]`

The `{aws-vault profile}` is one of the user's configured profiles in `.aws/config`. It can be a profile with stored credentials or an IAM Role to assume with a source profile, and can optionally have MFA configured. The `{optional role ARN}` is a second role to assume by chaining on the profile's credentials.

### Examples:

`/creds/sandbox`
Gets credentials for the "sandbox" profile. This is equivalent to running "aws-vault exec sandbox"

`/creds/sandbox/arn:aws:iam::1234567890:role/myrole`
Gets credentials for the "sandbox" profile, and then chains to the given role "myrole". This is equivalent to running "aws-vault exec sandbox -- aws sts assume-role --role-arn arn:aws:iam::1234567890:role/myrole"


## User experience:

The following is an example of how this works from the perspective of a user. Let's assume the user has already configured their static IAM user credentials, as well as a "staging" and "sandbox" profiles with MFA that assume a role in two different accounts. The Role in Staging is also allowed to assume roles "ServiceA" for a service written in Java and "ServiceB" for another service written in Python.

1. User runs `aws-vault ecs-server` on a Terminal (or configures it to run as a daemon)
2. User opens his favourite Java and Python IDEs and loads both ServiceA and ServiceB to start working on.
3. User adds the following environment variables to the project settings of both services:
- For ServiceA: `AWS_CONTAINER_CREDENTIALS_FULL_URI=http://localhost:9999/creds/staging/arn:aws:iam::1234567890:role/ServiceA`
- For ServiceB: `AWS_CONTAINER_CREDENTIALS_FULL_URI=http://localhost:9999/creds/staging/arn:aws:iam::1234567890:role/ServiceB`
4. User starts ServiceA for debugging. A prompt comes up asking for his AWS MFA code, that he types. ServiceA is now running with its intended IAM Role permissions.
5. User starts ServiceB for debugging. No MFA prompt because the session has not expired. ServiceB is now running with its intended IAM Role permissions.
6. When the credentials expire after 15 minutes, both services will automatically request new ones and both services will receive their own set of credentials from their Roles.
7. User wants to run some scripts on the Sandbox account. He types `export AWS_CONTAINER_CREDENTIALS_FULL_URI=http://localhost:9999/creds/sandbox` (this can be easily turned into an alias) in the Terminal and can now run any script or aws-cli command directly with his Sandbox account permissions.


## Benefits:

- No root required. It listens on a non-privileged port of localhost, so there is no need to use sudo or change network route settings.
- Runs as a daemon. It can be set up to start on the background during login and will always be available. MFAs are requested as needed, not on startup.
- Assume multiple profiles/roles at the same time. No need to switch profiles or use complicated commands.
- Simple workflow. Just set an environment variable on your project and you're ready to go.
- Least privilege permissions. Allow developers to assume the exact roles their services will be running, and nothing more.
- Role chaining. No need to configure a large amount of profiles for every role to be assumed.


## Security:

- The service will always bind to localhost so it has no access over the network. This is also a limitation enforced by the AWS SDK: this credentials method only works on localhost!
- Any requests from non-loopback addresses will be rejected. Any CORS requests from browsers will be rejected as well.
- There is an optional setting to configure an authentication token. When this option is enabled, the configured token must be sent on every request to the credentials service. The AWS SDKs will send this token when setting the `AWS_CONTAINER_AUTHORIZATION_TOKEN` environment variable.


## Limitations:

When using the option to chain multiple roles there are two limitations to take into account:

- The chained role can have a maximum duration of 1 hour. The `--assume-role-ttl` argument is only used for the first profile, the chained role is always assumed with the default of 15 minutes.
- The chained role must have a Trust Policy that allows access from the source role (or account), even if both roles are already on the same account.


## Usage tips:

- Configure a graphical input method for the MFA token (like `osascript` on the Mac) so you get a popup instead of a prompt on a Terminal you might have lost track of.
- Configure a long session TTL, to avoid continuous MFA prompts.

Here is an example macOS LaunchAgent configuration to run this command as a daemon: https://gist.github.com/xose/03375fd98732259f5992657b297a07b7