### PR TITLE
no-role and no-session flags for rotate

### DIFF
--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -14,6 +14,7 @@ type RotateCommandInput struct {
 	Keyring   keyring.Keyring
 	MfaToken  string
 	MfaPrompt prompt.PromptFunc
+	NoRole    bool
 	NoSession bool
 }
 
@@ -25,6 +26,9 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 	cmd.Arg("profile", "Name of the profile").
 		Required().
 		StringVar(&input.Profile)
+
+	cmd.Flag("no-role", "No role assumed").
+		BoolVar(&input.NoRole)
 
 	cmd.Flag("no-session", "No session created (overrides heuristic)").
 		Short('n').
@@ -48,6 +52,7 @@ func RotateCommand(app *kingpin.Application, input RotateCommandInput) {
 		Keyring:   input.Keyring,
 		MfaToken:  input.MfaToken,
 		MfaPrompt: input.MfaPrompt,
+		NoRole:    input.NoRole,
 		NoSession: input.NoSession,
 		Config:    awsConfig,
 	}

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -14,15 +14,21 @@ type RotateCommandInput struct {
 	Keyring   keyring.Keyring
 	MfaToken  string
 	MfaPrompt prompt.PromptFunc
+	NoSession bool
 }
 
 func ConfigureRotateCommand(app *kingpin.Application) {
 	input := RotateCommandInput{}
 
 	cmd := app.Command("rotate", "Rotates credentials")
+
 	cmd.Arg("profile", "Name of the profile").
 		Required().
 		StringVar(&input.Profile)
+
+	cmd.Flag("no-session", "No session created (overrides heuristic)").
+		Short('n').
+		BoolVar(&input.NoSession)
 
 	cmd.Flag("mfa-token", "The mfa token to use").
 		Short('t').
@@ -37,10 +43,12 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 }
 
 func RotateCommand(app *kingpin.Application, input RotateCommandInput) {
+
 	rotator := vault.Rotator{
 		Keyring:   input.Keyring,
 		MfaToken:  input.MfaToken,
 		MfaPrompt: input.MfaPrompt,
+		NoSession: input.NoSession,
 		Config:    awsConfig,
 	}
 

--- a/vault/rotator.go
+++ b/vault/rotator.go
@@ -19,6 +19,7 @@ type Rotator struct {
 	Keyring   keyring.Keyring
 	MfaToken  string
 	MfaPrompt prompt.PromptFunc
+	NoRole    bool
 	NoSession bool
 	Config    *Config
 }
@@ -60,6 +61,7 @@ func (r *Rotator) Rotate(profile string) error {
 		MfaToken:    r.MfaToken,
 		MfaPrompt:   r.MfaPrompt,
 		Config:      r.Config,
+		NoRole:      r.NoRole,
 		NoSession:   r.NoSession || !r.needsSessionToRotate(profile),
 		MasterCreds: &oldMasterCreds,
 	})
@@ -116,6 +118,7 @@ func (r *Rotator) Rotate(profile string) error {
 		MfaToken:    r.MfaToken,
 		MfaPrompt:   r.MfaPrompt,
 		Config:      r.Config,
+		NoRole:      r.NoRole,
 		NoSession:   r.NoSession || !r.needsSessionToRotate(profile),
 		MasterCreds: &newMasterCreds,
 	})

--- a/vault/rotator.go
+++ b/vault/rotator.go
@@ -19,6 +19,7 @@ type Rotator struct {
 	Keyring   keyring.Keyring
 	MfaToken  string
 	MfaPrompt prompt.PromptFunc
+	NoSession bool
 	Config    *Config
 }
 
@@ -59,7 +60,7 @@ func (r *Rotator) Rotate(profile string) error {
 		MfaToken:    r.MfaToken,
 		MfaPrompt:   r.MfaPrompt,
 		Config:      r.Config,
-		NoSession:   !r.needsSessionToRotate(profile),
+		NoSession:   r.NoSession || !r.needsSessionToRotate(profile),
 		MasterCreds: &oldMasterCreds,
 	})
 	if err != nil {
@@ -115,7 +116,7 @@ func (r *Rotator) Rotate(profile string) error {
 		MfaToken:    r.MfaToken,
 		MfaPrompt:   r.MfaPrompt,
 		Config:      r.Config,
-		NoSession:   !r.needsSessionToRotate(profile),
+		NoSession:   r.NoSession || !r.needsSessionToRotate(profile),
 		MasterCreds: &newMasterCreds,
 	})
 	if err != nil {


### PR DESCRIPTION
Adds `--no-session` and `--no-role` flags to the `aws-vault rotate` command.

`--no-session` is for overriding the `needsSessionToRotate` heuristic.

`--no-role` overrides the default behavior of assuming the role given in the profile, so a user can can `aws-vault rotate --no-role ...` instead of having to comment out the `role_arn` in their `~/.aws/config` every time they need to rotate.