### PR TITLE
Add default profile for login command

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -45,6 +45,7 @@ func ConfigureLoginCommand(app *kingpin.Application) {
 		BoolVar(&input.NoSession)
 
 	cmd.Arg("profile", "Name of the profile").
+		Envar("AWS_VAULT").
 		Required().
 		HintAction(ProfileNames).
 		StringVar(&input.Profile)


### PR DESCRIPTION
Tiny feature to save some extra typing:

`aws-vault exec myprofile` already sets `AWS_VAULT` to `myprofile`, so why not use it when doing `aws-vault login` afterwards in a subshell?

Before PR:
```
$ aws-vault exec myprofile
(in subshell)
$ aws-vault login myprofile
```

After PR:

```
$ aws-vault exec myprofile
(in subshell)
$ aws-vault login
```