### PR TITLE
Add --no-save-session option for exec/login

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -32,6 +32,7 @@ type ExecCommandInput struct {
 	CredentialHelper bool
 	Signals          chan os.Signal
 	NoSession        bool
+	NoSaveSession    bool
 }
 
 // json metadata for AWS credential process. Ref: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
@@ -78,6 +79,10 @@ func ConfigureExecCommand(app *kingpin.Application) {
 		Short('s').
 		BoolVar(&input.StartServer)
 
+	cmd.Flag("no-save-session", "Don't save session data to keyring").
+		OverrideDefaultFromEnvar("AWS_VAULT_NO_SAVE_SESSION").
+		BoolVar(&input.NoSaveSession)
+
 	cmd.Arg("profile", "Name of the profile").
 		Required().
 		HintAction(ProfileNames).
@@ -119,6 +124,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 		MfaToken:           input.MfaToken,
 		MfaPrompt:          input.MfaPrompt,
 		NoSession:          input.NoSession,
+		NoSaveSession:      input.NoSaveSession,
 		Config:             awsConfig,
 	})
 	if err != nil {

--- a/cli/login.go
+++ b/cli/login.go
@@ -34,6 +34,7 @@ type LoginCommandInput struct {
 	Region                  string
 	Path                    string
 	NoSession               bool
+	NoSaveSession           bool
 }
 
 func ConfigureLoginCommand(app *kingpin.Application) {
@@ -71,6 +72,10 @@ func ConfigureLoginCommand(app *kingpin.Application) {
 		Short('s').
 		BoolVar(&input.UseStdout)
 
+	cmd.Flag("no-save-session", "Don't save session data to keyring").
+		OverrideDefaultFromEnvar("AWS_VAULT_NO_SAVE_SESSION").
+		BoolVar(&input.NoSaveSession)
+
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		input.MfaPrompt = prompt.Method(GlobalFlags.PromptDriver)
 		input.Keyring = keyringImpl
@@ -98,6 +103,7 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 		MfaPrompt:          input.MfaPrompt,
 		Path:               input.Path,
 		NoSession:          noSession,
+		NoSaveSession:      input.NoSaveSession,
 		Config:             awsConfig,
 		Region:             profile.Region,
 	})

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -34,6 +34,7 @@ type VaultOptions struct {
 	MfaToken           string
 	MfaPrompt          prompt.PromptFunc
 	NoSession          bool
+	NoSaveSession      bool
 	Config             *Config
 	MasterCreds        *credentials.Value
 	Region             string
@@ -138,8 +139,10 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 				return credentials.Value{}, err
 			}
 
-			if err = p.sessions.Store(p.profile, session, time.Now().Add(p.SessionDuration)); err != nil {
-				return credentials.Value{}, err
+			if !p.NoSaveSession {
+				if err = p.sessions.Store(p.profile, session, time.Now().Add(p.SessionDuration)); err != nil {
+					return credentials.Value{}, err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This flag allows you to use short lived sessions without saving them
to your keyring.

This is useful (at least) for the password store backend to not save
the history of all sessions in the password store's git repository.

This fixes #418 