### PR TITLE
Report errors via stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func run(args []string, exit func(int)) {
 		`A vault for securely storing and accessing AWS credentials in development environments.`,
 	)
 
+	app.ErrorWriter(os.Stderr)
 	app.Writer(os.Stdout)
 	app.Version(Version)
 	app.Terminate(exit)


### PR DESCRIPTION
This fixes an issue where piping the standard output from `aws-vault exec` to another program hides error messages when `aws-vault` itself encounters an error.  For example, when an MFA token is invalid.

Thanks for making such a useful tool!