### PR TITLE
fix: session cache key should vary with mfa serial

### DIFF
--- a/cli/ls.go
+++ b/cli/ls.go
@@ -108,15 +108,19 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 			fmt.Fprintf(w, "-\t")
 		}
 
-		var sessionIDs []string
+		var sessionLabels []string
 		for _, sess := range sessions {
 			if profile.Name == sess.Profile.Name {
-				sessionIDs = append(sessionIDs, sess.SessionID)
+				label := fmt.Sprintf("%d", sess.Expiration.Unix())
+				if sess.MfaSerial != "" {
+					label += " (mfa)"
+				}
+				sessionLabels = append(sessionLabels, label)
 			}
 		}
 
 		if len(sessions) > 0 {
-			fmt.Fprintf(w, "%s\t\n", strings.Join(sessionIDs, ", "))
+			fmt.Fprintf(w, "%s\t\n", strings.Join(sessionLabels, ", "))
 		} else {
 			fmt.Fprintf(w, "-\t\n")
 		}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -100,7 +100,7 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 	}
 
 	// sessions get stored by profile, not the source
-	session, err := p.sessions.Retrieve(p.profile)
+	session, err := p.sessions.Retrieve(p.profile, p.VaultOptions.MfaSerial)
 	if err != nil {
 		if err == keyring.ErrKeyNotFound {
 			log.Printf("Session not found in keyring for %s", p.profile)
@@ -138,7 +138,7 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 				return credentials.Value{}, err
 			}
 
-			if err = p.sessions.Store(p.profile, session, time.Now().Add(p.SessionDuration)); err != nil {
+			if err = p.sessions.Store(p.profile, p.VaultOptions.MfaSerial, session); err != nil {
 				return credentials.Value{}, err
 			}
 		}

--- a/vault/sessions_test.go
+++ b/vault/sessions_test.go
@@ -14,6 +14,8 @@ func TestIsSessionKey(t *testing.T) {
 		{"blah", false},
 		{"blah session (61633665646639303539)", true},
 		{"blah-iam session (32383863333237616430)", true},
+		{"session:c2Vzc2lvbg::1572281751", true},
+		{"session:c2Vzc2lvbg:YXJuOmF3czppYW06OjEyMzQ1Njc4OTA6bWZhL2pzdGV3bW9u:1572281751", true},
 	}
 
 	for _, tc := range testCases {

--- a/vault/sessions_test.go
+++ b/vault/sessions_test.go
@@ -14,8 +14,8 @@ func TestIsSessionKey(t *testing.T) {
 		{"blah", false},
 		{"blah session (61633665646639303539)", true},
 		{"blah-iam session (32383863333237616430)", true},
-		{"session:c2Vzc2lvbg::1572281751", true},
-		{"session:c2Vzc2lvbg:YXJuOmF3czppYW06OjEyMzQ1Njc4OTA6bWZhL2pzdGV3bW9u:1572281751", true},
+		{"session,c2Vzc2lvbg,,1572281751", true},
+		{"session,c2Vzc2lvbg,YXJuOmF3czppYW06OjEyMzQ1Njc4OTA6bWZhL2pzdGV3bW9u,1572281751", true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### fix: session cache key should vary with mfa serial

If the master credentials were used as the source for:

  - role A without mfa_serial
  - role B with mfa_serial

Then, creating a cached session with role A would result in operations
with role B failing because the temporary session established when
assuming role A would not have been created with an mfa token.

The mfa serial is now encoded in the cache key, so that the scenario
mentioned above produces distinct cache keys - one with an mfa serial
and one without an mfa serial.

This also resolves a potentially unexpected behavior when a user changes
the value of a mfa_serial attribute.

Because the session key format has changed, any sessions matching the
previous pattern will be identified as obsolete and removed, similarly
to how expired sessions are removed as they are visited.

fixes #438 

edit: fixed wording in commit message