### PR TITLE
Add support for AWS_MFA_SERIAL env var for rotate

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -195,13 +195,13 @@ source_profile = intermediary
 role_arn = arn:aws:iam::123456789012:role/target
 ```
 
-If desired, you can override (or set) your `mfa_serial` with an environment variable `AWS_MFA_SERIAL` or by setting the `--mfa-serial-override` flag from `aws-vault exec`. This behavior is `aws-vault` specific and isn't supported from the `awscli`.
+If desired, you can set your `mfa_serial` with an environment variable `AWS_MFA_SERIAL` or by setting the `--mfa-serial` flag from `aws-vault exec`. This behavior is `aws-vault` specific and isn't supported from the `awscli`.
 
 ```shell
-# Override MFA Serial with flag
-$ aws-vault exec --mfa-serial-override arn:aws:iam::123456789012:mfa/jonsmith my_profile ...
+# Set MFA Serial with flag
+$ aws-vault exec --mfa-serial arn:aws:iam::123456789012:mfa/jonsmith my_profile ...
 
-# Override MFA Serial with environment variable
+# Set MFA Serial with environment variable
 $ export AWS_MFA_SERIAL=arn:aws:iam::123456789012:mfa/jonsmith
 $ aws-vault exec my_profile ...
 ```

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -66,8 +66,12 @@ func ConfigureExecCommand(app *kingpin.Application) {
 		Short('m').
 		StringVar(&input.MfaToken)
 
-	cmd.Flag("mfa-serial-override", "Override the MFA Serial defined in AWS Profile").
-		OverrideDefaultFromEnvar("AWS_MFA_SERIAL").
+	cmd.Flag("mfa-serial-override", "Deprecated, use --mfa-serial instead").
+		Hidden().
+		StringVar(&input.MfaSerial)
+
+	cmd.Flag("mfa-serial", "The identification number of the MFA device to use").
+		Envar("AWS_MFA_SERIAL").
 		StringVar(&input.MfaSerial)
 
 	cmd.Flag("json", "AWS credential helper. Ref: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes").

--- a/cli/login.go
+++ b/cli/login.go
@@ -27,6 +27,7 @@ type LoginCommandInput struct {
 	Profile                 string
 	Keyring                 keyring.Keyring
 	MfaToken                string
+	MfaSerial               string
 	MfaPrompt               prompt.PromptFunc
 	UseStdout               bool
 	FederationTokenDuration time.Duration
@@ -52,6 +53,10 @@ func ConfigureLoginCommand(app *kingpin.Application) {
 	cmd.Flag("mfa-token", "The mfa token to use").
 		Short('t').
 		StringVar(&input.MfaToken)
+
+	cmd.Flag("mfa-serial", "The identification number of the MFA device to use").
+		Envar("AWS_MFA_SERIAL").
+		StringVar(&input.MfaSerial)
 
 	cmd.Flag("path", "The AWS service you would like access").
 		StringVar(&input.Path)
@@ -95,6 +100,7 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 	creds, err := vault.NewVaultCredentials(input.Keyring, input.Profile, vault.VaultOptions{
 		AssumeRoleDuration: input.AssumeRoleDuration,
 		MfaToken:           input.MfaToken,
+		MfaSerial:          input.MfaSerial,
 		MfaPrompt:          input.MfaPrompt,
 		Path:               input.Path,
 		NoSession:          noSession,

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -13,6 +13,7 @@ type RotateCommandInput struct {
 	Profile   string
 	Keyring   keyring.Keyring
 	MfaToken  string
+	MfaSerial string
 	MfaPrompt prompt.PromptFunc
 }
 
@@ -28,6 +29,10 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 		Short('t').
 		StringVar(&input.MfaToken)
 
+	cmd.Flag("mfa-serial-override", "Override the MFA Serial defined in AWS Profile").
+		OverrideDefaultFromEnvar("AWS_MFA_SERIAL").
+		StringVar(&input.MfaSerial)
+
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		input.MfaPrompt = prompt.Method(GlobalFlags.PromptDriver)
 		input.Keyring = keyringImpl
@@ -40,6 +45,7 @@ func RotateCommand(app *kingpin.Application, input RotateCommandInput) {
 	rotator := vault.Rotator{
 		Keyring:   input.Keyring,
 		MfaToken:  input.MfaToken,
+		MfaSerial: input.MfaSerial,
 		MfaPrompt: input.MfaPrompt,
 		Config:    awsConfig,
 	}

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -29,8 +29,8 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 		Short('t').
 		StringVar(&input.MfaToken)
 
-	cmd.Flag("mfa-serial-override", "Override the MFA Serial defined in AWS Profile").
-		OverrideDefaultFromEnvar("AWS_MFA_SERIAL").
+	cmd.Flag("mfa-serial", "The identification number of the MFA device to use").
+		Envar("AWS_MFA_SERIAL").
 		StringVar(&input.MfaSerial)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {

--- a/vault/rotator.go
+++ b/vault/rotator.go
@@ -18,6 +18,7 @@ import (
 type Rotator struct {
 	Keyring   keyring.Keyring
 	MfaToken  string
+	MfaSerial string
 	MfaPrompt prompt.PromptFunc
 	Config    *Config
 }
@@ -57,6 +58,7 @@ func (r *Rotator) Rotate(profile string) error {
 
 	oldSessionCreds, err := NewVaultCredentials(r.Keyring, profile, VaultOptions{
 		MfaToken:    r.MfaToken,
+		MfaSerial:   r.MfaSerial,
 		MfaPrompt:   r.MfaPrompt,
 		Config:      r.Config,
 		NoSession:   !r.needsSessionToRotate(profile),
@@ -113,6 +115,7 @@ func (r *Rotator) Rotate(profile string) error {
 
 	newSessionCreds, err := NewVaultCredentials(r.Keyring, profile, VaultOptions{
 		MfaToken:    r.MfaToken,
+		MfaSerial:   r.MfaSerial,
 		MfaPrompt:   r.MfaPrompt,
 		Config:      r.Config,
 		NoSession:   !r.needsSessionToRotate(profile),
@@ -226,6 +229,9 @@ func retry(duration time.Duration, sleep time.Duration, callback func() error) (
 // This is a heuristic which might need to continue to evolve.  :(
 func (r *Rotator) needsSessionToRotate(profileName string) bool {
 	if r.MfaToken != "" {
+		return true
+	}
+	if r.MfaSerial != "" {
 		return true
 	}
 	sourceProfile, known := r.Config.SourceProfile(profileName)


### PR DESCRIPTION
Rotate didn't respect the AWS_MFA_SERIAL environment variable that is
used by the AWS SDK. when mfa_serial is defined in the profile directly,
or even 1 level of source_profile contains mfa_serial it made use of
that.
If however the mfa serial was provided as an environment variable with
AWS_MFA_SERIAL the rotate command failed.

This change allows rotate to pick up AWS_MFA_SERIAL env var and use a session
when the env var is defined.