### PR TITLE
Refactor variable names

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -72,7 +72,7 @@ func AddCommand(app *kingpin.Application, input AddCommandInput) {
 	}
 
 	creds := credentials.Value{AccessKeyID: accessKeyId, SecretAccessKey: secretKey}
-	provider := &vault.KeyringProvider{Keyring: input.Keyring, Profile: input.ProfileName}
+	provider := &vault.KeyringProvider{Keyring: input.Keyring, CredentialName: input.ProfileName}
 
 	if err := provider.Store(creds); err != nil {
 		app.Fatalf(err.Error())

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -244,12 +244,3 @@ func (e *environ) Set(key, val string) {
 	e.Unset(key)
 	*e = append(*e, key+"="+val)
 }
-
-// ProfileNames returns a slice of profile names from the AWS config
-func ProfileNames() []string {
-	var profileNames []string
-	for _, profile := range awsConfig.Profiles() {
-		profileNames = append(profileNames, profile.Name)
-	}
-	return profileNames
-}

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -53,13 +53,13 @@ func ConfigureExecCommand(app *kingpin.Application) {
 
 	cmd.Flag("session-ttl", "Expiration time for aws session").
 		Default("4h").
-		OverrideDefaultFromEnvar("AWS_SESSION_TTL").
+		Envar("AWS_SESSION_TTL").
 		Short('t').
 		DurationVar(&input.Duration)
 
 	cmd.Flag("assume-role-ttl", "Expiration time for aws assumed role").
 		Default("15m").
-		OverrideDefaultFromEnvar("AWS_ASSUME_ROLE_TTL").
+		Envar("AWS_ASSUME_ROLE_TTL").
 		DurationVar(&input.RoleDuration)
 
 	cmd.Flag("mfa-token", "The mfa token to use").

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -19,7 +19,7 @@ import (
 )
 
 type ExecCommandInput struct {
-	Profile          string
+	ProfileName      string
 	Command          string
 	Args             []string
 	Keyring          keyring.Keyring
@@ -85,7 +85,7 @@ func ConfigureExecCommand(app *kingpin.Application) {
 	cmd.Arg("profile", "Name of the profile").
 		Required().
 		HintAction(ProfileNames).
-		StringVar(&input.Profile)
+		StringVar(&input.ProfileName)
 
 	cmd.Arg("cmd", "Command to execute").
 		Default(os.Getenv("SHELL")).
@@ -116,7 +116,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 		return
 	}
 
-	creds, err := vault.NewVaultCredentials(input.Keyring, input.Profile, vault.VaultOptions{
+	creds, err := vault.NewVaultCredentials(input.Keyring, input.ProfileName, vault.VaultOptions{
 		SessionDuration:    input.Duration,
 		AssumeRoleDuration: input.RoleDuration,
 		MfaSerial:          input.MfaSerial,
@@ -131,7 +131,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 
 	val, err := creds.Get()
 	if err != nil {
-		app.Fatalf(awsConfig.FormatCredentialError(err, input.Profile))
+		app.Fatalf(awsConfig.FormatCredentialError(err, input.ProfileName))
 	}
 
 	if input.StartServer {
@@ -160,7 +160,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 	} else {
 
 		env := environ(os.Environ())
-		env.Set("AWS_VAULT", input.Profile)
+		env.Set("AWS_VAULT", input.ProfileName)
 
 		env.Unset("AWS_ACCESS_KEY_ID")
 		env.Unset("AWS_SECRET_ACCESS_KEY")
@@ -168,7 +168,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 		env.Unset("AWS_DEFAULT_PROFILE")
 		env.Unset("AWS_PROFILE")
 
-		if profile, _ := awsConfig.Profile(input.Profile); profile.Region != "" {
+		if profile, _ := awsConfig.Profile(input.ProfileName); profile.Region != "" {
 			log.Printf("Setting subprocess env: AWS_DEFAULT_REGION=%s, AWS_REGION=%s", profile.Region, profile.Region)
 			env.Set("AWS_DEFAULT_REGION", profile.Region)
 			env.Set("AWS_REGION", profile.Region)

--- a/cli/global.go
+++ b/cli/global.go
@@ -43,29 +43,29 @@ func ConfigureGlobals(app *kingpin.Application) {
 		BoolVar(&GlobalFlags.Debug)
 
 	app.Flag("backend", fmt.Sprintf("Secret backend to use %v", backendsAvailable)).
-		OverrideDefaultFromEnvar("AWS_VAULT_BACKEND").
+		Envar("AWS_VAULT_BACKEND").
 		EnumVar(&GlobalFlags.Backend, backendsAvailable...)
 
 	app.Flag("prompt", fmt.Sprintf("Prompt driver to use %v", promptsAvailable)).
 		Default("terminal").
-		OverrideDefaultFromEnvar("AWS_VAULT_PROMPT").
+		Envar("AWS_VAULT_PROMPT").
 		EnumVar(&GlobalFlags.PromptDriver, promptsAvailable...)
 
 	app.Flag("keychain", "Name of macOS keychain to use, if it doesn't exist it will be created").
 		Default("aws-vault").
-		OverrideDefaultFromEnvar("AWS_VAULT_KEYCHAIN_NAME").
+		Envar("AWS_VAULT_KEYCHAIN_NAME").
 		StringVar(&GlobalFlags.KeychainName)
 
 	app.Flag("pass-dir", "Pass password store directory").
-		OverrideDefaultFromEnvar("AWS_VAULT_PASS_PASSWORD_STORE_DIR").
+		Envar("AWS_VAULT_PASS_PASSWORD_STORE_DIR").
 		StringVar(&GlobalFlags.PassDir)
 
 	app.Flag("pass-cmd", "Name of the pass executable").
-		OverrideDefaultFromEnvar("AWS_VAULT_PASS_CMD").
+		Envar("AWS_VAULT_PASS_CMD").
 		StringVar(&GlobalFlags.PassCmd)
 
 	app.Flag("pass-prefix", "Prefix to prepend to the item path stored in pass").
-		OverrideDefaultFromEnvar("AWS_VAULT_PASS_PREFIX").
+		Envar("AWS_VAULT_PASS_PREFIX").
 		StringVar(&GlobalFlags.PassPrefix)
 
 	app.PreAction(func(c *kingpin.ParseContext) (err error) {

--- a/cli/global.go
+++ b/cli/global.go
@@ -118,3 +118,12 @@ func fileKeyringPassphrasePrompt(prompt string) (string, error) {
 	fmt.Println()
 	return string(b), nil
 }
+
+// ProfileNames returns a slice of profile names from the AWS config
+func ProfileNames() []string {
+	var profileNames []string
+	for _, profile := range awsConfig.Profiles() {
+		profileNames = append(profileNames, profile.Name)
+	}
+	return profileNames
+}

--- a/cli/login.go
+++ b/cli/login.go
@@ -63,13 +63,13 @@ func ConfigureLoginCommand(app *kingpin.Application) {
 
 	cmd.Flag("federation-token-ttl", "Expiration time for aws console session").
 		Default("12h").
-		OverrideDefaultFromEnvar("AWS_FEDERATION_TOKEN_TTL").
+		Envar("AWS_FEDERATION_TOKEN_TTL").
 		Short('f').
 		DurationVar(&input.FederationTokenDuration)
 
 	cmd.Flag("assume-role-ttl", "Expiration time for aws assumed role").
 		Default("15m").
-		OverrideDefaultFromEnvar("AWS_ASSUME_ROLE_TTL").
+		Envar("AWS_ASSUME_ROLE_TTL").
 		DurationVar(&input.AssumeRoleDuration)
 
 	cmd.Flag("stdout", "Print login URL to stdout instead of opening in default browser").

--- a/cli/login.go
+++ b/cli/login.go
@@ -24,7 +24,7 @@ import (
 const allowAllIAMPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`
 
 type LoginCommandInput struct {
-	Profile                 string
+	ProfileName             string
 	Keyring                 keyring.Keyring
 	MfaToken                string
 	MfaSerial               string
@@ -48,7 +48,7 @@ func ConfigureLoginCommand(app *kingpin.Application) {
 	cmd.Arg("profile", "Name of the profile").
 		Required().
 		HintAction(ProfileNames).
-		StringVar(&input.Profile)
+		StringVar(&input.ProfileName)
 
 	cmd.Flag("mfa-token", "The mfa token to use").
 		Short('t').
@@ -90,14 +90,14 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 		return
 	}
 
-	profile, _ := awsConfig.Profile(input.Profile)
+	profile, _ := awsConfig.Profile(input.ProfileName)
 
 	noSession := input.NoSession
 	if profile.SourceProfile == "" {
 		noSession = true
 	}
 
-	creds, err := vault.NewVaultCredentials(input.Keyring, input.Profile, vault.VaultOptions{
+	creds, err := vault.NewVaultCredentials(input.Keyring, input.ProfileName, vault.VaultOptions{
 		AssumeRoleDuration: input.AssumeRoleDuration,
 		MfaToken:           input.MfaToken,
 		MfaSerial:          input.MfaSerial,
@@ -112,7 +112,7 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 	}
 	val, err := creds.Get()
 	if err != nil {
-		app.Fatalf(awsConfig.FormatCredentialError(err, input.Profile))
+		app.Fatalf(awsConfig.FormatCredentialError(err, input.ProfileName))
 	}
 
 	var isFederated bool

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -40,9 +40,9 @@ func ConfigureListCommand(app *kingpin.Application) {
 	})
 }
 
-func containsProfile(profile string, accounts []string) bool {
-	for _, account := range accounts {
-		if !vault.IsSessionKey(account) && account == profile {
+func contains(profileName string, credentialNames []string) bool {
+	for _, credentialName := range credentialNames {
+		if !vault.IsSessionKey(credentialName) && credentialName == profileName {
 			return true
 		}
 	}
@@ -56,16 +56,16 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 		return
 	}
 
-	accounts, err := input.Keyring.Keys()
+	credentialNames, err := input.Keyring.Keys()
 	if err != nil {
 		app.Fatalf(err.Error())
 		return
 	}
 
 	if input.OnlyCredentials {
-		for _, account := range accounts {
-			if !vault.IsSessionKey(account) {
-				fmt.Printf("%s\n", account)
+		for _, c := range credentialNames {
+			if !vault.IsSessionKey(c) {
+				fmt.Printf("%s\n", c)
 			}
 		}
 		return
@@ -79,9 +79,9 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 	}
 
 	if input.OnlySessions {
-		for _, account := range accounts {
-			if vault.IsSessionKey(account) {
-				fmt.Printf("%s\n", account)
+		for _, c := range credentialNames {
+			if vault.IsSessionKey(c) {
+				fmt.Printf("%s\n", c)
 			}
 		}
 		return
@@ -102,7 +102,7 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 		fmt.Fprintf(w, "%s\t", profile.Name)
 
 		source, _ := awsConfig.SourceProfile(profile.Name)
-		if containsProfile(source.Name, accounts) {
+		if contains(source.Name, credentialNames) {
 			fmt.Fprintf(w, "%s\t", source.Name)
 		} else {
 			fmt.Fprintf(w, "-\t")
@@ -127,10 +127,10 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 	}
 
 	// show credentials that don't have profiles
-	for _, account := range accounts {
-		if !vault.IsSessionKey(account) {
-			if _, ok := awsConfig.Profile(account); !ok {
-				fmt.Fprintf(w, "-\t%s\t-\t\n", account)
+	for _, c := range credentialNames {
+		if !vault.IsSessionKey(c) {
+			if _, ok := awsConfig.Profile(c); !ok {
+				fmt.Fprintf(w, "-\t%s\t-\t\n", c)
 			}
 		}
 	}
@@ -140,7 +140,7 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 		return
 	}
 
-	if len(accounts) == 0 {
+	if len(credentialNames) == 0 {
 		app.Fatalf("No credentials found")
 		return
 	}

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -23,6 +23,7 @@ func ConfigureRemoveCommand(app *kingpin.Application) {
 
 	cmd.Arg("profile", "Name of the profile").
 		Required().
+		HintAction(ProfileNames).
 		StringVar(&input.ProfileName)
 
 	cmd.Flag("sessions-only", "Only remove sessions, leave credentials intact").

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -39,7 +39,7 @@ func ConfigureRemoveCommand(app *kingpin.Application) {
 
 func RemoveCommand(app *kingpin.Application, input RemoveCommandInput) {
 	if !input.SessionsOnly {
-		provider := &vault.KeyringProvider{Keyring: input.Keyring, Profile: input.ProfileName}
+		provider := &vault.KeyringProvider{Keyring: input.Keyring, CredentialName: input.ProfileName}
 		r, err := prompt.TerminalPrompt(fmt.Sprintf("Delete credentials for profile %q? (Y|n)", input.ProfileName))
 		if err != nil {
 			app.Fatalf(err.Error())

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -10,7 +10,7 @@ import (
 )
 
 type RemoveCommandInput struct {
-	Profile      string
+	ProfileName  string
 	Keyring      keyring.Keyring
 	SessionsOnly bool
 }
@@ -23,7 +23,7 @@ func ConfigureRemoveCommand(app *kingpin.Application) {
 
 	cmd.Arg("profile", "Name of the profile").
 		Required().
-		StringVar(&input.Profile)
+		StringVar(&input.ProfileName)
 
 	cmd.Flag("sessions-only", "Only remove sessions, leave credentials intact").
 		Short('s').
@@ -38,8 +38,8 @@ func ConfigureRemoveCommand(app *kingpin.Application) {
 
 func RemoveCommand(app *kingpin.Application, input RemoveCommandInput) {
 	if !input.SessionsOnly {
-		provider := &vault.KeyringProvider{Keyring: input.Keyring, Profile: input.Profile}
-		r, err := prompt.TerminalPrompt(fmt.Sprintf("Delete credentials for profile %q? (Y|n)", input.Profile))
+		provider := &vault.KeyringProvider{Keyring: input.Keyring, Profile: input.ProfileName}
+		r, err := prompt.TerminalPrompt(fmt.Sprintf("Delete credentials for profile %q? (Y|n)", input.ProfileName))
 		if err != nil {
 			app.Fatalf(err.Error())
 			return
@@ -60,7 +60,7 @@ func RemoveCommand(app *kingpin.Application, input RemoveCommandInput) {
 		return
 	}
 
-	n, err := sessions.Delete(input.Profile)
+	n, err := sessions.Delete(input.ProfileName)
 	if err != nil {
 		app.Fatalf(err.Error())
 		return

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -10,11 +10,11 @@ import (
 )
 
 type RotateCommandInput struct {
-	Profile   string
-	Keyring   keyring.Keyring
-	MfaToken  string
-	MfaSerial string
-	MfaPrompt prompt.PromptFunc
+	ProfileName string
+	Keyring     keyring.Keyring
+	MfaToken    string
+	MfaSerial   string
+	MfaPrompt   prompt.PromptFunc
 }
 
 func ConfigureRotateCommand(app *kingpin.Application) {
@@ -23,7 +23,7 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 	cmd := app.Command("rotate", "Rotates credentials")
 	cmd.Arg("profile", "Name of the profile").
 		Required().
-		StringVar(&input.Profile)
+		StringVar(&input.ProfileName)
 
 	cmd.Flag("mfa-token", "The mfa token to use").
 		Short('t').
@@ -50,10 +50,10 @@ func RotateCommand(app *kingpin.Application, input RotateCommandInput) {
 		Config:    awsConfig,
 	}
 
-	fmt.Printf("Rotating credentials for profile %q (takes 10-20 seconds)\n", input.Profile)
+	fmt.Printf("Rotating credentials for profile %q (takes 10-20 seconds)\n", input.ProfileName)
 
-	if err := rotator.Rotate(input.Profile); err != nil {
-		app.Fatalf(awsConfig.FormatCredentialError(err, input.Profile))
+	if err := rotator.Rotate(input.ProfileName); err != nil {
+		app.Fatalf(awsConfig.FormatCredentialError(err, input.ProfileName))
 		return
 	}
 

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -23,6 +23,7 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 	cmd := app.Command("rotate", "Rotates credentials")
 	cmd.Arg("profile", "Name of the profile").
 		Required().
+		HintAction(ProfileNames).
 		StringVar(&input.ProfileName)
 
 	cmd.Flag("mfa-token", "The mfa token to use").

--- a/vault/getuser.go
+++ b/vault/getuser.go
@@ -1,0 +1,41 @@
+package vault
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+var getUserErrorRegexp = regexp.MustCompile(`^AccessDenied: User: arn:aws:iam::(\d+):user/(.+) is not`)
+
+// GetUsernameFromSession returns the IAM username (or root) associated with the current aws session
+func GetUsernameFromSession(sess *session.Session) (string, error) {
+	client := iam.New(sess)
+
+	resp, err := client.GetUser(&iam.GetUserInput{})
+	if err != nil {
+		// Even if GetUser fails, the current user is included in the error. This happens when you have o IAM permissions
+		// on the master credentials, but have permission to use assumeRole later
+		matches := getUserErrorRegexp.FindStringSubmatch(err.Error())
+		if len(matches) > 0 {
+			pathParts := strings.Split(matches[2], "/")
+			return pathParts[len(pathParts)-1], nil
+		}
+
+		return "", err
+	}
+
+	if resp.User.UserName != nil {
+		return *resp.User.UserName, nil
+	}
+
+	if resp.User.Arn != nil {
+		arnParts := strings.Split(*resp.User.Arn, ":")
+		return arnParts[len(arnParts)-1], nil
+	}
+
+	return "", fmt.Errorf("Couldn't determine current username")
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -68,26 +68,26 @@ func (o VaultOptions) ApplyDefaults() VaultOptions {
 type VaultProvider struct {
 	credentials.Expiry
 	VaultOptions
-	profile  string
-	expires  time.Time
-	keyring  keyring.Keyring
-	sessions *KeyringSessions
-	config   *Config
-	creds    map[string]credentials.Value
+	credentialName string
+	expires        time.Time
+	keyring        keyring.Keyring
+	sessions       *KeyringSessions
+	config         *Config
+	creds          map[string]credentials.Value
 }
 
-func NewVaultProvider(k keyring.Keyring, profile string, opts VaultOptions) (*VaultProvider, error) {
+func NewVaultProvider(k keyring.Keyring, credentialName string, opts VaultOptions) (*VaultProvider, error) {
 	opts = opts.ApplyDefaults()
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
 	return &VaultProvider{
-		VaultOptions: opts,
-		keyring:      k,
-		sessions:     &KeyringSessions{k, opts.Config},
-		profile:      profile,
-		config:       opts.Config,
-		creds:        map[string]credentials.Value{},
+		VaultOptions:   opts,
+		keyring:        k,
+		sessions:       &KeyringSessions{k, opts.Config},
+		credentialName: credentialName,
+		config:         opts.Config,
+		creds:          map[string]credentials.Value{},
 	}, nil
 }
 
@@ -100,10 +100,10 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 	}
 
 	// sessions get stored by profile, not the source
-	session, err := p.sessions.Retrieve(p.profile, p.VaultOptions.MfaSerial)
+	session, err := p.sessions.Retrieve(p.credentialName, p.VaultOptions.MfaSerial)
 	if err != nil {
 		if err == keyring.ErrKeyNotFound {
-			log.Printf("Session not found in keyring for %s", p.profile)
+			log.Printf("Session not found in keyring for %s", p.credentialName)
 		} else {
 			log.Println(err)
 		}
@@ -111,7 +111,7 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 		// session lookup missed, we need to create a new one.
 		// If the selected profile has a SourceProfile, create a new VaultCredentials for the source
 		// to support using an existing session for master credentials and allow assume role chaining.
-		if profile, exists := p.config.Profile(p.profile); exists && profile.SourceProfile != "" {
+		if profile, exists := p.config.Profile(p.credentialName); exists && profile.SourceProfile != "" {
 			creds, err := NewVaultCredentials(p.keyring, profile.SourceProfile, p.VaultOptions)
 			if err != nil {
 				log.Printf("Failed to create NewVaultCredentials for profile %q", profile.SourceProfile)
@@ -138,7 +138,7 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 				return credentials.Value{}, err
 			}
 
-			if err = p.sessions.Store(p.profile, p.VaultOptions.MfaSerial, session); err != nil {
+			if err = p.sessions.Store(p.credentialName, p.VaultOptions.MfaSerial, session); err != nil {
 				return credentials.Value{}, err
 			}
 		}
@@ -148,7 +148,7 @@ func (p *VaultProvider) Retrieve() (credentials.Value, error) {
 		(*session.AccessKeyId)[len(*session.AccessKeyId)-4:],
 		session.Expiration.Sub(time.Now()).String())
 
-	if profile, exists := p.config.Profile(p.profile); exists && profile.RoleARN != "" {
+	if profile, exists := p.config.Profile(p.credentialName); exists && profile.RoleARN != "" {
 		session, err = p.assumeRoleFromSession(session, profile)
 		if err != nil {
 			return credentials.Value{}, err
@@ -187,7 +187,7 @@ func (p *VaultProvider) RetrieveWithoutSessionToken() (credentials.Value, error)
 		return credentials.Value{}, err
 	}
 
-	if profile, exists := p.config.Profile(p.profile); exists && profile.RoleARN != "" {
+	if profile, exists := p.config.Profile(p.credentialName); exists && profile.RoleARN != "" {
 		session, err := p.assumeRole(creds, profile)
 		if err != nil {
 			return credentials.Value{}, err
@@ -229,7 +229,7 @@ func (p VaultProvider) awsConfig() *aws.Config {
 		return aws.NewConfig().WithRegion(region)
 	}
 
-	if profile, ok := p.Config.Profile(p.profile); ok {
+	if profile, ok := p.Config.Profile(p.credentialName); ok {
 		if profile.Region != "" {
 			log.Printf("Using region %q from profile", profile.Region)
 			return aws.NewConfig().WithRegion(profile.Region)
@@ -244,7 +244,7 @@ func (p *VaultProvider) getMasterCreds() (credentials.Value, error) {
 		return *p.MasterCreds, nil
 	}
 
-	source, _ := p.Config.SourceProfile(p.profile)
+	source, _ := p.Config.SourceProfile(p.credentialName)
 
 	val, ok := p.creds[source.Name]
 	if !ok {
@@ -285,7 +285,7 @@ func (p *VaultProvider) getSessionToken(creds *credentials.Value) (sts.Credentia
 			Value: *creds,
 		}))))
 
-	source, _ := p.Config.SourceProfile(p.profile)
+	source, _ := p.Config.SourceProfile(p.credentialName)
 	log.Printf("Getting new session token for profile %s", source.Name)
 
 	resp, err := client.GetSessionToken(params)
@@ -297,7 +297,7 @@ func (p *VaultProvider) getSessionToken(creds *credentials.Value) (sts.Credentia
 }
 
 func (p *VaultProvider) roleSessionName() string {
-	if profile, _ := p.Config.Profile(p.profile); profile.RoleSessionName != "" {
+	if profile, _ := p.Config.Profile(p.credentialName); profile.RoleSessionName != "" {
 		return profile.RoleSessionName
 	}
 

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -248,7 +248,7 @@ func (p *VaultProvider) getMasterCreds() (credentials.Value, error) {
 
 	val, ok := p.creds[source.Name]
 	if !ok {
-		creds := credentials.NewCredentials(&KeyringProvider{Keyring: p.keyring, Profile: source.Name})
+		creds := credentials.NewCredentials(&KeyringProvider{Keyring: p.keyring, CredentialName: source.Name})
 
 		var err error
 		if val, err = creds.Get(); err != nil {
@@ -373,9 +373,9 @@ func (p *VaultProvider) assumeRole(creds credentials.Value, profile Profile) (st
 }
 
 type KeyringProvider struct {
-	Keyring keyring.Keyring
-	Profile string
-	Region  string
+	Keyring        keyring.Keyring
+	CredentialName string
+	Region         string
 }
 
 func (p *KeyringProvider) IsExpired() bool {
@@ -383,8 +383,8 @@ func (p *KeyringProvider) IsExpired() bool {
 }
 
 func (p *KeyringProvider) Retrieve() (val credentials.Value, err error) {
-	log.Printf("Looking up keyring for %s", p.Profile)
-	item, err := p.Keyring.Get(p.Profile)
+	log.Printf("Looking up keyring for %s", p.CredentialName)
+	item, err := p.Keyring.Get(p.CredentialName)
 	if err != nil {
 		log.Println("Error from keyring", err)
 		return val, err
@@ -402,8 +402,8 @@ func (p *KeyringProvider) Store(val credentials.Value) error {
 	}
 
 	return p.Keyring.Set(keyring.Item{
-		Key:   p.Profile,
-		Label: fmt.Sprintf("aws-vault (%s)", p.Profile),
+		Key:   p.CredentialName,
+		Label: fmt.Sprintf("aws-vault (%s)", p.CredentialName),
 		Data:  bytes,
 
 		// specific Keychain settings
@@ -412,7 +412,7 @@ func (p *KeyringProvider) Store(val credentials.Value) error {
 }
 
 func (p *KeyringProvider) Delete() error {
-	return p.Keyring.Remove(p.Profile)
+	return p.Keyring.Remove(p.CredentialName)
 }
 
 type VaultCredentials struct {

--- a/vault/rotator.go
+++ b/vault/rotator.go
@@ -31,9 +31,9 @@ func (r *Rotator) Rotate(profileName string) error {
 	// Get the existing credentials
 
 	provider := &KeyringProvider{
-		Keyring: r.Keyring,
-		Profile: source.Name,
-		Region:  source.Region,
+		Keyring:        r.Keyring,
+		CredentialName: source.Name,
+		Region:         source.Region,
 	}
 
 	oldMasterCreds, err := provider.Retrieve()

--- a/vault/rotator.go
+++ b/vault/rotator.go
@@ -22,10 +22,10 @@ type Rotator struct {
 }
 
 // Rotate creates a new key and deletes the old one
-func (r *Rotator) Rotate(profile string) error {
+func (r *Rotator) Rotate(profileName string) error {
 	var err error
 
-	source, _ := r.Config.SourceProfile(profile)
+	source, _ := r.Config.SourceProfile(profileName)
 
 	// --------------------------------
 	// Get the existing credentials
@@ -54,12 +54,12 @@ func (r *Rotator) Rotate(profile string) error {
 		oldMasterCreds.AccessKeyID[len(oldMasterCreds.AccessKeyID)-4:],
 		currentUserName)
 
-	oldSessionCreds, err := NewVaultCredentials(r.Keyring, profile, VaultOptions{
+	oldSessionCreds, err := NewVaultCredentials(r.Keyring, profileName, VaultOptions{
 		MfaToken:    r.MfaToken,
 		MfaSerial:   r.MfaSerial,
 		MfaPrompt:   r.MfaPrompt,
 		Config:      r.Config,
-		NoSession:   !r.needsSessionToRotate(profile),
+		NoSession:   !r.needsSessionToRotate(profileName),
 		MasterCreds: &oldMasterCreds,
 	})
 	if err != nil {
@@ -111,12 +111,12 @@ func (r *Rotator) Rotate(profile string) error {
 
 	log.Println("Using new credentials to delete the old new access key")
 
-	newSessionCreds, err := NewVaultCredentials(r.Keyring, profile, VaultOptions{
+	newSessionCreds, err := NewVaultCredentials(r.Keyring, profileName, VaultOptions{
 		MfaToken:    r.MfaToken,
 		MfaSerial:   r.MfaSerial,
 		MfaPrompt:   r.MfaPrompt,
 		Config:      r.Config,
-		NoSession:   !r.needsSessionToRotate(profile),
+		NoSession:   !r.needsSessionToRotate(profileName),
 		MasterCreds: &newMasterCreds,
 	})
 	if err != nil {
@@ -154,11 +154,11 @@ func (r *Rotator) Rotate(profile string) error {
 		return err
 	}
 
-	if n, _ := sessions.Delete(profile); n > 0 {
+	if n, _ := sessions.Delete(profileName); n > 0 {
 		log.Printf("Deleted %d existing sessions.", n)
 	}
 
-	log.Printf("Rotated credentials for profile %q in vault", profile)
+	log.Printf("Rotated credentials for profile %q in vault", profileName)
 	return nil
 }
 


### PR DESCRIPTION
Refactors variable names to improve clarity of intent.

There are many instances of "profile" being used in the source code. I've changed these variable names to be either `profileName` (the name of an ordinary profile) or `credentialName` the name of a credential (corresponding to a profile)

This makes the code easier to work with as you know whether the variable is referring to a credential or a profile. This naming scheme is identical to what you see when using `aws-vault list`.

This is a pure refactor and doesn't change any behaviour