### PR TITLE
Add parent_profile config variable

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1,22 +1,24 @@
 # Usage
 
-* [Help](#help)
-* [Managing profiles](#managing-profiles)
-    * [Using multiple profiles](#using-multiple-profiles)
-    * [Example ~/.aws/config](#example-~/.aws/config)
-    * [Listing profiles](#listing-profiles)
-    * [Removing profiles](#removing-profiles)
+* [Getting Help](#getting-help)
+* [Config](#config)
 * [Environment variables](#environment-variables)
+* [Managing Profiles](#managing-profiles)
+  * [Using multiple profiles](#using-multiple-profiles)
+  * [Example ~/.aws/config](#example---aws-config)
+  * [Listing profiles](#listing-profiles)
+  * [Removing profiles](#removing-profiles)
 * [Backends](#backends)
+* [MFA](#mfa)
 * [Removing stored sessions](#removing-stored-sessions)
-* [Logging into aws console](#logging-into-aws-console)
+* [Logging into AWS console](#logging-into-aws-console)
 * [Using credential helper](#using-credential-helper)
 * [Not using session credentials](#not-using-session-credentials)
-     * [Considerations](#considerations)
-     * [Assuming a role for more than 1h](#assuming-a-role-for-more-than-1h)
-     * [Being able to perform certain sts operations](#being-able-to-perform-certain-sts-operations)
-* [Rotating credentials](#rotating-credentials)
-* [Overriding the aws cli to use aws-vault](#overriding-the-aws-cli-to-use-aws-vault)
+  * [Considerations](#considerations)
+  * [Assuming a role for more than 1h](#assuming-a-role-for-more-than-1h)
+  * [Being able to perform certain STS operations](#being-able-to-perform-certain-sts-operations)
+* [Rotating Credentials](#rotating-credentials)
+* [Overriding the aws CLI to use aws-vault](#overriding-the-aws-cli-to-use-aws-vault)
 * [Using a yubikey as a virtual MFA](#using-a-yubikey-as-a-virtual-mfa)
 
 ## Getting Help
@@ -33,6 +35,50 @@ $ aws-vault --help-long
 # Show the most detailed information about the exec command
 $ aws-vault exec --help
 ```
+
+
+## Config
+
+aws-vault uses your `~/.aws/config` to load AWS config. This should work identically to the config specified by the [aws-cli docs](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html).
+
+aws-vault also recognises an extra config variable, `parent_profile`. This variable sets a profile to inherit configuration from. In the following example, the `work-admin` profile inherits `region` and `mfa_serial` from the `work` profile.
+
+```ini
+[profile work]
+region = eu-west-1
+mfa_serial = arn:aws:iam::111111111111:mfa/work-account
+
+[profile work-admin]
+role_arn = arn:aws:iam::111111111111:role/Administrator
+parent_profile = work
+```
+
+
+## Environment variables
+
+The following environment variables can be set to override the default flag
+values of `aws-vault` and its subcommands.
+
+For the `aws-vault` command:
+
+* `AWS_VAULT_BACKEND`: Secret backend to use (see the flag `--backend`)
+* `AWS_VAULT_KEYCHAIN_NAME`: Name of macOS keychain to use (see the flag `--keychain`)
+* `AWS_VAULT_PROMPT`: Prompt driver to use (see the flag `--prompt`)
+* `AWS_VAULT_PASS_PASSWORD_STORE_DIR`: Pass password store directory (see the flag `--pass-dir`)
+* `AWS_VAULT_PASS_CMD`: Name of the pass executable (see the flag `--pass-cmd`)
+* `AWS_VAULT_PASS_PREFIX`: Prefix to prepend to the item path stored in pass (see the flag `--pass-prefix`)
+
+For the `aws-vault exec` subcommand:
+
+* `AWS_ASSUME_ROLE_TTL`: Expiration time for aws assumed role (see the flag `--assume-role-ttl`)
+* `AWS_SESSION_TTL`:  Expiration time for aws session (see the flag `--session-ttl`)
+* `AWS_MFA_SERIAL`: The identification number of the MFA device to use  (see the flag `--mfa-serial`)
+
+For the `aws-vault login` subcommand:
+
+* `AWS_FEDERATION_TOKEN_TTL`: Expiration time for aws console session (see the flag `--federation-token-ttl`)
+* `AWS_MFA_SERIAL`: The identification number of the MFA device to use  (see the flag `--mfa-serial`)
+
 
 ## Managing Profiles
 
@@ -77,11 +123,7 @@ mfa_serial = arn:aws:iam::111111111111:mfa/home-account
 [profile work]
 region = eu-west-1
 mfa_serial = arn:aws:iam::111111111111:mfa/work-account
-
-[profile work-read-only]
-region = us-east-1
 role_arn = arn:aws:iam::111111111111:role/ReadOnly
-source_profile = work
 
 [profile work-admin]
 region = us-east-1
@@ -124,30 +166,6 @@ Deleted 1 sessions.
 $ aws-vault remove work --sessions-only
 Deleted 1 sessions.
 ```
-
-## Environment variables
-
-The following environment variables can be set to override the default flag
-values of `aws-vault` and its subcommands.
-
-For the `aws-vault` command:
-
-* `AWS_VAULT_BACKEND`: Secret backend to use (see the flag `--backend`)
-* `AWS_VAULT_KEYCHAIN_NAME`: Name of macOS keychain to use (see the flag `--keychain`)
-* `AWS_VAULT_PROMPT`: Prompt driver to use (see the flag `--prompt`)
-* `AWS_VAULT_PASS_PASSWORD_STORE_DIR`: Pass password store directory (see the flag `--pass-dir`)
-* `AWS_VAULT_PASS_CMD`: Name of the pass executable (see the flag `--pass-cmd`)
-* `AWS_VAULT_PASS_PREFIX`: Prefix to prepend to the item path stored in pass (see the flag `--pass-prefix`)
-
-For the `aws-vault exec` subcommand:
-
-* `AWS_ASSUME_ROLE_TTL`: Expiration time for aws assumed role (see the flag `--assume-role-ttl`)
-* `AWS_SESSION_TTL`:  Expiration time for aws session (see the flag `--session-ttl`)
-
-For the `aws-vault login` subcommand:
-
-* `AWS_ASSUME_ROLE_TTL`: Expiration time for aws assumed role console session when not using --no-session (see the flag `--assume-role-ttl`)
-* `AWS_FEDERATION_TOKEN_TTL`: Expiration time for aws console session (see the flag `--federation-token-ttl`)
 
 
 ## Backends

--- a/cli/add.go
+++ b/cli/add.go
@@ -50,6 +50,11 @@ func AddCommand(app *kingpin.Application, input AddCommandInput) {
 			p.SourceProfile, input.ProfileName)
 		return
 	}
+	if p.ParentProfile != "" {
+		app.Fatalf("Your profile has a parent_profile of %s, adding credentials to %s won't have any effect",
+			p.ParentProfile, input.ProfileName)
+		return
+	}
 
 	if input.FromEnv {
 		if accessKeyId = os.Getenv("AWS_ACCESS_KEY_ID"); accessKeyId == "" {

--- a/cli/add.go
+++ b/cli/add.go
@@ -44,9 +44,10 @@ func ConfigureAddCommand(app *kingpin.Application) {
 func AddCommand(app *kingpin.Application, input AddCommandInput) {
 	var accessKeyId, secretKey string
 
-	if source, _ := awsConfig.SourceProfile(input.ProfileName); source.Name != input.ProfileName {
+	profile, _ := awsConfig.Profile(input.ProfileName)
+	if profile.SourceProfile != "" {
 		app.Fatalf("Your profile has a source_profile of %s, adding credentials to %s won't have any effect",
-			source.Name, input.ProfileName)
+			profile.SourceProfile, input.ProfileName)
 		return
 	}
 
@@ -93,15 +94,13 @@ func AddCommand(app *kingpin.Application, input AddCommandInput) {
 
 	if _, hasProfile := awsConfig.Profile(input.ProfileName); !hasProfile {
 		if input.AddConfig {
-			// copy a source profile if one exists
-			newProfileFromSource, _ := awsConfig.SourceProfile(input.ProfileName)
-			newProfileFromSource.Name = input.ProfileName
-
+			newProfile := vault.Profile{
+				Name: input.ProfileName,
+			}
 			log.Printf("Adding profile %s to config at %s", input.ProfileName, awsConfig.Path)
-			if err = awsConfig.Add(newProfileFromSource); err != nil {
+			if err = awsConfig.Add(newProfile); err != nil {
 				app.Fatalf("Error adding profile: %#v", err)
 			}
 		}
 	}
-
 }

--- a/cli/add.go
+++ b/cli/add.go
@@ -78,7 +78,7 @@ func AddCommand(app *kingpin.Application, input AddCommandInput) {
 	}
 
 	creds := credentials.Value{AccessKeyID: accessKeyId, SecretAccessKey: secretKey}
-	provider := &vault.KeyringProvider{Keyring: input.Keyring, CredentialName: input.ProfileName}
+	provider := &vault.KeyringProvider{Keyring: input.Keyring, CredentialsName: input.ProfileName}
 
 	if err := provider.Store(creds); err != nil {
 		app.Fatalf(err.Error())

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/99designs/aws-vault/prompt"
 	"github.com/99designs/aws-vault/server"
@@ -23,15 +22,14 @@ type ExecCommandInput struct {
 	Command          string
 	Args             []string
 	Keyring          keyring.Keyring
-	Duration         time.Duration
-	RoleDuration     time.Duration
-	MfaToken         string
-	MfaPrompt        prompt.PromptFunc
-	MfaSerial        string
 	StartServer      bool
 	CredentialHelper bool
 	Signals          chan os.Signal
-	NoSession        bool
+	Config           vault.Config
+}
+
+type AwsConfigOverride struct {
+	MfaSerial string
 }
 
 // json metadata for AWS credential process. Ref: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
@@ -49,30 +47,30 @@ func ConfigureExecCommand(app *kingpin.Application) {
 	cmd := app.Command("exec", "Executes a command with AWS credentials in the environment")
 	cmd.Flag("no-session", "Use root credentials, no session created").
 		Short('n').
-		BoolVar(&input.NoSession)
+		BoolVar(&input.Config.NoSession)
 
 	cmd.Flag("session-ttl", "Expiration time for aws session").
 		Default("4h").
 		Envar("AWS_SESSION_TTL").
 		Short('t').
-		DurationVar(&input.Duration)
+		DurationVar(&input.Config.SessionDuration)
 
 	cmd.Flag("assume-role-ttl", "Expiration time for aws assumed role").
 		Default("15m").
 		Envar("AWS_ASSUME_ROLE_TTL").
-		DurationVar(&input.RoleDuration)
+		DurationVar(&input.Config.AssumeRoleDuration)
 
 	cmd.Flag("mfa-token", "The mfa token to use").
 		Short('m').
-		StringVar(&input.MfaToken)
+		StringVar(&input.Config.MfaToken)
 
 	cmd.Flag("mfa-serial-override", "Deprecated, use --mfa-serial instead").
 		Hidden().
-		StringVar(&input.MfaSerial)
+		StringVar(&input.Config.MfaSerial)
 
 	cmd.Flag("mfa-serial", "The identification number of the MFA device to use").
-		Envar("AWS_MFA_SERIAL").
-		StringVar(&input.MfaSerial)
+		// Envar("AWS_MFA_SERIAL").
+		StringVar(&input.Config.MfaSerial)
 
 	cmd.Flag("json", "AWS credential helper. Ref: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes").
 		Short('j').
@@ -84,7 +82,7 @@ func ConfigureExecCommand(app *kingpin.Application) {
 
 	cmd.Arg("profile", "Name of the profile").
 		Required().
-		HintAction(ProfileNames).
+		HintAction(awsConfigFile.ProfileNames).
 		StringVar(&input.ProfileName)
 
 	cmd.Arg("cmd", "Command to execute").
@@ -96,7 +94,7 @@ func ConfigureExecCommand(app *kingpin.Application) {
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		input.Keyring = keyringImpl
-		input.MfaPrompt = prompt.Method(GlobalFlags.PromptDriver)
+		input.Config.MfaPrompt = prompt.Method(GlobalFlags.PromptDriver)
 		input.Signals = make(chan os.Signal)
 		ExecCommand(app, input)
 		return nil
@@ -111,27 +109,24 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 
 	var setEnv = true
 
-	if input.NoSession && input.StartServer {
+	if input.Config.NoSession && input.StartServer {
 		app.Fatalf("Can't start a credential server without a session")
 		return
 	}
 
-	creds, err := vault.NewVaultCredentials(input.Keyring, input.ProfileName, vault.VaultOptions{
-		SessionDuration:    input.Duration,
-		AssumeRoleDuration: input.RoleDuration,
-		MfaSerial:          input.MfaSerial,
-		MfaToken:           input.MfaToken,
-		MfaPrompt:          input.MfaPrompt,
-		NoSession:          input.NoSession,
-		Config:             awsConfig,
-	})
+	err := configLoader.LoadFromProfile(input.ProfileName, &input.Config)
+	if err != nil {
+		app.Fatalf("%v", err)
+	}
+
+	creds, err := vault.NewVaultCredentials(input.Keyring, input.ProfileName, &input.Config)
 	if err != nil {
 		app.Fatalf("%v", err)
 	}
 
 	val, err := creds.Get()
 	if err != nil {
-		app.Fatalf(awsConfig.FormatCredentialError(err, input.ProfileName))
+		app.Fatalf(awsConfigFile.FormatCredentialError(err, input.ProfileName))
 	}
 
 	if input.StartServer {
@@ -149,7 +144,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 			SecretAccessKey: val.SecretAccessKey,
 			SessionToken:    val.SessionToken,
 		}
-		if !input.NoSession {
+		if !input.Config.NoSession {
 			credentialData.Expiration = creds.Expires().Format("2006-01-02T15:04:05Z")
 		}
 		json, err := json.Marshal(&credentialData)
@@ -168,11 +163,9 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 		env.Unset("AWS_DEFAULT_PROFILE")
 		env.Unset("AWS_PROFILE")
 
-		if profile, _ := awsConfig.Profile(input.ProfileName); profile.Region != "" {
-			log.Printf("Setting subprocess env: AWS_DEFAULT_REGION=%s, AWS_REGION=%s", profile.Region, profile.Region)
-			env.Set("AWS_DEFAULT_REGION", profile.Region)
-			env.Set("AWS_REGION", profile.Region)
-		}
+		log.Printf("Setting subprocess env: AWS_DEFAULT_REGION=%s, AWS_REGION=%s", input.Config.Region, input.Config.Region)
+		env.Set("AWS_DEFAULT_REGION", input.Config.Region)
+		env.Set("AWS_REGION", input.Config.Region)
 
 		if setEnv {
 			log.Println("Setting subprocess env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY")

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -121,7 +121,7 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 
 	val, err := creds.Get()
 	if err != nil {
-		app.Fatalf(FormatCredentialError(err, input.ProfileName))
+		app.Fatalf(FormatCredentialError(err, input.Config.CredentialsName))
 	}
 
 	if input.StartServer {

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -145,7 +145,11 @@ func ExecCommand(app *kingpin.Application, input ExecCommandInput) {
 			SessionToken:    val.SessionToken,
 		}
 		if !input.Config.NoSession {
-			credentialData.Expiration = creds.Expires().Format("2006-01-02T15:04:05Z")
+			credsExprest, err := creds.ExpiresAt()
+			if err != nil {
+				app.Fatalf("Error getting credential expiration: %v", err)
+			}
+			credentialData.Expiration = credsExprest.Format("2006-01-02T15:04:05Z")
 		}
 		json, err := json.Marshal(&credentialData)
 		if err != nil {

--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -3,10 +3,12 @@ package cli
 import (
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/99designs/aws-vault/vault"
 	"github.com/99designs/keyring"
 )
 
 func ExampleExecCommand() {
+	awsConfigFile = &vault.ConfigFile{}
 	keyringImpl = keyring.NewArrayKeyring([]keyring.Item{
 		{Key: "llamas", Data: []byte(`{"AccessKeyID":"ABC","SecretAccessKey":"XYZ"}`)},
 	})

--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -3,12 +3,10 @@ package cli
 import (
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/99designs/aws-vault/vault"
 	"github.com/99designs/keyring"
 )
 
 func ExampleExecCommand() {
-	awsConfig = &vault.Config{}
 	keyringImpl = keyring.NewArrayKeyring([]keyring.Item{
 		{Key: "llamas", Data: []byte(`{"AccessKeyID":"ABC","SecretAccessKey":"XYZ"}`)},
 	})

--- a/cli/global.go
+++ b/cli/global.go
@@ -101,8 +101,8 @@ func ConfigureGlobals(app *kingpin.Application) {
 		}
 		if awsConfigFile == nil {
 			awsConfigFile, err = vault.LoadConfigFromEnv()
-			configLoader = &vault.ConfigLoader{File: awsConfigFile}
 		}
+		configLoader = &vault.ConfigLoader{File: awsConfigFile}
 		return err
 	})
 }
@@ -122,6 +122,6 @@ func fileKeyringPassphrasePrompt(prompt string) (string, error) {
 }
 
 // FormatCredentialError formats errors with some user friendly context
-func FormatCredentialError(err error, profileName string) string {
-	return fmt.Sprintf("Failed to get credentials for %s: %v", profileName, err)
+func FormatCredentialError(err error, credentialsName string) string {
+	return fmt.Sprintf("Failed to get credentials for %s: %v", credentialsName, err)
 }

--- a/cli/global.go
+++ b/cli/global.go
@@ -19,7 +19,8 @@ const (
 
 var (
 	keyringImpl      keyring.Keyring
-	awsConfig        *vault.Config
+	awsConfigFile    *vault.ConfigFile
+	configLoader     *vault.ConfigLoader
 	promptsAvailable = prompt.Available()
 )
 
@@ -98,8 +99,9 @@ func ConfigureGlobals(app *kingpin.Application) {
 				return err
 			}
 		}
-		if awsConfig == nil {
-			awsConfig, err = vault.LoadConfigFromEnv()
+		if awsConfigFile == nil {
+			awsConfigFile, err = vault.LoadConfigFromEnv()
+			configLoader = &vault.ConfigLoader{File: awsConfigFile}
 		}
 		return err
 	})
@@ -117,13 +119,4 @@ func fileKeyringPassphrasePrompt(prompt string) (string, error) {
 	}
 	fmt.Println()
 	return string(b), nil
-}
-
-// ProfileNames returns a slice of profile names from the AWS config
-func ProfileNames() []string {
-	var profileNames []string
-	for _, profile := range awsConfig.Profiles() {
-		profileNames = append(profileNames, profile.Name)
-	}
-	return profileNames
 }

--- a/cli/global.go
+++ b/cli/global.go
@@ -120,3 +120,8 @@ func fileKeyringPassphrasePrompt(prompt string) (string, error) {
 	fmt.Println()
 	return string(b), nil
 }
+
+// FormatCredentialError formats errors with some user friendly context
+func FormatCredentialError(err error, profileName string) string {
+	return fmt.Sprintf("Failed to get credentials for %s: %v", profileName, err)
+}

--- a/cli/login.go
+++ b/cli/login.go
@@ -100,11 +100,10 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 
 	val, err := creds.Get()
 	if err != nil {
-		app.Fatalf(FormatCredentialError(err, input.ProfileName))
+		app.Fatalf(FormatCredentialError(err, input.Config.CredentialsName))
 	}
 
 	isFederated := false
-	sessionDuration := input.FederationTokenDuration
 
 	// if AssumeRole isn't used, GetFederationToken has to be used for IAM credentials
 	if val.SessionToken == "" {
@@ -140,7 +139,7 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 		return
 	}
 
-	log.Printf("Creating login token, expires in %s", sessionDuration)
+	log.Printf("Creating login token, expires in %s", input.FederationTokenDuration)
 
 	q := req.URL.Query()
 	q.Add("Action", "getSigninToken")
@@ -148,7 +147,7 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 
 	// not needed for federation tokens
 	if input.Config.NoSession && !isFederated {
-		q.Add("SessionDuration", fmt.Sprintf("%.f", sessionDuration.Seconds()))
+		q.Add("SessionDuration", fmt.Sprintf("%.f", input.FederationTokenDuration.Seconds()))
 	}
 
 	req.URL.RawQuery = q.Encode()

--- a/cli/login.go
+++ b/cli/login.go
@@ -28,14 +28,8 @@ type LoginCommandInput struct {
 	Keyring                 keyring.Keyring
 	UseStdout               bool
 	FederationTokenDuration time.Duration
-	AssumeRoleDuration      time.Duration
 	Path                    string
 	Config                  vault.Config
-	// MfaToken                string
-	// MfaSerial               string
-	// MfaPrompt               prompt.PromptFunc
-	// Region                  string
-	// NoSession               bool
 }
 
 func ConfigureLoginCommand(app *kingpin.Application) {
@@ -70,7 +64,7 @@ func ConfigureLoginCommand(app *kingpin.Application) {
 	cmd.Flag("assume-role-ttl", "Expiration time for aws assumed role").
 		Default("15m").
 		Envar("AWS_ASSUME_ROLE_TTL").
-		DurationVar(&input.AssumeRoleDuration)
+		DurationVar(&input.Config.AssumeRoleDuration)
 
 	cmd.Flag("stdout", "Print login URL to stdout instead of opening in default browser").
 		Short('s').
@@ -106,11 +100,11 @@ func LoginCommand(app *kingpin.Application, input LoginCommandInput) {
 
 	val, err := creds.Get()
 	if err != nil {
-		app.Fatalf(awsConfigFile.FormatCredentialError(err, input.ProfileName))
+		app.Fatalf(FormatCredentialError(err, input.ProfileName))
 	}
 
-	var isFederated bool
-	var sessionDuration = input.FederationTokenDuration
+	isFederated := false
+	sessionDuration := input.FederationTokenDuration
 
 	// if AssumeRole isn't used, GetFederationToken has to be used for IAM credentials
 	if val.SessionToken == "" {

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -109,7 +109,7 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 		if contains(credentialsNames, config.CredentialsName) {
 			fmt.Fprintf(w, "%s\t", config.CredentialsName)
 		} else if config.CredentialsName != "" {
-			fmt.Fprintf(w, "[%s missing]\t", config.CredentialsName)
+			fmt.Fprintf(w, "%s (missing)\t", config.CredentialsName)
 		} else {
 			fmt.Fprintf(w, "-\t")
 		}
@@ -133,11 +133,10 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 	}
 
 	// show credentials that don't have profiles
-	for _, c := range credentialsNames {
-		profileConfig := vault.Config{}
-		err := configLoader.LoadFromProfile(c, &profileConfig)
-		if err != nil {
-			fmt.Fprintf(w, "-\t%s\t-\t\n", c)
+	for _, credentialName := range credentialsNames {
+		_, ok := awsConfigFile.ProfileSection(credentialName)
+		if !ok {
+			fmt.Fprintf(w, "-\t%s\t-\t\n", credentialName)
 		}
 	}
 

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -58,18 +58,18 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 		return
 	}
 
-	credentialNames := []string{}
+	credentialsNames := []string{}
 	sessionNames := []string{}
 	for _, c := range keys {
 		if vault.IsSessionKey(c) {
 			sessionNames = append(sessionNames, c)
 		} else {
-			credentialNames = append(credentialNames, c)
+			credentialsNames = append(credentialsNames, c)
 		}
 	}
 
 	if input.OnlyCredentials {
-		for _, c := range credentialNames {
+		for _, c := range credentialsNames {
 			fmt.Printf("%s\n", c)
 		}
 		return
@@ -106,10 +106,10 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 		config := vault.Config{}
 		configLoader.LoadFromProfile(profileName, &config)
 
-		if contains(credentialNames, config.CredentialName) {
-			fmt.Fprintf(w, "%s\t", config.CredentialName)
-		} else if config.CredentialName != "" {
-			fmt.Fprintf(w, "[%s missing]\t", config.CredentialName)
+		if contains(credentialsNames, config.CredentialsName) {
+			fmt.Fprintf(w, "%s\t", config.CredentialsName)
+		} else if config.CredentialsName != "" {
+			fmt.Fprintf(w, "[%s missing]\t", config.CredentialsName)
 		} else {
 			fmt.Fprintf(w, "-\t")
 		}
@@ -133,7 +133,7 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 	}
 
 	// show credentials that don't have profiles
-	for _, c := range credentialNames {
+	for _, c := range credentialsNames {
 		profileConfig := vault.Config{}
 		err := configLoader.LoadFromProfile(c, &profileConfig)
 		if err != nil {

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -101,9 +101,9 @@ func LsCommand(app *kingpin.Application, input LsCommandInput) {
 	for _, profile := range awsConfig.Profiles() {
 		fmt.Fprintf(w, "%s\t", profile.Name)
 
-		source, _ := awsConfig.SourceProfile(profile.Name)
-		if contains(source.Name, credentialNames) {
-			fmt.Fprintf(w, "%s\t", source.Name)
+		c := profile.CredentialName()
+		if contains(c, credentialNames) {
+			fmt.Fprintf(w, "%s\t", c)
 		} else {
 			fmt.Fprintf(w, "-\t")
 		}

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -39,7 +39,7 @@ func ConfigureRemoveCommand(app *kingpin.Application) {
 
 func RemoveCommand(app *kingpin.Application, input RemoveCommandInput) {
 	if !input.SessionsOnly {
-		provider := &vault.KeyringProvider{Keyring: input.Keyring, CredentialName: input.ProfileName}
+		provider := &vault.KeyringProvider{Keyring: input.Keyring, CredentialsName: input.ProfileName}
 		r, err := prompt.TerminalPrompt(fmt.Sprintf("Delete credentials for profile %q? (Y|n)", input.ProfileName))
 		if err != nil {
 			app.Fatalf(err.Error())

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -23,7 +23,7 @@ func ConfigureRemoveCommand(app *kingpin.Application) {
 
 	cmd.Arg("profile", "Name of the profile").
 		Required().
-		HintAction(ProfileNames).
+		HintAction(awsConfigFile.ProfileNames).
 		StringVar(&input.ProfileName)
 
 	cmd.Flag("sessions-only", "Only remove sessions, leave credentials intact").
@@ -55,11 +55,7 @@ func RemoveCommand(app *kingpin.Application, input RemoveCommandInput) {
 		fmt.Printf("Deleted credentials.\n")
 	}
 
-	sessions, err := vault.NewKeyringSessions(input.Keyring, awsConfig)
-	if err != nil {
-		app.Fatalf(err.Error())
-		return
-	}
+	sessions := vault.NewKeyringSessions(input.Keyring)
 
 	n, err := sessions.Delete(input.ProfileName)
 	if err != nil {

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -23,7 +23,7 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 	cmd := app.Command("rotate", "Rotates credentials")
 	cmd.Arg("profile", "Name of the profile").
 		Required().
-		HintAction(ProfileNames).
+		HintAction(awsConfigFile.ProfileNames).
 		StringVar(&input.ProfileName)
 
 	cmd.Flag("mfa-token", "The mfa token to use").
@@ -44,17 +44,17 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 
 func RotateCommand(app *kingpin.Application, input RotateCommandInput) {
 	rotator := vault.Rotator{
-		Keyring:   input.Keyring,
-		MfaToken:  input.MfaToken,
-		MfaSerial: input.MfaSerial,
-		MfaPrompt: input.MfaPrompt,
-		Config:    awsConfig,
+		Keyring: input.Keyring,
+		// MfaToken: input.MfaToken,
+		// MfaSerial: input.MfaSerial,
+		// MfaPrompt: input.MfaPrompt,
+		// Config:    awsConfig,
 	}
 
 	fmt.Printf("Rotating credentials for profile %q (takes 10-20 seconds)\n", input.ProfileName)
 
 	if err := rotator.Rotate(input.ProfileName); err != nil {
-		app.Fatalf(awsConfig.FormatCredentialError(err, input.ProfileName))
+		app.Fatalf(awsConfigFile.FormatCredentialError(err, input.ProfileName))
 		return
 	}
 

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -29,8 +29,11 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 		StringVar(&input.Config.MfaToken)
 
 	cmd.Flag("mfa-serial", "The identification number of the MFA device to use").
-		Envar("AWS_MFA_SERIAL").
 		StringVar(&input.Config.MfaSerial)
+
+	cmd.Flag("no-session", "Use root credentials, no session created").
+		Short('n').
+		BoolVar(&input.Config.NoSession)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		input.Config.MfaPrompt = prompt.Method(GlobalFlags.PromptDriver)
@@ -48,7 +51,8 @@ func RotateCommand(app *kingpin.Application, input RotateCommandInput) {
 
 	fmt.Printf("Rotating credentials for profile %q (takes 10-20 seconds)\n", input.ProfileName)
 	if err := vault.Rotate(input.ProfileName, input.Keyring, &input.Config); err != nil {
-		app.Fatalf(awsConfigFile.FormatCredentialError(err, input.ProfileName))
+		fmt.Println("Rotation failed. Try using --no-session")
+		app.Fatalf(err.Error())
 		return
 	}
 

--- a/vault/config.go
+++ b/vault/config.go
@@ -349,12 +349,14 @@ type Config struct {
 func (c *Config) Validate() error {
 	if c.SessionDuration < MinSessionDuration {
 		return errors.New("Minimum session duration is " + MinSessionDuration.String())
-	} else if c.SessionDuration > MaxSessionDuration {
+	}
+	if c.SessionDuration > MaxSessionDuration {
 		return errors.New("Maximum session duration is " + MaxSessionDuration.String())
 	}
 	if c.AssumeRoleDuration < MinAssumeRoleDuration {
 		return errors.New("Minimum duration for assumed roles is " + MinAssumeRoleDuration.String())
-	} else if c.AssumeRoleDuration > MaxAssumeRoleDuration {
+	}
+	if c.AssumeRoleDuration > MaxAssumeRoleDuration {
 		return errors.New("Maximum duration for assumed roles is " + MaxAssumeRoleDuration.String())
 	}
 

--- a/vault/config.go
+++ b/vault/config.go
@@ -191,25 +191,6 @@ func (c *ConfigFile) Add(profile ProfileSection) error {
 	return c.iniFile.SaveTo(c.Path)
 }
 
-// FormatCredentialError formats errors with some user friendly context
-func (c *ConfigFile) FormatCredentialError(err error, profileName string) string {
-	// profile, _ := c.Profile(profileName)
-
-	sourceDescr := profileName
-	// if profile.CredentialName != profileName {
-	// 	sourceDescr = fmt.Sprintf("%s (source profile for %s)", profile.CredentialName, profileName)
-	// }
-
-	// if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
-	// 	return fmt.Sprintf(
-	// 		"No credentials found for profile %s.\n"+
-	// 			"Use 'aws-vault add %s' to set up credentials or 'aws-vault list' to see what credentials exist",
-	// 		sourceDescr, profile.CredentialName)
-	// }
-
-	return fmt.Sprintf("Failed to get credentials for %s: %v", sourceDescr, err)
-}
-
 // ProfileNames returns a slice of profile names from the AWS config
 func (c *ConfigFile) ProfileNames() []string {
 	var profileNames []string
@@ -253,12 +234,12 @@ func (c *ConfigLoader) populateFromDefaults(config *Config) {
 
 func (c *ConfigLoader) populateFromConfigFile(config *Config, profileName string) error {
 	if !c.visitProfile(profileName) {
-		fmt.Errorf("Loop detected in config file for profile '%s'", profileName)
+		return fmt.Errorf("Loop detected in config file for profile '%s'", profileName)
 	}
 
 	psection, ok := c.File.ProfileSection(profileName)
 	if !ok {
-		fmt.Errorf("Can't find profile '%s' in config file", profileName)
+		return fmt.Errorf("Can't find profile '%s' in config file", profileName)
 	}
 
 	if config.MfaSerial == "" {

--- a/vault/config.go
+++ b/vault/config.go
@@ -129,8 +129,8 @@ type ProfileSection struct {
 	ParentProfile   string `ini:"parent_profile,omitempty"`
 }
 
-// Profiles returns all the profiles in the config
-func (c *ConfigFile) profiles() []ProfileSection {
+// Profiles returns all the profile sections in the config
+func (c *ConfigFile) ProfileSections() []ProfileSection {
 	var result []ProfileSection
 
 	if c.iniFile == nil {
@@ -194,7 +194,7 @@ func (c *ConfigFile) Add(profile ProfileSection) error {
 // ProfileNames returns a slice of profile names from the AWS config
 func (c *ConfigFile) ProfileNames() []string {
 	var profileNames []string
-	for _, profile := range c.profiles() {
+	for _, profile := range c.ProfileSections() {
 		profileNames = append(profileNames, profile.Name)
 	}
 	return profileNames
@@ -239,7 +239,8 @@ func (c *ConfigLoader) populateFromConfigFile(config *Config, profileName string
 
 	psection, ok := c.File.ProfileSection(profileName)
 	if !ok {
-		return fmt.Errorf("Can't find profile '%s' in config file", profileName)
+		// ignore missing profiles
+		log.Printf("Can't find profile '%s' in config file", profileName)
 	}
 
 	if config.MfaSerial == "" {

--- a/vault/config.go
+++ b/vault/config.go
@@ -259,9 +259,9 @@ func (c *ConfigLoader) populateFromConfigFile(config *Config, profileName string
 	}
 
 	if psection.SourceProfile != "" {
-		config.CredentialName = psection.SourceProfile
+		config.CredentialsName = psection.SourceProfile
 	} else {
-		config.CredentialName = profileName
+		config.CredentialsName = profileName
 	}
 
 	if psection.ParentProfile != "" {
@@ -311,8 +311,8 @@ func (c *ConfigLoader) LoadFromProfile(profileName string, config *Config) error
 }
 
 type Config struct {
-	ProfileName    string
-	CredentialName string
+	ProfileName     string
+	CredentialsName string
 
 	MfaSerial       string
 	RoleARN         string

--- a/vault/config.go
+++ b/vault/config.go
@@ -240,7 +240,7 @@ func (c *ConfigLoader) populateFromConfigFile(config *Config, profileName string
 	psection, ok := c.File.ProfileSection(profileName)
 	if !ok {
 		// ignore missing profiles
-		log.Printf("Can't find profile '%s' in config file", profileName)
+		log.Printf("Profile '%s' missing in config file", profileName)
 	}
 
 	if config.MfaSerial == "" {

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -114,7 +114,7 @@ func TestConfigParsingDefault(t *testing.T) {
 	}
 }
 
-func TestSourceProfileFromConfig(t *testing.T) {
+func TestCredentialNameFromConfig(t *testing.T) {
 	f := newConfigFile(t, exampleConfig)
 	defer os.Remove(f)
 
@@ -123,13 +123,13 @@ func TestSourceProfileFromConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	source, ok := cfg.SourceProfile("withmfa")
+	profile, ok := cfg.Profile("withmfa")
 	if !ok {
-		t.Fatalf("Should have found a source")
+		t.Fatalf("Should have found a profile")
 	}
 
-	if source.Name != "user2" {
-		t.Fatalf("Expected source name %q, got %q", "user2", source.Name)
+	if profile.CredentialName() != "user2" {
+		t.Fatalf("Expected CredentialName name %q, got %q", "user2", profile.SourceProfile)
 	}
 }
 

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -69,24 +69,24 @@ func TestConfigParsingProfiles(t *testing.T) {
 	}
 
 	var testCases = []struct {
-		expected vault.Profile
+		expected vault.ProfileSection
 		ok       bool
 	}{
-		{vault.Profile{Name: "user2", Region: "us-east-1"}, true},
-		{vault.Profile{Name: "withsource", SourceProfile: "user2", Region: "us-east-1"}, true},
-		{vault.Profile{
+		{vault.ProfileSection{Name: "user2", Region: "us-east-1"}, true},
+		{vault.ProfileSection{Name: "withsource", SourceProfile: "user2", Region: "us-east-1"}, true},
+		{vault.ProfileSection{
 			Name:          "withmfa",
 			SourceProfile: "user2",
 			Region:        "us-east-1",
 			RoleARN:       "arn:aws:iam::4451234513441615400570:role/aws_admin",
-			MFASerial:     "arn:aws:iam::1234513441:mfa/blah",
+			MfaSerial:     "arn:aws:iam::1234513441:mfa/blah",
 		}, true},
-		{vault.Profile{Name: "nopenotthere"}, false},
+		{vault.ProfileSection{Name: "nopenotthere"}, false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("profile_%s", tc.expected.Name), func(t *testing.T) {
-			actual, ok := cfg.Profile(tc.expected.Name)
+			actual, ok := cfg.ProfileSection(tc.expected.Name)
 			if ok != tc.ok {
 				t.Fatalf("Expected second param to be %v, got %v", tc.ok, ok)
 			}
@@ -106,12 +106,12 @@ func TestConfigParsingDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	def, ok := cfg.Profile("default")
+	def, ok := cfg.ProfileSection("default")
 	if !ok {
 		t.Fatalf("Expected to find default profile")
 	}
 
-	expected := vault.Profile{
+	expected := vault.ProfileSection{
 		Name:   "default",
 		Region: "us-west-2",
 	}
@@ -130,7 +130,7 @@ func TestCredentialNameFromConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	profile, ok := cfg.Profile("withmfa")
+	profile, ok := cfg.ProfileSection("withmfa")
 	if !ok {
 		t.Fatalf("Should have found a profile")
 	}
@@ -149,12 +149,12 @@ func TestProfilesFromConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	profiles := cfg.Profiles()
-	expected := []vault.Profile{
-		vault.Profile{Name: "default", Region: "us-west-2"},
-		vault.Profile{Name: "user2", Region: "us-east-1"},
-		vault.Profile{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
-		vault.Profile{Name: "withmfa", MFASerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", SourceProfile: "user2"},
+	profiles, _ := cfg.profiles()
+	expected := []vault.ProfileSection{
+		vault.ProfileSection{Name: "default", Region: "us-west-2"},
+		vault.ProfileSection{Name: "user2", Region: "us-east-1"},
+		vault.ProfileSection{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
+		vault.ProfileSection{Name: "withmfa", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", SourceProfile: "user2"},
 	}
 
 	if !reflect.DeepEqual(expected, profiles) {
@@ -171,9 +171,9 @@ func TestAddProfileToExistingConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = cfg.Add(vault.Profile{
+	err = cfg.Add(vault.ProfileSection{
 		Name:          "llamas",
-		MFASerial:     "testserial",
+		MfaSerial:     "testserial",
 		Region:        "us-east-1",
 		SourceProfile: "default",
 	})
@@ -181,13 +181,13 @@ func TestAddProfileToExistingConfig(t *testing.T) {
 		t.Fatalf("Error adding profile: %#v", err)
 	}
 
-	profiles := cfg.Profiles()
-	expected := []vault.Profile{
-		vault.Profile{Name: "default", Region: "us-west-2"},
-		vault.Profile{Name: "user2", Region: "us-east-1"},
-		vault.Profile{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
-		vault.Profile{Name: "withmfa", MFASerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", SourceProfile: "user2"},
-		vault.Profile{Name: "llamas", MFASerial: "testserial", Region: "us-east-1", SourceProfile: "default"},
+	profiles, _ := cfg.profiles()
+	expected := []vault.ProfileSection{
+		vault.ProfileSection{Name: "default", Region: "us-west-2"},
+		vault.ProfileSection{Name: "user2", Region: "us-east-1"},
+		vault.ProfileSection{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
+		vault.ProfileSection{Name: "withmfa", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", SourceProfile: "user2"},
+		vault.ProfileSection{Name: "llamas", MfaSerial: "testserial", Region: "us-east-1", SourceProfile: "default"},
 	}
 
 	if !reflect.DeepEqual(expected, profiles) {
@@ -204,9 +204,9 @@ func TestAddProfileToExistingNestedConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = cfg.Add(vault.Profile{
+	err = cfg.Add(vault.ProfileSection{
 		Name:      "llamas",
-		MFASerial: "testserial",
+		MfaSerial: "testserial",
 		Region:    "us-east-1",
 	})
 	if err != nil {

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -121,7 +121,7 @@ func TestConfigParsingDefault(t *testing.T) {
 	}
 }
 
-func TestCredentialNameFromConfig(t *testing.T) {
+func TestCredentialsNameFromConfig(t *testing.T) {
 	f := newConfigFile(t, exampleConfig)
 	defer os.Remove(f)
 
@@ -135,8 +135,8 @@ func TestCredentialNameFromConfig(t *testing.T) {
 		t.Fatalf("Should have found a profile")
 	}
 
-	if profile.CredentialName() != "user2" {
-		t.Fatalf("Expected CredentialName name %q, got %q", "user2", profile.SourceProfile)
+	if profile.CredentialsName() != "user2" {
+		t.Fatalf("Expected CredentialsName name %q, got %q", "user2", profile.SourceProfile)
 	}
 }
 

--- a/vault/getuser.go
+++ b/vault/getuser.go
@@ -13,9 +13,7 @@ var getUserErrorRegexp = regexp.MustCompile(`^AccessDenied: User: arn:aws:iam::(
 
 // GetUsernameFromSession returns the IAM username (or root) associated with the current aws session
 func GetUsernameFromSession(sess *session.Session) (string, error) {
-	client := iam.New(sess)
-
-	resp, err := client.GetUser(&iam.GetUserInput{})
+	resp, err := iam.New(sess).GetUser(&iam.GetUserInput{})
 	if err != nil {
 		// Even if GetUser fails, the current user is included in the error. This happens when you have o IAM permissions
 		// on the master credentials, but have permission to use assumeRole later

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -10,7 +10,7 @@ import (
 )
 
 type KeyringProvider struct {
-	Keyring        keyring.Keyring
+	Keyring         keyring.Keyring
 	CredentialsName string
 }
 

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -12,7 +12,6 @@ import (
 type KeyringProvider struct {
 	Keyring        keyring.Keyring
 	CredentialName string
-	Region         string
 }
 
 func (p *KeyringProvider) IsExpired() bool {

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -11,7 +11,7 @@ import (
 
 type KeyringProvider struct {
 	Keyring        keyring.Keyring
-	CredentialName string
+	CredentialsName string
 }
 
 func (p *KeyringProvider) IsExpired() bool {
@@ -19,8 +19,8 @@ func (p *KeyringProvider) IsExpired() bool {
 }
 
 func (p *KeyringProvider) Retrieve() (val credentials.Value, err error) {
-	log.Printf("Looking up keyring for %s", p.CredentialName)
-	item, err := p.Keyring.Get(p.CredentialName)
+	log.Printf("Looking up keyring for %s", p.CredentialsName)
+	item, err := p.Keyring.Get(p.CredentialsName)
 	if err != nil {
 		log.Println("Error from keyring", err)
 		return val, err
@@ -38,8 +38,8 @@ func (p *KeyringProvider) Store(val credentials.Value) error {
 	}
 
 	return p.Keyring.Set(keyring.Item{
-		Key:   p.CredentialName,
-		Label: fmt.Sprintf("aws-vault (%s)", p.CredentialName),
+		Key:   p.CredentialsName,
+		Label: fmt.Sprintf("aws-vault (%s)", p.CredentialsName),
 		Data:  bytes,
 
 		// specific Keychain settings
@@ -48,5 +48,5 @@ func (p *KeyringProvider) Store(val credentials.Value) error {
 }
 
 func (p *KeyringProvider) Delete() error {
-	return p.Keyring.Remove(p.CredentialName)
+	return p.Keyring.Remove(p.CredentialsName)
 }

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -1,0 +1,53 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/99designs/keyring"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+type KeyringProvider struct {
+	Keyring        keyring.Keyring
+	CredentialName string
+	Region         string
+}
+
+func (p *KeyringProvider) IsExpired() bool {
+	return false
+}
+
+func (p *KeyringProvider) Retrieve() (val credentials.Value, err error) {
+	log.Printf("Looking up keyring for %s", p.CredentialName)
+	item, err := p.Keyring.Get(p.CredentialName)
+	if err != nil {
+		log.Println("Error from keyring", err)
+		return val, err
+	}
+	if err = json.Unmarshal(item.Data, &val); err != nil {
+		return val, fmt.Errorf("Invalid data in keyring: %v", err)
+	}
+	return val, err
+}
+
+func (p *KeyringProvider) Store(val credentials.Value) error {
+	bytes, err := json.Marshal(val)
+	if err != nil {
+		return err
+	}
+
+	return p.Keyring.Set(keyring.Item{
+		Key:   p.CredentialName,
+		Label: fmt.Sprintf("aws-vault (%s)", p.CredentialName),
+		Data:  bytes,
+
+		// specific Keychain settings
+		KeychainNotTrustApplication: true,
+	})
+}
+
+func (p *KeyringProvider) Delete() error {
+	return p.Keyring.Remove(p.CredentialName)
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -244,19 +244,19 @@ func (p *VaultProvider) getMasterCreds() (credentials.Value, error) {
 		return *p.MasterCreds, nil
 	}
 
-	source, _ := p.Config.SourceProfile(p.credentialName)
+	profile, _ := p.Config.Profile(p.credentialName)
 
-	val, ok := p.creds[source.Name]
+	val, ok := p.creds[profile.SourceProfile]
 	if !ok {
-		creds := credentials.NewCredentials(&KeyringProvider{Keyring: p.keyring, CredentialName: source.Name})
+		creds := credentials.NewCredentials(&KeyringProvider{Keyring: p.keyring, CredentialName: profile.CredentialName()})
 
 		var err error
 		if val, err = creds.Get(); err != nil {
-			log.Printf("Failed to find credentials for profile %q in keyring", source.Name)
+			log.Printf("Failed to find credentials for profile %q in keyring", profile.CredentialName())
 			return val, err
 		}
 
-		p.creds[source.Name] = val
+		p.creds[profile.SourceProfile] = val
 	}
 
 	return val, nil
@@ -285,8 +285,8 @@ func (p *VaultProvider) getSessionToken(creds *credentials.Value) (sts.Credentia
 			Value: *creds,
 		}))))
 
-	source, _ := p.Config.SourceProfile(p.credentialName)
-	log.Printf("Getting new session token for profile %s", source.Name)
+	profile, _ := p.Config.Profile(p.credentialName)
+	log.Printf("Getting new session token for profile %s", profile.SourceProfile)
 
 	resp, err := client.GetSessionToken(params)
 	if err != nil {

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -196,8 +196,7 @@ func (p *VaultProvider) getSessionToken(creds *credentials.Value) (sts.Credentia
 	client := sts.New(
 		session.New(
 			aws.NewConfig().WithCredentials(
-				credentials.NewCredentials(&credentials.StaticProvider{Value: *creds}),
-			)))
+				credentials.NewCredentials(&credentials.StaticProvider{Value: *creds}))))
 
 	log.Printf("Getting new session token for profile %s", p.config.CredentialName)
 
@@ -220,12 +219,10 @@ func (p *VaultProvider) roleSessionName() string {
 
 // assumeRoleFromSession takes a session created with GetSessionToken and uses that to assume a role
 func (p *VaultProvider) assumeRoleFromSession(creds sts.Credentials, config *Config) (sts.Credentials, error) {
-	client := sts.New(session.New(aws.NewConfig().
-		WithCredentials(credentials.NewStaticCredentials(
-			*creds.AccessKeyId,
-			*creds.SecretAccessKey,
-			*creds.SessionToken,
-		))))
+	client := sts.New(
+		session.New(
+			aws.NewConfig().WithCredentials(
+				credentials.NewStaticCredentials(*creds.AccessKeyId, *creds.SecretAccessKey, *creds.SessionToken))))
 
 	input := &sts.AssumeRoleInput{
 		RoleArn:         aws.String(config.RoleARN),

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -14,7 +14,6 @@ import (
 
 const DefaultExpirationWindow = 5 * time.Minute
 
-// VaultProvider implements
 type VaultProvider struct {
 	credentials.Expiry
 	keyring     keyring.Keyring

--- a/vault/rotator.go
+++ b/vault/rotator.go
@@ -18,7 +18,7 @@ func Rotate(profileName string, keyring keyring.Keyring, config *Config) error {
 	// Get the existing credentials
 
 	provider := &KeyringProvider{
-		Keyring:        keyring,
+		Keyring:         keyring,
 		CredentialsName: config.CredentialsName,
 	}
 

--- a/vault/rotator.go
+++ b/vault/rotator.go
@@ -19,7 +19,7 @@ func Rotate(profileName string, keyring keyring.Keyring, config *Config) error {
 
 	provider := &KeyringProvider{
 		Keyring:        keyring,
-		CredentialName: config.CredentialName,
+		CredentialsName: config.CredentialsName,
 	}
 
 	oldMasterCreds, err := provider.Retrieve()

--- a/vault/sessions.go
+++ b/vault/sessions.go
@@ -33,7 +33,6 @@ func IsSessionKey(s string) bool {
 	return false
 }
 
-// func parseSessionKey(key string, conf *ConfigLoader) (KeyringSession, error) {
 func parseSessionKey(key string) (KeyringSession, error) {
 	matches := sessionKeyPattern.FindStringSubmatch(key)
 	if len(matches) == 0 {
@@ -51,9 +50,8 @@ func parseSessionKey(key string) (KeyringSession, error) {
 	if err != nil {
 		return KeyringSession{}, err
 	}
-	// profile, _ := conf.Profile(string(profileName))
+
 	return KeyringSession{
-		// Profile:    profile,
 		ProfileName: string(profileName),
 		Key:         key,
 		Expiration:  time.Unix(tsInt, 0),
@@ -83,16 +81,16 @@ func (ks KeyringSession) IsExpired() bool {
 }
 
 type KeyringSessions struct {
-	Keyring keyring.Keyring
+	keyring keyring.Keyring
 }
 
 func NewKeyringSessions(k keyring.Keyring) *KeyringSessions {
-	return &KeyringSessions{Keyring: k}
+	return &KeyringSessions{keyring: k}
 }
 
 func (s *KeyringSessions) Sessions() ([]KeyringSession, error) {
 	log.Printf("Looking up all keys in keyring")
-	keys, err := s.Keyring.Keys()
+	keys, err := s.keyring.Keys()
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +102,7 @@ func (s *KeyringSessions) Sessions() ([]KeyringSession, error) {
 			ks, err := parseSessionKey(k)
 			if err != nil || ks.IsExpired() {
 				log.Printf("Session %s is obsolete, attempting deleting", k)
-				if err := s.Keyring.Remove(k); err != nil {
+				if err := s.keyring.Remove(k); err != nil {
 					log.Printf("Error deleting session: %v", err)
 				}
 				continue
@@ -118,16 +116,16 @@ func (s *KeyringSessions) Sessions() ([]KeyringSession, error) {
 }
 
 // Retrieve searches sessions for specific profile, expects the profile to be provided, not the source
-func (s *KeyringSessions) Retrieve(profile string, mfaSerial string) (creds sts.Credentials, err error) {
-	log.Printf("Looking for sessions for %s", profile)
+func (s *KeyringSessions) Retrieve(profileName string, mfaSerial string) (creds sts.Credentials, err error) {
+	log.Printf("Looking for sessions for %s", profileName)
 	sessions, err := s.Sessions()
 	if err != nil {
 		return creds, err
 	}
 
 	for _, session := range sessions {
-		if session.ProfileName == profile && session.MfaSerial == mfaSerial {
-			item, err := s.Keyring.Get(session.Key)
+		if session.ProfileName == profileName && session.MfaSerial == mfaSerial {
+			item, err := s.keyring.Get(session.Key)
 			if err != nil {
 				return creds, err
 			}
@@ -139,12 +137,11 @@ func (s *KeyringSessions) Retrieve(profile string, mfaSerial string) (creds sts.
 			// double check the actual expiry time
 			if creds.Expiration.Before(time.Now()) {
 				log.Printf("Session %q is expired, deleting", session.Key)
-				if err = s.Keyring.Remove(session.ProfileName); err != nil {
+				if err = s.keyring.Remove(session.ProfileName); err != nil {
 					return creds, err
 				}
 			}
 
-			// success!
 			return creds, nil
 		}
 	}
@@ -162,7 +159,7 @@ func (s *KeyringSessions) Store(profile string, mfaSerial string, session sts.Cr
 	key := formatSessionKey(profile, mfaSerial, session.Expiration)
 	log.Printf("Writing session for %s to keyring: %q", profile, key)
 
-	return s.Keyring.Set(keyring.Item{
+	return s.keyring.Set(keyring.Item{
 		Key:         key,
 		Label:       "aws-vault session for " + profile,
 		Description: "aws-vault session for " + profile,
@@ -184,7 +181,7 @@ func (s *KeyringSessions) Delete(profile string) (n int, err error) {
 	for _, session := range sessions {
 		if session.ProfileName == profile {
 			log.Printf("Session %q matches profile %q", session.Key, profile)
-			if err = s.Keyring.Remove(session.Key); err != nil {
+			if err = s.keyring.Remove(session.Key); err != nil {
 				return n, err
 			}
 			n++


### PR DESCRIPTION
Fixes #448.

#445 removed the profile chaining behaviour for `mfa_device`, as it broke compatibility.

This PR introduces a `parent_profile` parameter to specify wanted inheritance behaviour. This gives users the ability to build up more complex configurations without the need for templating.

Using `parent_profile` allows a profile to import all of the config and credentials from the specified parent profile. This includes `mfa_serial` but also extends to other config options. `source_profile` retains its original semantics of importing credentials only, which means compatibility with aws cli and the SDK.

It should be noted that aws-cli and the AWS SDK does not recognise `parent_profile` as a variable and will be ignored

In order to achieve this, I needed to refactor parts of the codebase 
- All config handling has been moved to `ConfigLoader`
- `VaultCredentials` has been removed, it is unnecessary
- `VaultProvider` has been simplified
- rotation has been simplified, this also adds `--no-session` to rotate

