### PR TITLE
Add more --server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ The credentials are exposed to the subprocess in one of two ways:
 
 The default is to use environment variables, but you can opt-in to the local instance metadata server with the `--server` flag on the `exec` command.
 
+If you already have set any of the below environment variables and you want to use `--server` remember to delete them previosuly from your System Environment Variables. **Otherwise you always will need to execute all commands that requires authentication with the `aws-vault` first** , e.g : `aws-vault ec2 describe-instances`, since the vault will use the local variables if any as primary option:
+
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+AWS_SECURITY_TOKEN
+AWS_SESSION_TOKEN
+
 ### Assuming Roles
 
 [Best-practice](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#delegate-using-roles) is to [create Roles to delegate permissions](https://docs.aws.amazon.com/cli/latest/userguide/cli-roles.html).

--- a/README.md
+++ b/README.md
@@ -73,13 +73,6 @@ The credentials are exposed to the subprocess in one of two ways:
 
 The default is to use environment variables, but you can opt-in to the local instance metadata server with the `--server` flag on the `exec` command.
 
-If you already have set any of the below environment variables and you want to use `--server` remember to delete them previosuly from your System Environment Variables. **Otherwise you always will need to execute all commands that requires authentication with the `aws-vault` first** , e.g : `aws-vault ec2 describe-instances`, since the vault will use the local variables if any as primary option:
-
-AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY
-AWS_SECURITY_TOKEN
-AWS_SESSION_TOKEN
-
 ### Assuming Roles
 
 [Best-practice](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#delegate-using-roles) is to [create Roles to delegate permissions](https://docs.aws.amazon.com/cli/latest/userguide/cli-roles.html).

--- a/USAGE.md
+++ b/USAGE.md
@@ -334,10 +334,18 @@ would have on an EC2 instance. When your application will want to connect to AWS
 credentials (typically in env variables), it will instead contact this server that will issue a new
 set of temporary credentials (using the same profile as the one the server was started with). This
 server will work only for the duration of the session (`--session-ttl`).  
+
 Note that this approach has the **major drawback** that while this `aws-vault` server runs, any
 application wanting to **connect** to AWS will be able to do so **implicitely**, with the profile the
 server was started with. Thanks to `aws-vault`, the credentials are not exposed, but the ability to
 use them to connect to AWS is!
+
+Also, note that if you already have set any of the below environment variables and you want to use `--server` remember to delete them previosuly from your System Environment Variables. **Otherwise you always will need to execute all commands that requires authentication with the `aws-vault` first** , e.g : `aws-vault ec2 describe-instances`, since the vault will use the local variables if any as primary option:
+
+* AWS_ACCESS_KEY_ID
+* AWS_SECRET_ACCESS_KEY
+* AWS_SECURITY_TOKEN
+* AWS_SESSION_TOKEN
 
 ### Being able to perform certain STS operations
 


### PR DESCRIPTION
We have faced an issue with that change explains and we think is a good point to share it.

We had a machine that for some reason had the environment variables previously set and after run the `aws-vault`in server mode we cannot run any aws command without the `aws-vault`first.