### PR TITLE
Do a real exec on execution

### DIFF
--- a/cli/exec_default.go
+++ b/cli/exec_default.go
@@ -1,0 +1,42 @@
+// +build !linux,!darwin
+
+package cli
+
+import (
+	"errors"
+	"os"
+	osexec "os/exec"
+	"os/signal"
+	"syscall"
+)
+
+func exec(command string, args []string, env []string) error {
+	cmd := osexec.Command(command, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = env
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan)
+
+	if err := cmd.Start(); err != nil {
+		return errors.New("Failed to start command: %v", err)
+	}
+
+	go func() {
+		for {
+			sig := <-sigChan
+			cmd.Process.Signal(sig)
+		}
+	}()
+
+	if err := cmd.Wait(); err != nil {
+		ecmd.Process.Signal(os.Kill)
+		return errors.New("Failed to wait for command termination: %v", err)
+	}
+
+	waitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	os.Exit(waitStatus.ExitStatus())
+	return nil
+}

--- a/cli/exec_unix.go
+++ b/cli/exec_unix.go
@@ -1,0 +1,21 @@
+// +build linux darwin
+
+package cli
+
+import (
+	osexec "os/exec"
+	"syscall"
+)
+
+func exec(command string, args []string, env []string) error {
+	argv0, err := osexec.LookPath(command)
+	if err != nil {
+		return err
+	}
+
+	argv := make([]string, 0, 1+len(args))
+	argv = append(argv, command)
+	argv = append(argv, args...)
+
+	return syscall.Exec(argv0, argv, env)
+}


### PR DESCRIPTION
In order to pass through signals to the new process, a real exec syscall should be done.

I think this should fix #453 
