### PR TITLE
Ignore case of section and key names when parsing config.

### DIFF
--- a/vault/config.go
+++ b/vault/config.go
@@ -111,6 +111,7 @@ func (c *ConfigFile) parseFile() error {
 	log.Printf("Parsing config file %s", c.Path)
 	f, err := ini.LoadSources(ini.LoadOptions{
 		AllowNestedValues: true,
+		Insensitive:       true,
 	}, c.Path)
 	if err != nil {
 		return fmt.Errorf("Error parsing config file %q: %v", c.Path, err)

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -28,7 +28,7 @@ region=us-east-1
 [profile withmfa]
 source_profile=user2
 role_arn=arn:aws:iam::4451234513441615400570:role/aws_admin
-mfa_serial=arn:aws:iam::1234513441:mfa/blah
+mfa_Serial=arn:aws:iam::1234513441:mfa/blah
 region=us-east-1
 duration_seconds=1200
 

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -25,7 +25,7 @@ output=text
 source_profile=user2
 region=us-east-1
 
-[profile withmfa]
+[profile withMFA]
 source_profile=user2
 role_arn=arn:aws:iam::4451234513441615400570:role/aws_admin
 mfa_Serial=arn:aws:iam::1234513441:mfa/blah
@@ -57,6 +57,26 @@ func newConfigFile(t *testing.T, b []byte) string {
 		t.Fatal(err)
 	}
 	return f.Name()
+}
+
+func TestConfigCaseInsensitivity(t *testing.T) {
+	f := newConfigFile(t, exampleConfig)
+	defer os.Remove(f)
+
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	def, ok := cfg.ProfileSection("withmfa")
+	if !ok {
+		t.Fatalf("Expected to match profile withMFA")
+	}
+
+	expectedMfaSerial := "arn:aws:iam::1234513441:mfa/blah"
+	if def.MfaSerial != expectedMfaSerial {
+		t.Fatalf("Expected %s, got %s", expectedMfaSerial, def.MfaSerial)
+	}
 }
 
 func TestConfigParsingProfiles(t *testing.T) {


### PR DESCRIPTION
This PR simply allows for the user to specify upper or lower (or mixed case) section and key names in their config. I raise it as I wasted 3 hours of my life wondering why my aws-vault generated session was invalid before realising mfa_**S**erial=arn:aws:iam::... was not being read.
The aws cli also ignores case. I've proven this by running 'aws configure' then 'aws_access_key_id=AK...' to '**A**ws_access_key_id=AK...' and it still reads the credentials. 

I've modified the test for config to handle this use-case.

There is another related issue to address: a user specifying a token value, but not an MFA serial, is returned an invalid session rather than being warned that there's no point specifying token value if serial isn't supplied. I'll try and get a PR out to handle that.