### PR TITLE
exec --help describe default command

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -68,7 +68,7 @@ func ConfigureExecCommand(app *kingpin.Application) {
 		HintAction(awsConfigFile.ProfileNames).
 		StringVar(&input.ProfileName)
 
-	cmd.Arg("cmd", "Command to execute").
+	cmd.Arg("cmd", "Command to execute, defaults to $SHELL").
 		Default(os.Getenv("SHELL")).
 		StringVar(&input.Command)
 


### PR DESCRIPTION
makes it obvious to new users that exec defaults to running the shell as a subprocess.