### PR TITLE
Update session duration defaults and the CLI flags

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -56,31 +56,27 @@ parent_profile = work
 
 ## Environment variables
 
-The following environment variables can be set to override the default flag
-values of `aws-vault` and its subcommands.
-
-For the `aws-vault` command:
+To configure the default flag values of `aws-vault` and its subcommands:
 * `AWS_VAULT_BACKEND`: Secret backend to use (see the flag `--backend`)
 * `AWS_VAULT_KEYCHAIN_NAME`: Name of macOS keychain to use (see the flag `--keychain`)
 * `AWS_VAULT_PROMPT`: Prompt driver to use (see the flag `--prompt`)
 * `AWS_VAULT_PASS_PASSWORD_STORE_DIR`: Pass password store directory (see the flag `--pass-dir`)
 * `AWS_VAULT_PASS_CMD`: Name of the pass executable (see the flag `--pass-cmd`)
 * `AWS_VAULT_PASS_PREFIX`: Prefix to prepend to the item path stored in pass (see the flag `--pass-prefix`)
+* `AWS_VAULT_FILE_PASSPHRASE`: Password for the "file" password store
+* `AWS_CONFIG_FILE`: The location of the AWS config file
 
-For the `exec` subcommand:
-* `AWS_SESSION_TTL`:  Expiration time for aws session (see the flag `--session-ttl`)
-* `AWS_ASSUME_ROLE_TTL`: Expiration time for aws assumed role (see the flag `--assume-role-ttl`)
-
-For the `aws-vault login` subcommand:
-* `AWS_FEDERATION_TOKEN_TTL`: Expiration time for aws console session (see the flag `--federation-token-ttl`)
-* `AWS_ASSUME_ROLE_TTL`: Expiration time for aws assumed role (see the flag `--assume-role-ttl`)
-
-For the `exec`, `login` and `rotate` subcommands:
+To override the AWS config file (used in the `exec`, `login` and `rotate` subcommands):
 * `AWS_REGION`: The AWS region
 * `AWS_DEFAULT_REGION`: The AWS region, applied only if `AWS_REGION` isn't set
 * `AWS_ROLE_ARN`: Specifies the ARN of an IAM role
 * `AWS_ROLE_SESSION_NAME`: Specifies the name to attach to the role session
 * `AWS_MFA_SERIAL`: The identification number of the MFA device to use
+
+To override session durations (used in `exec` and `login`):
+* `AWS_SESSION_TOKEN_TTL`: Expiration time for the `GetSessionToken` credentials. Defaults to 1h, or 8h when using `AssumeRole`
+* `AWS_ASSUME_ROLE_TTL`: Expiration time for the `AssumeRole` credentials. Defaults to 1h
+* `AWS_FEDERATION_TOKEN_TTL`: Expiration time for the `GetFederationToken` credentials. Defaults to 1h
 
 
 ## Managing Profiles

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -74,7 +74,7 @@ func TestConfigParsingProfiles(t *testing.T) {
 	}{
 		{vault.ProfileSection{Name: "user2", Region: "us-east-1"}, true},
 		{vault.ProfileSection{Name: "withsource", SourceProfile: "user2", Region: "us-east-1"}, true},
-		{vault.ProfileSection{Name: "withmfa", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: "1200", SourceProfile: "user2"}, true},
+		{vault.ProfileSection{Name: "withmfa", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2"}, true},
 		{vault.ProfileSection{Name: "nopenotthere"}, false},
 	}
 
@@ -150,7 +150,7 @@ func TestProfilesFromConfig(t *testing.T) {
 		vault.ProfileSection{Name: "default", Region: "us-west-2"},
 		vault.ProfileSection{Name: "user2", Region: "us-east-1"},
 		vault.ProfileSection{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
-		vault.ProfileSection{Name: "withmfa", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: "1200", SourceProfile: "user2"},
+		vault.ProfileSection{Name: "withmfa", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2"},
 		vault.ProfileSection{Name: "testparentprofile1", Region: "us-east-1"},
 		vault.ProfileSection{Name: "testparentprofile2", ParentProfile: "testparentprofile1"},
 	}
@@ -180,7 +180,7 @@ func TestAddProfileToExistingConfig(t *testing.T) {
 	}
 
 	profilesSections := cfg.ProfileSections()
-	expected := []vault.ProfileSection{vault.ProfileSection{Name: "default", MfaSerial: "", RoleARN: "", ExternalID: "", Region: "us-west-2", RoleSessionName: "", DurationSeconds: "", SourceProfile: "", ParentProfile: ""}, vault.ProfileSection{Name: "user2", MfaSerial: "", RoleARN: "", ExternalID: "", Region: "us-east-1", RoleSessionName: "", DurationSeconds: "", SourceProfile: "", ParentProfile: ""}, vault.ProfileSection{Name: "withsource", MfaSerial: "", RoleARN: "", ExternalID: "", Region: "us-east-1", RoleSessionName: "", DurationSeconds: "", SourceProfile: "user2", ParentProfile: ""}, vault.ProfileSection{Name: "withmfa", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", ExternalID: "", Region: "us-east-1", RoleSessionName: "", DurationSeconds: "1200", SourceProfile: "user2", ParentProfile: ""}, vault.ProfileSection{Name: "testparentprofile1", MfaSerial: "", RoleARN: "", ExternalID: "", Region: "us-east-1", RoleSessionName: "", DurationSeconds: "", SourceProfile: "", ParentProfile: ""}, vault.ProfileSection{Name: "testparentprofile2", MfaSerial: "", RoleARN: "", ExternalID: "", Region: "", RoleSessionName: "", DurationSeconds: "", SourceProfile: "", ParentProfile: "testparentprofile1"}, vault.ProfileSection{Name: "llamas", MfaSerial: "testserial", RoleARN: "", ExternalID: "", Region: "us-east-1", RoleSessionName: "", DurationSeconds: "", SourceProfile: "default", ParentProfile: ""}}
+	expected := []vault.ProfileSection{vault.ProfileSection{Name: "default", MfaSerial: "", RoleARN: "", ExternalID: "", Region: "us-west-2", RoleSessionName: "", DurationSeconds: 0, SourceProfile: "", ParentProfile: ""}, vault.ProfileSection{Name: "user2", MfaSerial: "", RoleARN: "", ExternalID: "", Region: "us-east-1", RoleSessionName: "", DurationSeconds: 0, SourceProfile: "", ParentProfile: ""}, vault.ProfileSection{Name: "withsource", MfaSerial: "", RoleARN: "", ExternalID: "", Region: "us-east-1", RoleSessionName: "", DurationSeconds: 0, SourceProfile: "user2", ParentProfile: ""}, vault.ProfileSection{Name: "withmfa", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", ExternalID: "", Region: "us-east-1", RoleSessionName: "", DurationSeconds: 1200, SourceProfile: "user2", ParentProfile: ""}, vault.ProfileSection{Name: "testparentprofile1", MfaSerial: "", RoleARN: "", ExternalID: "", Region: "us-east-1", RoleSessionName: "", DurationSeconds: 0, SourceProfile: "", ParentProfile: ""}, vault.ProfileSection{Name: "testparentprofile2", MfaSerial: "", RoleARN: "", ExternalID: "", Region: "", RoleSessionName: "", DurationSeconds: 0, SourceProfile: "", ParentProfile: "testparentprofile1"}, vault.ProfileSection{Name: "llamas", MfaSerial: "testserial", RoleARN: "", ExternalID: "", Region: "us-east-1", RoleSessionName: "", DurationSeconds: 0, SourceProfile: "default", ParentProfile: ""}}
 
 	if !reflect.DeepEqual(expected, profilesSections) {
 		t.Fatalf("Expected: %#v\nGot: %#v", expected, profilesSections)

--- a/vault/tempcreds.go
+++ b/vault/tempcreds.go
@@ -154,7 +154,7 @@ func (p *TempCredentialsProvider) createSessionToken() (*sts.Credentials, error)
 	var err error
 
 	input := &sts.GetSessionTokenInput{
-		DurationSeconds: aws.Int64(int64(p.config.SessionDuration.Seconds())),
+		DurationSeconds: aws.Int64(int64(p.config.GetSessionTokenDuration.Seconds())),
 	}
 
 	if p.config.MfaSerial != "" {


### PR DESCRIPTION
1. Replaces the `--session-ttl`, `--assume-role-ttl` and `--federation-token-ttl` flags with a single `--duration` flag.

   Given that we know which credential call will be made, having 3 flags is more complex than is necessary. This is especially apparent on the login command, where all 3 flags could potentially be used in creating the session, and it's difficult to know which flag to use.
   The `AWS_SESSION_TOKEN_TTL`, `AWS_ASSUME_ROLE_TTL`, `AWS_FEDERATION_TOKEN_TTL` env vars remain available for users who require more fine-grained control over the session.

2. Changes the default durations 
   - `GetSessionToken`: 1h (or 8h when using AssumeRole and the session is primarily to cache MFA) (previously 4h)
   - `AssumeRole`: 1h (previously 15m)
   - `GetFederationToken`: 1h (previously 12h)
   
   Rationale: 
      - 1h is the AWS default for GetSessionToken, AssumeRole and GetFederationToken
      - Anecdotally, 15m very often feels too short and is exceeded when using login
      - When using GetSessionToken without a role, credentials are supposed to be temporary so 4h seems too long
      - 1h is the AWS max for IAM users calling GetFederationToken
      - Having the same 1h default for all three calls is simpler
