### PR TITLE
add ability to force a new session rather than fetch from cache

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -49,6 +49,10 @@ func ConfigureExecCommand(app *kingpin.Application) {
 		Short('n').
 		BoolVar(&input.NoSession)
 
+	cmd.Flag("force-new-session", "Force a new session to be created").
+		Short('f').
+		BoolVar(&input.Config.ForceNewSession)
+
 	cmd.Flag("mfa-token", "The MFA token to use").
 		Short('t').
 		StringVar(&input.Config.MfaToken)

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -24,9 +24,9 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 		HintAction(awsConfigFile.ProfileNames).
 		StringVar(&input.ProfileName)
 
-    cmd.Flag("force-new-session", "Force a new session to be created").
-        Short('f').
-        BoolVar(&input.Config.ForceNewSession)
+	cmd.Flag("force-new-session", "Force a new session to be created").
+		Short('f').
+		BoolVar(&input.Config.ForceNewSession)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		input.Config.MfaPromptMethod = GlobalFlags.PromptDriver

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -24,6 +24,10 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 		HintAction(awsConfigFile.ProfileNames).
 		StringVar(&input.ProfileName)
 
+    cmd.Flag("force-new-session", "Force a new session to be created").
+        Short('f').
+        BoolVar(&input.Config.ForceNewSession)
+
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		input.Config.MfaPromptMethod = GlobalFlags.PromptDriver
 		input.Keyring = keyringImpl

--- a/vault/cachedsessiontokenprovider.go
+++ b/vault/cachedsessiontokenprovider.go
@@ -15,6 +15,7 @@ type CachedSessionTokenProvider struct {
 	Provider        *SessionTokenProvider
 	Keyring         keyring.Keyring
 	ExpiryWindow    time.Duration
+	ForceNewSession bool
 	credentials.Expiry
 }
 
@@ -24,7 +25,7 @@ func (p *CachedSessionTokenProvider) Retrieve() (credentials.Value, error) {
 	sessions := NewKeyringSessions(p.Keyring)
 
 	session, err := sessions.Retrieve(p.CredentialsName, p.Provider.MfaSerial)
-	if err != nil {
+	if err != nil || p.ForceNewSession {
 		// session lookup missed, we need to create a new one.
 		session, err = p.Provider.GetSessionToken()
 		if err != nil {

--- a/vault/config.go
+++ b/vault/config.go
@@ -407,6 +407,8 @@ type Config struct {
 
 	// GetFederationTokenDuration specifies the wanted duration for credentials generated with GetFederationToken
 	GetFederationTokenDuration time.Duration
+
+	ForceNewSession bool
 }
 
 // Validate checks that the Config is valid

--- a/vault/config.go
+++ b/vault/config.go
@@ -408,6 +408,7 @@ type Config struct {
 	// GetFederationTokenDuration specifies the wanted duration for credentials generated with GetFederationToken
 	GetFederationTokenDuration time.Duration
 
+	// Forces a new session instead of using a cached session
 	ForceNewSession bool
 }
 

--- a/vault/credentials.go
+++ b/vault/credentials.go
@@ -75,6 +75,7 @@ func NewCachedSessionTokenProvider(creds *credentials.Credentials, k keyring.Key
 				MfaSerial:       config.MfaSerial,
 			},
 		},
+		ForceNewSession: config.ForceNewSession,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes issues #122.

There are numerous use-cases where the credentials server won't work, particular when building tooling /around/ aws-vault itself.