### PR TITLE
475 5.0 removes default block header

### DIFF
--- a/vault/config.go
+++ b/vault/config.go
@@ -36,6 +36,7 @@ const (
 )
 
 func init() {
+	ini.DefaultHeader = true
 	ini.PrettyFormat = false
 }
 

--- a/vault/config.go
+++ b/vault/config.go
@@ -202,6 +202,10 @@ func (c *ConfigFile) ProfileSection(name string) (ProfileSection, bool) {
 	return profile, true
 }
 
+func (c *ConfigFile) Save() error {
+	return c.iniFile.SaveTo(c.Path)
+}
+
 // Add the profile to the configuration file
 func (c *ConfigFile) Add(profile ProfileSection) error {
 	if c.iniFile == nil {
@@ -219,7 +223,7 @@ func (c *ConfigFile) Add(profile ProfileSection) error {
 	if err = section.ReflectFrom(&profile); err != nil {
 		return fmt.Errorf("Error mapping profile to ini file: %v", err)
 	}
-	return c.iniFile.SaveTo(c.Path)
+	return c.Save()
 }
 
 // ProfileNames returns a slice of profile names from the AWS config

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -51,8 +51,13 @@ s3=
   max_queue_size=1000
 `)
 
-var onlyDefaultsConfig = []byte(`[default]
+var defaultsOnlyConfigWithHeader = []byte(`[default]
 region=us-west-2
+output=json
+
+`)
+
+var defaultsOnlyConfigWithoutHeader = []byte(`region=us-west-2
 output=json
 
 `)
@@ -285,8 +290,8 @@ func TestProfileIsEmpty(t *testing.T) {
 	}
 }
 
-func TestIniOutputHasDefaultHeader(t *testing.T) {
-	f := newConfigFile(t, onlyDefaultsConfig)
+func TestIniWithHeaderSavesWithHeader(t *testing.T) {
+	f := newConfigFile(t, defaultsOnlyConfigWithHeader)
 	defer os.Remove(f)
 
 	cfg, err := vault.LoadConfig(f)
@@ -299,12 +304,36 @@ func TestIniOutputHasDefaultHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := onlyDefaultsConfig
+	expected := defaultsOnlyConfigWithHeader
 
 	b, _ := ioutil.ReadFile(f)
 
 	if !bytes.Equal(expected, b) {
 		t.Fatalf("Expected:\n%q\nGot:\n%q", expected, b)
 	}
+
+}
+
+func TestIniWithoutHeaderSavesWithHeader(t *testing.T) {
+    f := newConfigFile(t, defaultsOnlyConfigWithoutHeader)
+    defer os.Remove(f)
+
+    cfg, err := vault.LoadConfig(f)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    err = cfg.Save()
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    expected := defaultsOnlyConfigWithHeader
+
+    b, _ := ioutil.ReadFile(f)
+
+    if !bytes.Equal(expected, b) {
+        t.Fatalf("Expected:\n%q\nGot:\n%q", expected, b)
+    }
 
 }

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -315,25 +315,24 @@ func TestIniWithHeaderSavesWithHeader(t *testing.T) {
 }
 
 func TestIniWithoutHeaderSavesWithHeader(t *testing.T) {
-    f := newConfigFile(t, defaultsOnlyConfigWithoutHeader)
-    defer os.Remove(f)
+	f := newConfigFile(t, defaultsOnlyConfigWithoutHeader)
+	defer os.Remove(f)
 
-    cfg, err := vault.LoadConfig(f)
-    if err != nil {
-        t.Fatal(err)
-    }
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    err = cfg.Save()
-    if err != nil {
-        t.Fatal(err)
-    }
+	err = cfg.Save()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    expected := defaultsOnlyConfigWithHeader
+	expected := defaultsOnlyConfigWithHeader
 
-    b, _ := ioutil.ReadFile(f)
+	b, _ := ioutil.ReadFile(f)
 
-    if !bytes.Equal(expected, b) {
-        t.Fatalf("Expected:\n%q\nGot:\n%q", expected, b)
-    }
-
+	if !bytes.Equal(expected, b) {
+		t.Fatalf("Expected:\n%q\nGot:\n%q", expected, b)
+	}
 }

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -51,6 +51,12 @@ s3=
   max_queue_size=1000
 `)
 
+var onlyDefaultsConfig = []byte(`[default]
+region=us-west-2
+output=json
+
+`)
+
 func newConfigFile(t *testing.T, b []byte) string {
 	f, err := ioutil.TempFile("", "aws-config")
 	if err != nil {
@@ -277,4 +283,28 @@ func TestProfileIsEmpty(t *testing.T) {
 	if !p.IsEmpty() {
 		t.Errorf("Expected p to be empty")
 	}
+}
+
+func TestIniOutputHasDefaultHeader(t *testing.T) {
+	f := newConfigFile(t, onlyDefaultsConfig)
+	defer os.Remove(f)
+
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cfg.Save()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := onlyDefaultsConfig
+
+	b, _ := ioutil.ReadFile(f)
+
+	if !bytes.Equal(expected, b) {
+		t.Fatalf("Expected:\n%q\nGot:\n%q", expected, b)
+	}
+
 }

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -40,7 +40,9 @@ region=us-east-1
 parent_profile=testparentprofile1
 `)
 
-var nestedConfig = []byte(`[profile testing]
+var nestedConfig = []byte(`[default]
+
+[profile testing]
 aws_access_key_id=foo
 aws_secret_access_key=bar
 region=us-west-2


### PR DESCRIPTION
Fixes issue #475 by configuring the INI lib to output the default header. Some other tools that read the AWS config file bork when this header is missing, despite it being valid for the INI specification. To be most compatible with other tools, any tool that edits/rewrites these files should use the same format as the stock AWS CLI tools -- and thus have the default header.