### PR TITLE
Fix --no-session

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -100,7 +100,7 @@ func ExecCommand(input ExecCommandInput) error {
 	}
 
 	configLoader.BaseConfig = input.Config
-	configLoader.ProfileNameForEnv = input.ProfileName
+	configLoader.ActiveProfile = input.ProfileName
 	config, err := configLoader.LoadFromProfile(input.ProfileName)
 	if err != nil {
 		return err
@@ -111,7 +111,7 @@ func ExecCommand(input ExecCommandInput) error {
 	if input.NoSession {
 		creds = vault.NewMasterCredentials(credKeyring, config.ProfileName)
 	} else {
-		creds, err = vault.NewTempCredentials(input.ProfileName, credKeyring, configLoader)
+		creds, err = vault.NewTempCredentials(input.ProfileName, credKeyring, config)
 		if err != nil {
 			return fmt.Errorf("Error getting temporary credentials: %w", err)
 		}

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -103,7 +103,7 @@ func ExecCommand(input ExecCommandInput) error {
 	}
 
 	credKeyring := &vault.CredentialKeyring{Keyring: input.Keyring}
-	creds, err := vault.NewTempCredentials(input.ProfileName, credKeyring, config)
+	creds, err := vault.NewTempCredentials(config, credKeyring)
 	if err != nil {
 		return fmt.Errorf("Error getting temporary credentials: %w", err)
 	}

--- a/cli/login.go
+++ b/cli/login.go
@@ -64,7 +64,7 @@ func ConfigureLoginCommand(app *kingpin.Application) {
 
 func LoginCommand(input LoginCommandInput) error {
 	configLoader.BaseConfig = input.Config
-	configLoader.ProfileNameForEnv = input.ProfileName
+	configLoader.ActiveProfile = input.ProfileName
 	config, err := configLoader.LoadFromProfile(input.ProfileName)
 	if err != nil {
 		return err
@@ -74,9 +74,9 @@ func LoginCommand(input LoginCommandInput) error {
 
 	// if AssumeRole isn't used, GetFederationToken has to be used for IAM credentials
 	if config.RoleARN == "" {
-		creds, err = vault.NewFederationTokenCredentials(input.ProfileName, input.Keyring, configLoader)
+		creds, err = vault.NewFederationTokenCredentials(input.ProfileName, input.Keyring, config)
 	} else {
-		creds, err = vault.NewTempCredentials(input.ProfileName, input.Keyring, configLoader)
+		creds, err = vault.NewTempCredentials(input.ProfileName, input.Keyring, config)
 	}
 	if err != nil {
 		return err

--- a/cli/login.go
+++ b/cli/login.go
@@ -76,7 +76,7 @@ func LoginCommand(input LoginCommandInput) error {
 	if config.RoleARN == "" {
 		creds, err = vault.NewFederationTokenCredentials(input.ProfileName, input.Keyring, config)
 	} else {
-		creds, err = vault.NewTempCredentials(input.ProfileName, input.Keyring, config)
+		creds, err = vault.NewTempCredentials(config, input.Keyring)
 	}
 	if err != nil {
 		return err

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -24,7 +24,7 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 
 	cmd := app.Command("rotate", "Rotates credentials")
 
-	cmd.Flag("no-session", "Use master credentials, no session created").
+	cmd.Flag("no-session", "Use master credentials, no session or role used").
 		Short('n').
 		BoolVar(&input.NoSession)
 
@@ -42,6 +42,7 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 }
 
 func RotateCommand(input RotateCommandInput) error {
+	vault.UseSession = !input.NoSession
 	vault.UseSessionCache = false
 
 	configLoader.BaseConfig = input.Config

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -78,7 +78,7 @@ func RotateCommand(input RotateCommandInput) error {
 	if input.NoSession {
 		sessCreds = vault.NewMasterCredentials(input.Keyring, config.ProfileName)
 	} else {
-		sessCreds, err = vault.NewTempCredentials(input.ProfileName, input.Keyring, config)
+		sessCreds, err = vault.NewTempCredentials(config, input.Keyring)
 		if err != nil {
 			return fmt.Errorf("Error getting temporary credentials: %w", err)
 		}

--- a/vault/config.go
+++ b/vault/config.go
@@ -461,6 +461,10 @@ type Config struct {
 	GetFederationTokenDuration time.Duration
 }
 
+func (c *Config) IsChained() bool {
+	return c.ChainedFromProfile != nil
+}
+
 // Validate checks that the Config is valid
 func (cl *Config) Validate() error {
 	if cl.GetSessionTokenDuration < MinGetSessionTokenDuration {

--- a/vault/config.go
+++ b/vault/config.go
@@ -465,6 +465,20 @@ func (c *Config) IsChained() bool {
 	return c.ChainedFromProfile != nil
 }
 
+func (c *Config) HasSourceProfile() bool {
+	return c.SourceProfile != nil
+}
+
+func (c *Config) HasMfaSerial() bool {
+	return c.MfaSerial != ""
+}
+
+func (c *Config) MfaAlreadyUsedInSourceProfile() bool {
+	return c.HasSourceProfile() &&
+		c.MfaSerial != "" &&
+		c.SourceProfile.MfaSerial == c.MfaSerial
+}
+
 // Validate checks that the Config is valid
 func (cl *Config) Validate() error {
 	if cl.GetSessionTokenDuration < MinGetSessionTokenDuration {

--- a/vault/config.go
+++ b/vault/config.go
@@ -14,21 +14,6 @@ import (
 )
 
 const (
-	// MinGetSessionTokenDuration is the AWS minumum duration for GetSessionToken
-	MinGetSessionTokenDuration = time.Minute * 15
-	// MaxGetSessionTokenDuration is the AWS maximum duration for GetSessionToken
-	MaxGetSessionTokenDuration = time.Hour * 36
-
-	// MinAssumeRoleDuration is the AWS minumum duration for AssumeRole
-	MinAssumeRoleDuration = time.Minute * 15
-	// MaxAssumeRoleDuration is the AWS maximum duration for AssumeRole
-	MaxAssumeRoleDuration = time.Hour * 12
-
-	// MinGetFederationTokenDuration is the AWS minumum duration for GetFederationToke
-	MinGetFederationTokenDuration = time.Minute * 15
-	// MaxGetFederationTokenDuration is the AWS maximum duration for GetFederationToke
-	MaxGetFederationTokenDuration = time.Hour * 36
-
 	// DefaultSessionDuration is the default duration for GetSessionToken or AssumeRole sessions
 	DefaultSessionDuration = time.Hour * 1
 
@@ -413,11 +398,6 @@ func (cl *ConfigLoader) LoadFromProfile(profileName string) (*Config, error) {
 		return nil, err
 	}
 
-	err = config.Validate()
-	if err != nil {
-		return nil, err
-	}
-
 	return &config, nil
 }
 
@@ -477,28 +457,4 @@ func (c *Config) MfaAlreadyUsedInSourceProfile() bool {
 	return c.HasSourceProfile() &&
 		c.MfaSerial != "" &&
 		c.SourceProfile.MfaSerial == c.MfaSerial
-}
-
-// Validate checks that the Config is valid
-func (cl *Config) Validate() error {
-	if cl.GetSessionTokenDuration < MinGetSessionTokenDuration {
-		return fmt.Errorf("Minimum GetSessionToken duration is %s", MinGetSessionTokenDuration)
-	}
-	if cl.GetSessionTokenDuration > MaxGetSessionTokenDuration {
-		return fmt.Errorf("Maximum GetSessionToken duration is %s", MaxGetSessionTokenDuration)
-	}
-	if cl.AssumeRoleDuration < MinAssumeRoleDuration {
-		return fmt.Errorf("Minimum AssumeRole duration is %s", MinAssumeRoleDuration)
-	}
-	if cl.AssumeRoleDuration > MaxAssumeRoleDuration {
-		return fmt.Errorf("Maximum AssumeRole duration is %s", MaxAssumeRoleDuration)
-	}
-	if cl.GetFederationTokenDuration < MinGetFederationTokenDuration {
-		return fmt.Errorf("Minimum GetFederationToken duration is %s", MinAssumeRoleDuration)
-	}
-	if cl.GetFederationTokenDuration > MaxGetFederationTokenDuration {
-		return fmt.Errorf("Maximum GetFederationToken duration is %s", MaxAssumeRoleDuration)
-	}
-
-	return nil
 }

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -156,7 +156,8 @@ func (c *CredentialLoader) ProviderWithChainedMfa(config *Config) (credentials.P
 
 	if config.RoleARN == "" {
 		if !UseSession {
-			log.Printf("profile %s: GetSessionToken disabled", config.ProfileName)
+			// log.Printf("profile %s: GetSessionToken disabled", config.ProfileName)
+			config.MfaSerial = ""
 			return sourceCredProvider, nil
 		}
 


### PR DESCRIPTION
Fixes the regression to `--no-session` that occurred in v5.0.0. 

Using `--no-session` now again correctly disables use of `GetSessionToken`

Fixes #488 and #493