### PR TITLE
[doc] Use valid duration_seconds value

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -52,7 +52,7 @@ region = us-west-1
 
 [profile parent]
 mfa_serial = arn:aws:iam::111111111111:mfa/user.name
-duration_seconds = 120
+duration_seconds = 900
 
 [profile account1]
 parent_profile = parent


### PR DESCRIPTION
Hi!

I was just trying out this `parent_profile` feature and found the example was incorrect.

```
aws-vault: error: exec: Failed to get credentials for <REDACTED>: InvalidParameter: 1 validation error(s) found.
- minimum field value of 900, AssumeRoleInput.DurationSeconds.
```