### PR TITLE
Improve completion script

### DIFF
--- a/cli/global.go
+++ b/cli/global.go
@@ -19,6 +19,7 @@ const (
 
 var (
 	keyringImpl      keyring.Keyring
+	credKeyring      *vault.CredentialKeyring
 	awsConfigFile    *vault.ConfigFile
 	configLoader     *vault.ConfigLoader
 	promptsAvailable = prompt.Available()
@@ -100,6 +101,7 @@ func ConfigureGlobals(app *kingpin.Application) {
 			}
 		}
 
+		credKeyring = &vault.CredentialKeyring{Keyring: keyringImpl}
 		awsConfigFile, err = vault.LoadConfigFromEnv()
 		configLoader = &vault.ConfigLoader{File: awsConfigFile}
 
@@ -123,4 +125,9 @@ func fileKeyringPassphrasePrompt(prompt string) (string, error) {
 
 func getProfileNames() []string {
 	return awsConfigFile.ProfileNames()
+}
+
+func getCredentialProfileNames() []string {
+	credentialsNames, _ := credKeyring.CredentialsKeys()
+	return credentialsNames
 }

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -22,7 +22,7 @@ func ConfigureRemoveCommand(app *kingpin.Application) {
 
 	cmd.Arg("profile", "Name of the profile").
 		Required().
-		HintAction(getProfileNames).
+		HintAction(getCredentialProfileNames).
 		StringVar(&input.ProfileName)
 
 	cmd.Flag("sessions-only", "Only remove sessions, leave credentials intact").

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -30,7 +30,7 @@ func ConfigureRotateCommand(app *kingpin.Application) {
 
 	cmd.Arg("profile", "Name of the profile").
 		Required().
-		HintAction(getProfileNames).
+		HintAction(getCredentialProfileNames).
 		StringVar(&input.ProfileName)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {


### PR DESCRIPTION
For the commands `rotate` and `remove` only provide completion hints of
profiles that aws-vault is managing credentials for.

Fixes #415