### PR TITLE
Add support for kdialog

### DIFF
--- a/prompt/kdialog.go
+++ b/prompt/kdialog.go
@@ -1,0 +1,21 @@
+package prompt
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func KDialogPrompt(prompt string) (string, error) {
+	cmd := exec.Command("kdialog", "--inputbox", prompt, "--title", "aws-vault")
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+func init() {
+	Methods["kdialog"] = KDialogPrompt
+}


### PR DESCRIPTION
This allows to use [KDialog](https://kde.org/applications/utilities/org.kde.kdialog) as prompt.