### PR TITLE
fix assume role with source_profile mfa_serial

### DIFF
--- a/vault/config.go
+++ b/vault/config.go
@@ -476,7 +476,7 @@ func (c *Config) CanUseGetSessionToken() (bool, string) {
 		if c.AssumeRoleDuration > roleChainingMaximumDuration {
 			return false, fmt.Sprintf("duration %s is greater than the AWS maximum %s for chaining MFA", c.AssumeRoleDuration, roleChainingMaximumDuration)
 		}
-	} else if c.IsChained() {
+	} else if c.IsChained() && !c.HasMfaSerial() {
 		if !c.ChainedFromProfile.HasMfaSerial() {
 			return false, fmt.Sprintf("profile '%s' has no MFA serial defined", c.ChainedFromProfile.ProfileName)
 		}


### PR DESCRIPTION
Given this config

```
[profile mfa]
region=eu-west-1
mfa_serial=arn:aws:iam::123456789:mfa/iamtest

[profile iamtest]
source_profile=mfa
role_arn=arn:aws:iam::123456789:role/developer
```

Before this change

```
 $ ./aws-vault exec --debug iamtest
2020/02/17 20:54:25 aws-vault dev
2020/02/17 20:54:25 [keyring] Considering backends: [keychain pass file]
2020/02/17 20:54:25 Loading config file /Users/peter/.aws/config
2020/02/17 20:54:25 Parsing config file /Users/peter/.aws/config
2020/02/17 20:54:25 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/02/17 20:54:25 [keyring] Found 6 results
2020/02/17 20:54:25 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/02/17 20:54:25 [keyring] Found 6 results
2020/02/17 20:54:25 profile mfa: using stored credentials
2020/02/17 20:54:25 profile mfa: skipping GetSessionToken because profile 'iamtest' has no MFA serial defined
2020/02/17 20:54:25 profile iamtest: using AssumeRole 
2020/02/17 20:54:25 Looking up keyring for 'mfa'
2020/02/17 20:54:25 [keyring] Querying keychain for service="aws-vault", account="mfa", keychain="aws-vault.keychain"
2020/02/17 20:54:26 [keyring] Found item "aws-vault (mfa)"
aws-vault: error: exec: Failed to get credentials for iamtest: AccessDenied: User: arn:aws:iam::123456789:user/iamtest is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::123456789:role/developer
        status code: 403, request id: fe627d21-8137-433c-a6ec-84b108957ce3
```


After this change

```
$ ./aws-vault exec --debug iamtest
2020/02/17 21:01:15 aws-vault dev
2020/02/17 21:01:15 [keyring] Considering backends: [keychain pass file]
2020/02/17 21:01:15 Loading config file /Users/peter/.aws/config
2020/02/17 21:01:15 Parsing config file /Users/peter/.aws/config
2020/02/17 21:01:15 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/02/17 21:01:15 [keyring] Found 5 results
2020/02/17 21:01:15 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/02/17 21:01:15 [keyring] Found 5 results
2020/02/17 21:01:15 profile mfa: using stored credentials
2020/02/17 21:01:15 profile mfa: using GetSessionToken (with MFA)
2020/02/17 21:01:15 profile iamtest: using AssumeRole
2020/02/17 21:01:15 Looking for sessions for mfa
2020/02/17 21:01:15 Looking up all keys in keyring
2020/02/17 21:01:15 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/02/17 21:01:15 [keyring] Found 5 results
Enter token for arn:aws:iam::123456789:mfa/iamtest: 523223
2020/02/17 21:01:38 Looking up keyring for 'mfa'
2020/02/17 21:01:38 [keyring] Querying keychain for service="aws-vault", account="mfa", keychain="aws-vault.keychain"
2020/02/17 21:01:44 [keyring] Found item "aws-vault (mfa)"
2020/02/17 21:01:44 Generated credentials ****************AAN7 using GetSessionToken, expires in 7h59m59.351913s
2020/02/17 21:01:44 Writing session for mfa to keyring: "session,bWZh,YXJuOmF3czppYW06OjIxOTYxMzQyODg5NjptZmEvaWFtdGVzdA,1582002104"
2020/02/17 21:01:44 [keyring] Checking keychain status
2020/02/17 21:01:44 [keyring] Keychain status returned nil, keychain exists
2020/02/17 21:01:44 [keyring] Keychain item trusts keyring
2020/02/17 21:01:44 [keyring] Adding service="aws-vault", label="aws-vault session for mfa", account="session,bWZh,YXJuOmF3czppYW06OjIxOTYxMzQyODg5NjptZmEvaWFtdGVzdA,1582002104", trusted=true to osx keychain "aws-vault.keychain"
2020/02/17 21:01:44 Generated credentials ****************YUAG using AssumeRole, expires in 59m59.236435s
2020/02/17 21:01:44 Setting subprocess env: AWS_DEFAULT_REGION=eu-west-1, AWS_REGION=eu-west-1
2020/02/17 21:01:44 Setting subprocess env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
2020/02/17 21:01:44 Setting subprocess env: AWS_SESSION_TOKEN, AWS_SECURITY_TOKEN
2020/02/17 21:01:44 Setting subprocess env: AWS_SESSION_EXPIRATION
```

