### PR TITLE
Fix/follow simlink to passwordstore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ BUILD_FLAGS=-ldflags="-X main.Version=$(VERSION) -s -w" -trimpath
 CERT_ID ?= Developer ID Application: 99designs Inc (NRM9HVJ62Z)
 SRC=$(shell find . -name '*.go')
 
+export CGO_ENABLED=0
+
 .PHONY: binaries clean release install
 
 binaries: aws-vault-linux-amd64 aws-vault-linux-arm64 aws-vault-darwin-amd64 aws-vault-windows-386.exe aws-vault-freebsd-amd64

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/99designs/keyring"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -35,7 +36,7 @@ func (ck *CredentialKeyring) Has(credentialsName string) (bool, error) {
 		return false, err
 	}
 	for _, keyName := range allKeys {
-		if keyName == credentialsName {
+		if strings.Contains(keyName, credentialsName) {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
[fix] Better way to deal with path names returned by following symlink

A better way of dealing with []keyName(s) retrieved from a symlink to
passwordstore.

A keyring fix will complement this work, waiting for upstream fixes in keyring:master
which has introduced what appears to be broken unit tests. See context in comments in https://github.com/99designs/keyring/issues/62

Related
https://github.com/99designs/keyring/issues/62
https://github.com/99designs/keyring/pull/63

Fixes
https://github.com/99designs/aws-vault/issues/529
