### PR TITLE
Allow AWS region retrieval from metadata server

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -117,6 +117,9 @@ func ExecCommand(input ExecCommandInput) error {
 		if err := server.StartCredentialsServer(creds); err != nil {
 			return fmt.Errorf("Failed to start credential server: %w", err)
 		}
+		if err := server.StartIdentityDocumentServer(config); err != nil {
+			return fmt.Errorf("Failed to start identity document server: %w", err)
+		}
 		setEnv = false
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -120,7 +120,7 @@ func StartIdentityDocumentServer(config *vault.Config) error {
 func identityDocHandler(config *vault.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := json.NewEncoder(w).Encode(map[string]interface{}{
-			"region":          config.Region,
+			"region": config.Region,
 		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
AWS region is returned via dynamic data, on instance identity document
endpoint of the metadata server. This region data is used by AWS SDK in
determining which region to consume the service on.

Allowing region retrieval on aws-vault server mode allows the server to
behave slightly more closely to the actual metadata server, and aids in
local application development, by allowing the code to be more agnostic
of its operating environment.