### PR TITLE
Make the exec command default to a login shell

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -74,7 +74,16 @@ func ConfigureExecCommand(app *kingpin.Application) {
 		Default(os.Getenv("SHELL")).
 		StringVar(&input.Command)
 
+	// bash, sh, csh, zsh, fish etc all support login shells
+	// we are starting an interactive session so people probably want to use a login shell
+	cmdArgsDefault := "-l"
+	if runtime.GOOS == "windows" {
+		// windows $SHELL defaults to cmd.exe, it does not have the concept of a login shell
+		cmdArgsDefault = ""
+	}
+
 	cmd.Arg("args", "Command arguments").
+		Default(cmdArgsDefault).
 		StringsVar(&input.Args)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {


### PR DESCRIPTION
Currently when you run `aws-vault exec <profile>` it runs $SHELL and puts you into a non login shell. This does not execute your shells login profile so you end up losing anything nice you have in your login profile.

Instead I think exec should default to executing a login shell. As far as I am aware all shells support `-l`, so this should be backwards compatible, and i don't envision any issues. This attempts to close out issue https://github.com/99designs/aws-vault/issues/406 too.