### PR TITLE
Improvements to exec and server

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -151,7 +151,7 @@ func ExecCommand(input ExecCommandInput) error {
 }
 
 func execServer(input ExecCommandInput, config *vault.Config, creds *credentials.Credentials) error {
-	if err := server.StartLocalServer(creds); err != nil {
+	if err := server.StartLocalServer(creds, config.Region); err != nil {
 		return fmt.Errorf("Failed to start credential server: %w", err)
 	}
 

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -139,7 +139,7 @@ func ExecCommand(input ExecCommandInput) error {
 	}
 
 	if input.StartServer {
-		if err := server.StartCredentialsServer(creds); err != nil {
+		if err := server.StartLocalServer(creds); err != nil {
 			return fmt.Errorf("Failed to start credential server: %w", err)
 		}
 		setEnv = false

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
+	osexec "os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
@@ -16,6 +16,7 @@ import (
 	"github.com/99designs/aws-vault/server"
 	"github.com/99designs/aws-vault/vault"
 	"github.com/99designs/keyring"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -37,7 +38,7 @@ type AwsCredentialHelperData struct {
 	Version         int    `json:"Version"`
 	AccessKeyID     string `json:"AccessKeyId"`
 	SecretAccessKey string `json:"SecretAccessKey"`
-	SessionToken    string `json:"SessionToken"`
+	SessionToken    string `json:"SessionToken,omitempty"`
 	Expiration      string `json:"Expiration,omitempty"`
 }
 
@@ -88,7 +89,7 @@ func ConfigureExecCommand(app *kingpin.Application) {
 		if input.Command == "" {
 			app.Fatalf("Argument 'cmd' not provided, and SHELL not present, try --help")
 		}
-		app.FatalIfError(ExecCommand(input), "exec")
+		app.FatalIfError(ExecCommand(input), "")
 		return nil
 	})
 }
@@ -117,8 +118,14 @@ func ExecCommand(input ExecCommandInput) error {
 		return fmt.Errorf("aws-vault sessions should be nested with care, unset $AWS_VAULT to force")
 	}
 
+	if input.StartServer && input.CredentialHelper {
+		return fmt.Errorf("Can't use --server with --json")
+	}
+	if input.StartServer && input.NoSession {
+		return fmt.Errorf("Can't use --server with --no-session")
+	}
+
 	vault.UseSession = !input.NoSession
-	setEnv := true
 
 	configLoader.BaseConfig = input.Config
 	configLoader.ActiveProfile = input.ProfileName
@@ -133,83 +140,107 @@ func ExecCommand(input ExecCommandInput) error {
 		return fmt.Errorf("Error getting temporary credentials: %w", err)
 	}
 
+	if input.StartServer {
+		return execServer(input, config, creds)
+	}
+	if input.CredentialHelper {
+		return execCredentialHelper(input, config, creds)
+	}
+
+	return execEnvironment(input, config, creds)
+}
+
+func execServer(input ExecCommandInput, config *vault.Config, creds *credentials.Credentials) error {
+	if err := server.StartLocalServer(creds); err != nil {
+		return fmt.Errorf("Failed to start credential server: %w", err)
+	}
+
+	env := environ(os.Environ())
+	env.Set("AWS_VAULT", input.ProfileName)
+	env.Unset("AWS_ACCESS_KEY_ID")
+	env.Unset("AWS_SECRET_ACCESS_KEY")
+	env.Unset("AWS_SESSION_TOKEN")
+	env.Unset("AWS_SECURITY_TOKEN")
+	env.Unset("AWS_CREDENTIAL_FILE")
+	env.Unset("AWS_DEFAULT_PROFILE")
+	env.Unset("AWS_PROFILE")
+	env.Unset("AWS_DEFAULT_REGION")
+	env.Unset("AWS_REGION")
+
+	return execCmd(input.Command, input.Args, env)
+}
+
+func execCredentialHelper(input ExecCommandInput, config *vault.Config, creds *credentials.Credentials) error {
 	val, err := creds.Get()
 	if err != nil {
 		return fmt.Errorf("Failed to get credentials for %s: %w", input.ProfileName, err)
 	}
 
-	if input.StartServer {
-		if err := server.StartLocalServer(creds); err != nil {
-			return fmt.Errorf("Failed to start credential server: %w", err)
-		}
-		setEnv = false
+	credentialData := AwsCredentialHelperData{
+		Version:         1,
+		AccessKeyID:     val.AccessKeyID,
+		SecretAccessKey: val.SecretAccessKey,
+	}
+	if val.SessionToken != "" {
+		credentialData.SessionToken = val.SessionToken
+	}
+	if credsExpiresAt, err := creds.ExpiresAt(); err == nil {
+		credentialData.Expiration = credsExpiresAt.Format("2006-01-02T15:04:05Z")
 	}
 
-	if input.CredentialHelper {
-		credentialData := AwsCredentialHelperData{
-			Version:         1,
-			AccessKeyID:     val.AccessKeyID,
-			SecretAccessKey: val.SecretAccessKey,
-			SessionToken:    val.SessionToken,
-		}
-		if !input.NoSession {
-			credsExprest, err := creds.ExpiresAt()
-			if err != nil {
-				return fmt.Errorf("Error getting credential expiration: %w", err)
-			}
-			credentialData.Expiration = credsExprest.Format("2006-01-02T15:04:05Z")
-		}
-		json, err := json.Marshal(&credentialData)
-		if err != nil {
-			return fmt.Errorf("Error creating credential json: %w", err)
-		}
-		fmt.Print(string(json))
-	} else {
-
-		env := environ(os.Environ())
-		env.Set("AWS_VAULT", input.ProfileName)
-
-		env.Unset("AWS_ACCESS_KEY_ID")
-		env.Unset("AWS_SECRET_ACCESS_KEY")
-		env.Unset("AWS_CREDENTIAL_FILE")
-		env.Unset("AWS_DEFAULT_PROFILE")
-		env.Unset("AWS_PROFILE")
-
-		if config.Region != "" {
-			log.Printf("Setting subprocess env: AWS_DEFAULT_REGION=%s, AWS_REGION=%s", config.Region, config.Region)
-			env.Set("AWS_DEFAULT_REGION", config.Region)
-			env.Set("AWS_REGION", config.Region)
-		}
-
-		if setEnv {
-			log.Println("Setting subprocess env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY")
-			env.Set("AWS_ACCESS_KEY_ID", val.AccessKeyID)
-			env.Set("AWS_SECRET_ACCESS_KEY", val.SecretAccessKey)
-
-			if val.SessionToken != "" {
-				log.Println("Setting subprocess env: AWS_SESSION_TOKEN, AWS_SECURITY_TOKEN")
-				env.Set("AWS_SESSION_TOKEN", val.SessionToken)
-				env.Set("AWS_SECURITY_TOKEN", val.SessionToken)
-				expiration, err := creds.ExpiresAt()
-				if err == nil {
-					log.Println("Setting subprocess env: AWS_SESSION_EXPIRATION")
-					env.Set("AWS_SESSION_EXPIRATION", expiration.Format(time.RFC3339))
-				}
-			}
-		}
-
-		if input.StartServer {
-			err = execCmd(input.Command, input.Args, env)
-		} else {
-			err = execSyscall(input.Command, input.Args, env)
-		}
-
-		if err != nil {
-			return fmt.Errorf("Error execing process: %w", err)
-		}
+	json, err := json.Marshal(&credentialData)
+	if err != nil {
+		return fmt.Errorf("Error creating credential json: %w", err)
 	}
+
+	fmt.Print(string(json))
 
 	return nil
+}
+
+func execEnvironment(input ExecCommandInput, config *vault.Config, creds *credentials.Credentials) error {
+	val, err := creds.Get()
+	if err != nil {
+		return fmt.Errorf("Failed to get credentials for %s: %w", input.ProfileName, err)
+	}
+
+	env := environ(os.Environ())
+	env.Set("AWS_VAULT", input.ProfileName)
+
+	env.Unset("AWS_ACCESS_KEY_ID")
+	env.Unset("AWS_SECRET_ACCESS_KEY")
+	env.Unset("AWS_SESSION_TOKEN")
+	env.Unset("AWS_SECURITY_TOKEN")
+	env.Unset("AWS_CREDENTIAL_FILE")
+	env.Unset("AWS_DEFAULT_PROFILE")
+	env.Unset("AWS_PROFILE")
+	env.Unset("AWS_SESSION_EXPIRATION")
+
+	if config.Region != "" {
+		log.Printf("Setting subprocess env: AWS_DEFAULT_REGION=%s, AWS_REGION=%s", config.Region, config.Region)
+		env.Set("AWS_DEFAULT_REGION", config.Region)
+		env.Set("AWS_REGION", config.Region)
+	}
+
+	log.Println("Setting subprocess env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY")
+	env.Set("AWS_ACCESS_KEY_ID", val.AccessKeyID)
+	env.Set("AWS_SECRET_ACCESS_KEY", val.SecretAccessKey)
+
+	if val.SessionToken != "" {
+		log.Println("Setting subprocess env: AWS_SESSION_TOKEN, AWS_SECURITY_TOKEN")
+		env.Set("AWS_SESSION_TOKEN", val.SessionToken)
+		env.Set("AWS_SECURITY_TOKEN", val.SessionToken)
+	}
+	if expiration, err := creds.ExpiresAt(); err == nil {
+		log.Println("Setting subprocess env: AWS_SESSION_EXPIRATION")
+		env.Set("AWS_SESSION_EXPIRATION", expiration.Format(time.RFC3339))
+	}
+
+	if !supportsExecSyscall() {
+		return execCmd(input.Command, input.Args, env)
+	}
+
+	return execSyscall(input.Command, input.Args, env)
 }
 
 // environ is a slice of strings representing the environment, in the form "key=value".
@@ -233,7 +264,9 @@ func (e *environ) Set(key, val string) {
 }
 
 func execCmd(command string, args []string, env []string) error {
-	cmd := exec.Command(command, args...)
+	log.Printf("Starting child process: %s %s", command, strings.Join(args, " "))
+
+	cmd := osexec.Command(command, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -243,7 +276,7 @@ func execCmd(command string, args []string, env []string) error {
 	signal.Notify(sigChan)
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("Failed to start command: %v", err)
+		return err
 	}
 
 	go func() {
@@ -268,11 +301,9 @@ func supportsExecSyscall() bool {
 }
 
 func execSyscall(command string, args []string, env []string) error {
-	if !supportsExecSyscall() {
-		return execCmd(command, args, env)
-	}
+	log.Printf("Exec command %s %s", command, strings.Join(args, " "))
 
-	argv0, err := exec.LookPath(command)
+	argv0, err := osexec.LookPath(command)
 	if err != nil {
 		return err
 	}

--- a/cli/server.go
+++ b/cli/server.go
@@ -21,7 +21,7 @@ func ConfigureServerCommand(app *kingpin.Application) {
 }
 
 func ServerCommand(app *kingpin.Application, input ServerCommandInput) {
-	if err := server.StartMetadataServer(); err != nil {
+	if err := server.StartEc2MetadataProxyServer(); err != nil {
 		app.Fatalf("Server failed: %v", err)
 	}
 }

--- a/server/proxy_default.go
+++ b/server/proxy_default.go
@@ -10,8 +10,8 @@ import (
 	"time"
 )
 
-// StartCredentialProxy starts a `aws-vault server` process
-func StartCredentialProxy() error {
+// StartProxyServerProcess starts a `aws-vault server` process
+func StartProxyServerProcess() error {
 	log.Println("Starting `aws-vault server` in the background")
 	cmd := exec.Command(os.Args[0], "server")
 	cmd.Stdin = os.Stdin
@@ -21,7 +21,7 @@ func StartCredentialProxy() error {
 		return err
 	}
 	time.Sleep(time.Second * 1)
-	if !checkServerRunning(metadataBind) {
+	if !isServerRunning(metadataBind) {
 		return errors.New("The credential proxy server isn't running. Run aws-vault server as Administrator in the background and then try this command again")
 	}
 	return nil

--- a/server/proxy_unix.go
+++ b/server/proxy_unix.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 )
 
-// StartCredentialProxy starts a `aws-vault server` process
-func StartCredentialProxy() error {
+// StartProxyServerProcess starts a `aws-vault server` process
+func StartProxyServerProcess() error {
 	log.Println("Starting `aws-vault server` as root in the background")
 	cmd := exec.Command("sudo", "-b", os.Args[0], "server")
 	cmd.Stdin = os.Stdin

--- a/server/server.go
+++ b/server/server.go
@@ -45,7 +45,7 @@ func isServerRunning(bind string) bool {
 }
 
 // StartLocalServer starts a http server to service the EC2 Instance Metadata endpoint
-func StartLocalServer(creds *credentials.Credentials) error {
+func StartLocalServer(creds *credentials.Credentials, region string) error {
 	if !isServerRunning(ec2ServerBind) {
 		if err := StartProxyServerProcess(); err != nil {
 			return err
@@ -68,6 +68,11 @@ func StartLocalServer(creds *credentials.Credentials) error {
 		// The AWS .NET SDK checks this endpoint during obtaining credentials/refreshing them
 		router.HandleFunc("/latest/meta-data/iam/info/", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, `{"Code" : "Success"}`)
+		})
+
+		// used by AWS SDK to determine region
+		router.HandleFunc("/latest/meta-data/dynamic/instance-identity/document", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{"region": "`+region+`"}`)
 		})
 
 		router.HandleFunc("/latest/meta-data/iam/security-credentials/local-credentials", credsHandler(creds))

--- a/server/server.go
+++ b/server/server.go
@@ -3,97 +3,86 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
 const (
-	metadataBind    = "169.254.169.254:80"
 	awsTimeFormat   = "2006-01-02T15:04:05Z"
-	localServerURL  = "http://127.0.0.1:9099"
+	ec2ServerBind   = "169.254.169.254:80"
 	localServerBind = "127.0.0.1:9099"
 )
 
-func StartMetadataServer() error {
+// StartEc2MetadataProxyServer starts a proxy server on the standard Ec2 Instance Metadata address
+func StartEc2MetadataProxyServer() error {
+	var localServerURL, err = url.Parse(fmt.Sprintf("http://%s/", localServerBind))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	if _, err := installNetworkAlias(); err != nil {
 		return err
 	}
 
-	router := http.NewServeMux()
-	router.HandleFunc("/latest/meta-data/iam/security-credentials/", indexHandler)
-	router.HandleFunc("/latest/meta-data/iam/security-credentials/local-credentials", credentialsHandler)
-	// The AWS Go SDK checks the instance-id endpoint to validate the existence of EC2 Metadata
-	router.HandleFunc("/latest/meta-data/instance-id/", instanceIdHandler)
-	// The AWS .NET SDK checks this endpoint during obtaining credentials/refreshing them
-	router.HandleFunc("/latest/meta-data/iam/info/", infoHandlerStub)
-
-	l, err := net.Listen("tcp", metadataBind)
+	l, err := net.Listen("tcp", ec2ServerBind)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("Local instance role server running on %s", l.Addr())
-	return http.Serve(l, router)
+	log.Printf("EC2 Instance Metadata server running on %s", l.Addr())
+	return http.Serve(l, httputil.NewSingleHostReverseProxy(localServerURL))
 }
 
-func infoHandlerStub(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, `{"Code" : "Success"}`)
-}
-
-func indexHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "local-credentials")
-}
-
-func credentialsHandler(w http.ResponseWriter, r *http.Request) {
-	resp, err := http.Get(localServerURL)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusGatewayTimeout)
-		return
-	}
-	defer resp.Body.Close()
-
-	log.Printf("Fetched credentials from %s", localServerURL)
-
-	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(http.StatusOK)
-
-	_, err = io.Copy(w, resp.Body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-}
-
-func instanceIdHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "aws-vault")
-}
-
-func checkServerRunning(bind string) bool {
+func isServerRunning(bind string) bool {
 	_, err := net.DialTimeout("tcp", bind, time.Millisecond*10)
 	return err == nil
 }
 
-func StartCredentialsServer(creds *credentials.Credentials) error {
-	if !checkServerRunning(metadataBind) {
-		if err := StartCredentialProxy(); err != nil {
+// StartLocalServer starts a http server to service the EC2 Instance Metadata endpoint
+func StartLocalServer(creds *credentials.Credentials) error {
+	if !isServerRunning(ec2ServerBind) {
+		if err := StartProxyServerProcess(); err != nil {
 			return err
 		}
 	}
 
-	log.Printf("Starting local instance role server on %s", localServerBind)
+	log.Printf("Starting local credentials server on %s", localServerBind)
 	go func() {
-		log.Fatalln(http.ListenAndServe(localServerBind, credsHandler(creds)))
+		router := http.NewServeMux()
+
+		router.HandleFunc("/latest/meta-data/iam/security-credentials/", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "local-credentials")
+		})
+
+		// The AWS Go SDK checks the instance-id endpoint to validate the existence of EC2 Metadata
+		router.HandleFunc("/latest/meta-data/instance-id/", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "aws-vault")
+		})
+
+		// The AWS .NET SDK checks this endpoint during obtaining credentials/refreshing them
+		router.HandleFunc("/latest/meta-data/iam/info/", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{"Code" : "Success"}`)
+		})
+
+		router.HandleFunc("/latest/meta-data/iam/security-credentials/local-credentials", credsHandler(creds))
+
+		log.Fatalln(http.ListenAndServe(localServerBind, withLoopbackSecurityCheck(router)))
 	}()
 
 	return nil
 }
 
-func credsHandler(creds *credentials.Credentials) http.HandlerFunc {
+// withLoopbackSecurityCheck is middleware to check that the request comes from the loopback device
+// We must make sure the remote ip is from the loopback, otherwise clients on the same network segment could
+// potentially route traffic via 169.254.169.254:80
+// See https://developer.apple.com/library/content/qa/qa1357/_index.html
+func withLoopbackSecurityCheck(next *http.ServeMux) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ip, _, err := net.SplitHostPort(r.RemoteAddr)
 		if err != nil {
@@ -101,15 +90,19 @@ func credsHandler(creds *credentials.Credentials) http.HandlerFunc {
 			return
 		}
 
-		// Must make sure the remote ip is from the loopback, otherwise clients on the same network segment could
-		// potentially route traffic via 169.254.169.254:80
-		// See https://developer.apple.com/library/content/qa/qa1357/_index.html
 		if !net.ParseIP(ip).IsLoopback() {
 			http.Error(w, "Access denied from non-localhost address", http.StatusUnauthorized)
 			return
 		}
 
 		log.Printf("RemoteAddr = %v", r.RemoteAddr)
+
+		next.ServeHTTP(w, r)
+	}
+}
+
+func credsHandler(creds *credentials.Credentials) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Credentials.IsExpired() = %#v", creds.IsExpired())
 
 		val, err := creds.Get()


### PR DESCRIPTION
Refactors the exec and server code to make it more consistent and easier to modify.

The motivation was that the change at #542 was a lot more difficult than it needed to be. This should also make it easier to land the ECS server PRs #400 #375

The proxy process is now completely cut back to being a http proxy only, as it originally was. That means `sudo aws-vault server` is executing the smallest amount of code necessary