### PR TITLE
Add ECS server

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -198,7 +198,7 @@ func execEc2Server(input ExecCommandInput, config *vault.Config, creds *credenti
 }
 
 func execEcsServer(input ExecCommandInput, config *vault.Config, creds *credentials.Credentials) error {
-	ecsServer, err := server.StartEcsCredentialServer(creds)
+	uri, token, err := server.StartEcsCredentialServer(creds)
 	if err != nil {
 		return fmt.Errorf("Failed to start credential server: %w", err)
 	}
@@ -208,8 +208,8 @@ func execEcsServer(input ExecCommandInput, config *vault.Config, creds *credenti
 	unsetAwsEnvVars(env)
 
 	log.Println("Setting subprocess env AWS_CONTAINER_CREDENTIALS_FULL_URI, AWS_CONTAINER_AUTHORIZATION_TOKEN")
-	env.Set("AWS_CONTAINER_CREDENTIALS_FULL_URI", ecsServer.Url)
-	env.Set("AWS_CONTAINER_AUTHORIZATION_TOKEN", ecsServer.Authorization)
+	env.Set("AWS_CONTAINER_CREDENTIALS_FULL_URI", uri)
+	env.Set("AWS_CONTAINER_AUTHORIZATION_TOKEN", token)
 
 	return execCmd(input.Command, input.Args, env)
 }

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -173,7 +173,7 @@ func ExecCommand(input ExecCommandInput) error {
 	return execEnvironment(input, config, creds)
 }
 
-func updateEnvForAwsVault(env environ, region string, profileName string) {
+func updateEnvForAwsVault(env environ, profileName string, region string) environ {
 	env.Unset("AWS_ACCESS_KEY_ID")
 	env.Unset("AWS_SECRET_ACCESS_KEY")
 	env.Unset("AWS_SESSION_TOKEN")
@@ -188,6 +188,8 @@ func updateEnvForAwsVault(env environ, region string, profileName string) {
 	log.Printf("Setting subprocess env: AWS_DEFAULT_REGION=%s, AWS_REGION=%s", region, region)
 	env.Set("AWS_DEFAULT_REGION", region)
 	env.Set("AWS_REGION", region)
+
+	return env
 }
 
 func execEc2Server(input ExecCommandInput, config *vault.Config, creds *credentials.Credentials) error {
@@ -196,7 +198,7 @@ func execEc2Server(input ExecCommandInput, config *vault.Config, creds *credenti
 	}
 
 	env := environ(os.Environ())
-	updateEnvForAwsVault(env, input.ProfileName, config.Region)
+	env = updateEnvForAwsVault(env, input.ProfileName, config.Region)
 
 	return execCmd(input.Command, input.Args, env)
 }
@@ -208,7 +210,7 @@ func execEcsServer(input ExecCommandInput, config *vault.Config, creds *credenti
 	}
 
 	env := environ(os.Environ())
-	updateEnvForAwsVault(env, input.ProfileName, config.Region)
+	env = updateEnvForAwsVault(env, input.ProfileName, config.Region)
 
 	log.Println("Setting subprocess env AWS_CONTAINER_CREDENTIALS_FULL_URI, AWS_CONTAINER_AUTHORIZATION_TOKEN")
 	env.Set("AWS_CONTAINER_CREDENTIALS_FULL_URI", uri)
@@ -252,7 +254,7 @@ func execEnvironment(input ExecCommandInput, config *vault.Config, creds *creden
 	}
 
 	env := environ(os.Environ())
-	updateEnvForAwsVault(env, input.ProfileName, config.Region)
+	env = updateEnvForAwsVault(env, input.ProfileName, config.Region)
 
 	log.Printf("Setting subprocess env: AWS_DEFAULT_REGION=%s, AWS_REGION=%s", config.Region, config.Region)
 	env.Set("AWS_DEFAULT_REGION", config.Region)

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -193,7 +193,7 @@ func updateEnvForAwsVault(env environ, profileName string, region string) enviro
 }
 
 func execEc2Server(input ExecCommandInput, config *vault.Config, creds *credentials.Credentials) error {
-	if err := server.StartLocalEc2Server(creds, config.Region); err != nil {
+	if err := server.StartEc2CredentialsServer(creds, config.Region); err != nil {
 		return fmt.Errorf("Failed to start credential server: %w", err)
 	}
 

--- a/cli/server.go
+++ b/cli/server.go
@@ -21,7 +21,7 @@ func ConfigureServerCommand(app *kingpin.Application) {
 }
 
 func ServerCommand(app *kingpin.Application, input ServerCommandInput) {
-	if err := server.StartEc2MetadataProxyServer(); err != nil {
+	if err := server.StartEc2MetadataEndpointProxy(); err != nil {
 		app.Fatalf("Server failed: %v", err)
 	}
 }

--- a/server/ec2.go
+++ b/server/ec2.go
@@ -44,8 +44,8 @@ func isServerRunning(bind string) bool {
 	return err == nil
 }
 
-// StartLocalServer starts a http server to service the EC2 Instance Metadata endpoint
-func StartLocalServer(creds *credentials.Credentials, region string) error {
+// StartLocalEc2Server starts a http server to service the EC2 Instance Metadata endpoint
+func StartLocalEc2Server(creds *credentials.Credentials, region string) error {
 	if !isServerRunning(ec2ServerBind) {
 		if err := StartProxyServerProcess(); err != nil {
 			return err

--- a/server/ec2alias_bsd.go
+++ b/server/ec2alias_bsd.go
@@ -4,6 +4,6 @@ package server
 
 import "os/exec"
 
-func installNetworkAlias() ([]byte, error) {
+func installEc2EndpointNetworkAlias() ([]byte, error) {
 	return exec.Command("ifconfig", "lo0", "alias", "169.254.169.254").CombinedOutput()
 }

--- a/server/ec2alias_linux.go
+++ b/server/ec2alias_linux.go
@@ -4,6 +4,6 @@ package server
 
 import "os/exec"
 
-func installNetworkAlias() ([]byte, error) {
+func installEc2EndpointNetworkAlias() ([]byte, error) {
 	return exec.Command("ip", "addr", "add", "169.254.169.254/24", "dev", "lo", "label", "lo:0").CombinedOutput()
 }

--- a/server/ec2alias_windows.go
+++ b/server/ec2alias_windows.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func installNetworkAlias() ([]byte, error) {
+func installEc2EndpointNetworkAlias() ([]byte, error) {
 	out, err := exec.Command("netsh", "interface", "ipv4", "add", "address", "Loopback Pseudo-Interface 1", "169.254.169.254", "255.255.0.0").CombinedOutput()
 
 	if err == nil || strings.Contains(string(out), "The object already exists") {

--- a/server/ec2proxy_default.go
+++ b/server/ec2proxy_default.go
@@ -10,8 +10,8 @@ import (
 	"time"
 )
 
-// StartProxyServerProcess starts a `aws-vault server` process
-func StartProxyServerProcess() error {
+// StartEc2EndpointProxyServerProcess starts a `aws-vault server` process
+func StartEc2EndpointProxyServerProcess() error {
 	log.Println("Starting `aws-vault server` in the background")
 	cmd := exec.Command(os.Args[0], "server")
 	cmd.Stdin = os.Stdin
@@ -21,8 +21,8 @@ func StartProxyServerProcess() error {
 		return err
 	}
 	time.Sleep(time.Second * 1)
-	if !isServerRunning(metadataBind) {
-		return errors.New("The credential proxy server isn't running. Run aws-vault server as Administrator in the background and then try this command again")
+	if !isServerRunning(ec2MetadataEndpointAddr) {
+		return errors.New("The EC2 Instance Metadata endpoint proxy server isn't running. Run `aws-vault server` as Administrator or root in the background and then try this command again")
 	}
 	return nil
 }

--- a/server/ec2proxy_unix.go
+++ b/server/ec2proxy_unix.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 )
 
-// StartProxyServerProcess starts a `aws-vault server` process
-func StartProxyServerProcess() error {
+// StartEc2EndpointProxyServerProcess starts a `aws-vault server` process
+func StartEc2EndpointProxyServerProcess() error {
 	log.Println("Starting `aws-vault server` as root in the background")
 	cmd := exec.Command("sudo", "-b", os.Args[0], "server")
 	cmd.Stdin = os.Stdin

--- a/server/ecs.go
+++ b/server/ecs.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+type EcsCredentialServer struct {
+	Url           string
+	Authorization string
+}
+
+type EcsCredentialData struct {
+	AccessKeyID     string `json:"AccessKeyId"`
+	SecretAccessKey string `json:"SecretAccessKey"`
+	SessionToken    string `json:"Token"`
+	Expiration      string `json:"Expiration"`
+}
+
+type EcsCredentialError struct {
+	Message string `json:"message"`
+}
+
+func StartEcsCredentialServer(creds *credentials.Credentials) (*EcsCredentialServer, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	token, err := GenerateToken(16)
+	if err != nil {
+		return nil, err
+	}
+	srv := &http.Server{Addr: listener.Addr().String()}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == token {
+			body, err := getResponse(creds)
+			if err != nil {
+				body, err = json.Marshal(&EcsCredentialError{Message: err.Error()})
+				if err != nil {
+					log.Fatalf("Failed to serialize err: %s", err)
+				}
+			}
+			w.Write(body)
+		} else {
+			w.WriteHeader(http.StatusForbidden)
+			body, err := json.Marshal(&EcsCredentialError{Message: "invalid Authorization token"})
+			if err != nil {
+				log.Fatalf("Failed to serialize err: %s", err)
+			}
+			w.Write(body)
+		}
+	})
+
+	go func() {
+		// returns ErrServerClosed on graceful close
+		if err := srv.Serve(listener); err != http.ErrServerClosed {
+			log.Fatalf("Serve(): %s", err)
+		}
+	}()
+
+	return &EcsCredentialServer{
+		Authorization: token,
+		Url:           fmt.Sprintf("http://%s", listener.Addr().String()),
+	}, nil
+}
+
+func getResponse(creds *credentials.Credentials) ([]byte, error) {
+	val, err := creds.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	credsExpiresAt, err := creds.ExpiresAt()
+	if err != nil {
+		return nil, err
+	}
+
+	ecsCredential := &EcsCredentialData{
+		AccessKeyID:     val.AccessKeyID,
+		SecretAccessKey: val.SecretAccessKey,
+		SessionToken:    val.SessionToken,
+		Expiration:      credsExpiresAt.Format("2006-01-02T15:04:05Z"),
+	}
+	serialized, err := json.Marshal(&ecsCredential)
+	if err != nil {
+		return nil, err
+	}
+	return serialized, nil
+}
+
+func GenerateToken(bytes int) (string, error) {
+	b, err := GenerateRandomBytes(bytes)
+	return base64.RawURLEncoding.EncodeToString(b), err
+}
+
+func GenerateRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/server/ecs.go
+++ b/server/ecs.go
@@ -29,6 +29,7 @@ func withAuthorizationCheck(token string, next http.HandlerFunc) http.HandlerFun
 	}
 }
 
+// StartEcsCredentialServer starts an ECS credential server on a random port
 func StartEcsCredentialServer(creds *credentials.Credentials) (string, string, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -40,10 +41,10 @@ func StartEcsCredentialServer(creds *credentials.Credentials) (string, string, e
 	}
 
 	go func() {
-		err := http.Serve(listener, withAuthorizationCheck(token, ecsCredsHandler(creds)))
+		err := http.Serve(listener, logRequest(withAuthorizationCheck(token, ecsCredsHandler(creds))))
 		// returns ErrServerClosed on graceful close
 		if err != http.ErrServerClosed {
-			log.Fatalf("Serve(): %s", err)
+			log.Fatalf("ecs server: %s", err.Error())
 		}
 	}()
 

--- a/server/httplog.go
+++ b/server/httplog.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+type loggingMiddlewareResponseWriter struct {
+	http.ResponseWriter
+	Code int
+}
+
+func (w *loggingMiddlewareResponseWriter) WriteHeader(statusCode int) {
+	w.Code = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func logRequest(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestStart := time.Now()
+		w2 := &loggingMiddlewareResponseWriter{w, http.StatusOK}
+		handler.ServeHTTP(w2, r)
+		log.Printf("http: %s: %d %s %s (%s)", r.RemoteAddr, w2.Code, r.Method, r.URL, time.Since(requestStart))
+	})
+}


### PR DESCRIPTION
Rebases #375

AWS SDKs universally support the ECS Credential Service, which supports
reading the service URI from environment variables.

Providing an http interface allows the subprocess to refresh credentials
as long as the master credentials session is valid.

Supporting the ECS Credential provider offers the following advantages
over the EC2 Metadata provider:

- Binding to a random, ephimeral port
  - Does not require adminstrator privileges
  - Allows multiple providers simultaneously for discrete processes
  - Partially mitigates the security issues that accompany the EC2
    Metadata Service because the address is not well-known
- Requiring an Authorization token further mitigates the potential for
  another process to access the credentials, since the Authorization
  token is only exposed to the subprocess via environment variables
