### PR TITLE
Add --region to login and exec

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -56,6 +56,9 @@ func ConfigureExecCommand(app *kingpin.Application) {
 		Short('n').
 		BoolVar(&input.NoSession)
 
+	cmd.Flag("region", "The AWS region").
+		StringVar(&input.Config.Region)
+
 	cmd.Flag("mfa-token", "The MFA token to use").
 		Short('t').
 		StringVar(&input.Config.MfaToken)

--- a/cli/login.go
+++ b/cli/login.go
@@ -46,6 +46,9 @@ func ConfigureLoginCommand(app *kingpin.Application) {
 	cmd.Flag("path", "The AWS service you would like access").
 		StringVar(&input.Path)
 
+	cmd.Flag("region", "The AWS region").
+		StringVar(&input.Config.Region)
+
 	cmd.Flag("stdout", "Print login URL to stdout instead of opening in default browser").
 		Short('s').
 		BoolVar(&input.UseStdout)


### PR DESCRIPTION
Adds a `--region` override flag to login and exec

Fixes #531