### PR TITLE
Rename parent_profile to include_profile

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -56,6 +56,10 @@ func AddCommand(input AddCommandInput, keyring *vault.CredentialKeyring, awsConf
 		return fmt.Errorf("Your profile has a source_profile of %s, adding credentials to %s won't have any effect",
 			p.SourceProfile, input.ProfileName)
 	}
+	if p.IncludeProfile != "" {
+		return fmt.Errorf("Your profile has a include_profile of %s, adding credentials to %s won't have any effect",
+			p.IncludeProfile, input.ProfileName)
+	}
 	if p.ParentProfile != "" {
 		return fmt.Errorf("Your profile has a parent_profile of %s, adding credentials to %s won't have any effect",
 			p.ParentProfile, input.ProfileName)

--- a/vault/config.go
+++ b/vault/config.go
@@ -135,7 +135,8 @@ type ProfileSection struct {
 	RoleSessionName string `ini:"role_session_name,omitempty"`
 	DurationSeconds uint   `ini:"duration_seconds,omitempty"`
 	SourceProfile   string `ini:"source_profile,omitempty"`
-	ParentProfile   string `ini:"parent_profile,omitempty"`
+	ParentProfile   string `ini:"parent_profile,omitempty"` // deprecated
+	IncludeProfile  string `ini:"include_profile,omitempty"`
 	SSOStartURL     string `ini:"sso_start_url,omitempty"`
 	SSORegion       string `ini:"sso_region,omitempty"`
 	SSOAccountID    string `ini:"sso_account_id,omitempty"`
@@ -314,6 +315,15 @@ func (cl *ConfigLoader) populateFromConfigFile(config *Config, profileName strin
 	}
 
 	if psection.ParentProfile != "" {
+		fmt.Fprint(os.Stderr, "Warning: parent_profile is deprecated, please use include_profile instead in your AWS config")
+	}
+
+	if psection.IncludeProfile != "" {
+		err := cl.populateFromConfigFile(config, psection.IncludeProfile)
+		if err != nil {
+			return err
+		}
+	} else if psection.ParentProfile != "" {
 		err := cl.populateFromConfigFile(config, psection.ParentProfile)
 		if err != nil {
 			return err

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -33,11 +33,11 @@ mfa_Serial=arn:aws:iam::1234513441:mfa/blah
 region=us-east-1
 duration_seconds=1200
 
-[profile testparentprofile1]
+[profile testincludeprofile1]
 region=us-east-1
 
-[profile testparentprofile2]
-parent_profile=testparentprofile1
+[profile testincludeprofile2]
+include_profile=testincludeprofile1
 `)
 
 var nestedConfig = []byte(`[default]
@@ -163,8 +163,8 @@ func TestProfilesFromConfig(t *testing.T) {
 		{Name: "user2", Region: "us-east-1"},
 		{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
 		{Name: "withmfa", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2"},
-		{Name: "testparentprofile1", Region: "us-east-1"},
-		{Name: "testparentprofile2", ParentProfile: "testparentprofile1"},
+		{Name: "testincludeprofile1", Region: "us-east-1"},
+		{Name: "testincludeprofile2", IncludeProfile: "testincludeprofile1"},
 	}
 	actual := cfg.ProfileSections()
 
@@ -197,8 +197,8 @@ func TestAddProfileToExistingConfig(t *testing.T) {
 		{Name: "user2", Region: "us-east-1"},
 		{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
 		{Name: "withmfa", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2"},
-		{Name: "testparentprofile1", Region: "us-east-1"},
-		{Name: "testparentprofile2", ParentProfile: "testparentprofile1"},
+		{Name: "testincludeprofile1", Region: "us-east-1"},
+		{Name: "testincludeprofile2", IncludeProfile: "testincludeprofile1"},
 		{Name: "llamas", MfaSerial: "testserial", Region: "us-east-1", SourceProfile: "default"},
 	}
 	actual := cfg.ProfileSections()
@@ -238,7 +238,7 @@ func TestAddProfileToExistingNestedConfig(t *testing.T) {
 
 }
 
-func TestParentProfile(t *testing.T) {
+func TestIncludeProfile(t *testing.T) {
 	f := newConfigFile(t, exampleConfig)
 	defer os.Remove(f)
 
@@ -248,7 +248,7 @@ func TestParentProfile(t *testing.T) {
 	}
 
 	configLoader := &vault.ConfigLoader{File: configFile}
-	config, err := configLoader.LoadFromProfile("testparentprofile2")
+	config, err := configLoader.LoadFromProfile("testincludeprofile2")
 	if err != nil {
 		t.Fatalf("Should have found a profile: %v", err)
 	}
@@ -351,7 +351,7 @@ func TestSourceProfileCanReferToParent(t *testing.T) {
 [profile root]
 
 [profile foo]
-parent_profile=root
+include_profile=root
 source_profile=root
 `))
 	defer os.Remove(f)


### PR DESCRIPTION
Rename the `parent_profile` config variable to `include_profile` and expands the documentation.

Rationale: the relationship between profiles is not a parent-child relationship, it's a horizontal "mixin" import of config 

Fixes #520
