### PR TITLE
fix(sso): fix issue where file backend type is used

### DIFF
--- a/vault/ssorolecredentialsprovider.go
+++ b/vault/ssorolecredentialsprovider.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"time"
 
@@ -146,7 +147,13 @@ func (p *SSOOIDCProvider) GetAccessToken() (*SSOAccessToken, error) {
 		credsUpdated bool
 	)
 
-	item, err := p.Keyring.Keyring.Get(p.StartURL)
+	parsedUrl, err := url.Parse(p.StartURL)
+	if err != nil {
+		return nil, err
+	}
+	startUrlHost := parsedUrl.Host
+
+	item, err := p.Keyring.Keyring.Get(startUrlHost)
 	if err != nil && err != keyring.ErrKeyNotFound {
 		return nil, err
 	}
@@ -181,8 +188,8 @@ func (p *SSOOIDCProvider) GetAccessToken() (*SSOAccessToken, error) {
 			return nil, err
 		}
 		err = p.Keyring.Keyring.Set(keyring.Item{
-			Key:                         p.StartURL,
-			Label:                       fmt.Sprintf("aws-vault (%s)", p.StartURL),
+			Key:                         startUrlHost,
+			Label:                       fmt.Sprintf("aws-vault (%s)", startUrlHost),
 			Data:                        bytes,
 			KeychainNotTrustApplication: true,
 		})


### PR DESCRIPTION
This PR fixes an issue where using the sso start url as the keyring item key causes an issue when using the `file` backend type.

Instead of using the startUrl as the keyring item key it will now parse the URL and just use the URL Host. 

So if you have
```ini
sso_start_url=https://aws-sso-portal.awsapps.com/start
```

Then it will now store the sso credentials with the key `aws-sso-portal.awsapps.com`

BREAKING CHANGE: The SSO functionality hasn't been released yet, so it's not breaking yet, but would be if it gets released before this fix is merged. since the keyring item key is being changed, any existing sso credentials that have been added will have to be re-added with the new item key. 