### PR TITLE
Revert "Ignore case of section and key names when parsing config."

### DIFF
--- a/vault/config.go
+++ b/vault/config.go
@@ -116,7 +116,6 @@ func (c *ConfigFile) parseFile() error {
 	log.Printf("Parsing config file %s", c.Path)
 	f, err := ini.LoadSources(ini.LoadOptions{
 		AllowNestedValues: true,
-		Insensitive:       true,
 	}, c.Path)
 	if err != nil {
 		return fmt.Errorf("Error parsing config file %q: %v", c.Path, err)

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -26,10 +26,10 @@ output=text
 source_profile=user2
 region=us-east-1
 
-[profile withMFA]
+[profile withmfa]
 source_profile=user2
 role_arn=arn:aws:iam::4451234513441615400570:role/aws_admin
-mfa_Serial=arn:aws:iam::1234513441:mfa/blah
+mfa_serial=arn:aws:iam::1234513441:mfa/blah
 region=us-east-1
 duration_seconds=1200
 
@@ -71,26 +71,6 @@ func newConfigFile(t *testing.T, b []byte) string {
 		t.Fatal(err)
 	}
 	return f.Name()
-}
-
-func TestConfigCaseInsensitivity(t *testing.T) {
-	f := newConfigFile(t, exampleConfig)
-	defer os.Remove(f)
-
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	def, ok := cfg.ProfileSection("withmfa")
-	if !ok {
-		t.Fatalf("Expected to match profile withMFA")
-	}
-
-	expectedMfaSerial := "arn:aws:iam::1234513441:mfa/blah"
-	if def.MfaSerial != expectedMfaSerial {
-		t.Fatalf("Expected %s, got %s", expectedMfaSerial, def.MfaSerial)
-	}
 }
 
 func TestConfigParsingProfiles(t *testing.T) {


### PR DESCRIPTION
Reverts 99designs/aws-vault#461 to resolve #528