### PR TITLE
Fix infinite recursion issue for missing/invalid profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,17 +145,23 @@ sso_role_name=Administrator
 
 This profile should work expected with AWS Vault commands, e.g. `exec` and `login`. See [Basic Usage](#basic-usage) for more information.
 
-## Development
+## Local Development
+Have [go installed](https://golang.org/doc/install?download=go1.14.1.darwin-amd64.pkg)
 
 The [macOS release builds](https://github.com/99designs/aws-vault/releases) are code-signed to avoid extra prompts in Keychain. You can verify this with:
 
     $ codesign --verify --verbose $(which aws-vault)
 
-If you are developing or compiling the aws-vault binary yourself, you can [generate a self-signed certificate](https://support.apple.com/en-au/guide/keychain-access/kyca8916/mac) by accessing Keychain Access > Certificate Assistant > Create Certificate > Code Signing Certificate. You can then sign your binary with:
+If you are developing or compiling the aws-vault binary yourself, you can [generate a self-signed certificate](https://support.apple.com/en-au/guide/keychain-access/kyca8916/mac) by accessing Keychain Access > Certificate Assistant > Create Certificate
+The certificate 'Name' can be whatever; the 'Identity Type' can be the default; for Certificate Type choose 'Code Signing'; hit create.
+
+You can then sign your binary with:
 
     $ go build .
-    $ codesign --sign "Name of my certificate" ./aws-vault
+    $ codesign --sign <Name of certificate created above> ./aws-vault
+    $ go run main.go # should work if everything was configured correctly
 
+`go run main.go` is the local equivalent of running `aws-vault`
 
 ## References and Inspiration
 

--- a/vault/credentialkeyring.go
+++ b/vault/credentialkeyring.go
@@ -26,6 +26,9 @@ func (ck *CredentialKeyring) CredentialsKeys() (credentialsNames []string, err e
 }
 
 func (ck *CredentialKeyring) Has(credentialsName string) (bool, error) {
+	if credentialsName == "" {
+		return false, fmt.Errorf("Error finding credentials")
+	}
 	allKeys, err := ck.Keyring.Keys()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
- happens when invalid profile is passed to login command
- did some light tweaks to README

## issues
https://github.com/99designs/aws-vault/issues/545
https://github.com/99designs/aws-vault/issues/507#issuecomment-577427034

## testing
manually from CLI

## credits 
fix is from https://github.com/99designs/aws-vault/issues/507#issuecomment-577427034 - just changed error message to be more generic

## notes
- i don't know this code base, so unintended consequences are totally possible so 👀 would be appreciated
- error message IMO shouldn't say "empty credential name" (even though it's more specific) because it'll then bubble up that as the error message for invalid profiles
