### PR TITLE
Get aws vault params from ~/.aws/config file (v2)

### DIFF
--- a/cli/global.go
+++ b/cli/global.go
@@ -102,7 +102,6 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 		EnumVar(&a.KeyringBackend, backendsAvailable...)
 
 	app.Flag("prompt", fmt.Sprintf("Prompt driver to use %v", promptsAvailable)).
-		Default("terminal").
 		Envar("AWS_VAULT_PROMPT").
 		EnumVar(&a.PromptDriver, promptsAvailable...)
 

--- a/vault/config.go
+++ b/vault/config.go
@@ -41,8 +41,8 @@ type ConfigFile struct {
 	iniFile *ini.File
 }
 
-// configPath returns either $AWS_CONFIG_FILE or ~/.aws/config
-func configPath() (string, error) {
+// ConfigPath returns either $AWS_CONFIG_FILE or ~/.aws/config
+func ConfigPath() (string, error) {
 	file := os.Getenv("AWS_CONFIG_FILE")
 	if file == "" {
 		home, err := homedir.Dir()
@@ -58,7 +58,7 @@ func configPath() (string, error) {
 
 // createConfigFilesIfMissing will create the config directory and file if they do not exist
 func createConfigFilesIfMissing() error {
-	file, err := configPath()
+	file, err := ConfigPath()
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func LoadConfig(path string) (*ConfigFile, error) {
 
 // LoadConfigFromEnv finds the config file from the environment
 func LoadConfigFromEnv() (*ConfigFile, error) {
-	file, err := configPath()
+	file, err := ConfigPath()
 	if err != nil {
 		return nil, err
 	}

--- a/vault/config.go
+++ b/vault/config.go
@@ -24,6 +24,8 @@ const (
 
 	defaultSectionName          = "default"
 	roleChainingMaximumDuration = 1 * time.Hour
+
+	defaultMfaPromptMethod = "terminal"
 )
 
 // UseSession will disable the use of GetSessionToken when set to false
@@ -140,6 +142,7 @@ func (c *ConfigFile) parseFile() error {
 type ProfileSection struct {
 	Name            string `ini:"-"`
 	MfaSerial       string `ini:"mfa_serial,omitempty"`
+	MfaPromptMethod string `ini:"mfa_prompt,omitempty"`
 	RoleARN         string `ini:"role_arn,omitempty"`
 	ExternalID      string `ini:"external_id,omitempty"`
 	Region          string `ini:"region,omitempty"`
@@ -278,6 +281,9 @@ func (cl *ConfigLoader) populateFromDefaults(config *Config) {
 	if config.ChainedGetSessionTokenDuration == 0 {
 		config.ChainedGetSessionTokenDuration = DefaultChainedSessionDuration
 	}
+	if config.MfaPromptMethod == "" {
+		config.MfaPromptMethod = defaultMfaPromptMethod
+	}
 }
 
 func (cl *ConfigLoader) populateFromConfigFile(config *Config, profileName string) error {
@@ -293,6 +299,9 @@ func (cl *ConfigLoader) populateFromConfigFile(config *Config, profileName strin
 
 	if config.MfaSerial == "" {
 		config.MfaSerial = psection.MfaSerial
+	}
+	if config.MfaPromptMethod == "" {
+		config.MfaPromptMethod = psection.MfaPromptMethod
 	}
 	if config.RoleARN == "" {
 		config.RoleARN = psection.RoleARN


### PR DESCRIPTION
As suggested in #582, read keyring params from the separate section

```
[aws-vault]
backend = pass
pass_prefix = aws-vault

[default]
output=table
region = eu-central-1
mfa_prompt = osascript
```

mfa prompt method is already passed in Config.MfaPromptMethod,
so I think it's better to read it from the profile config