### PR TITLE
Add credential helper provider

### DIFF
--- a/vault/config.go
+++ b/vault/config.go
@@ -154,6 +154,7 @@ type ProfileSection struct {
 	SSORoleName             string `ini:"sso_role_name,omitempty"`
 	WebIdentityTokenFile    string `ini:"web_identity_token_file,omitempty"`
 	WebIdentityTokenProcess string `ini:"web_identity_token_process,omitempty"`
+	CredentialProcess        string `ini:"credential_process,omitempty"`
 }
 
 func (s ProfileSection) IsEmpty() bool {
@@ -333,6 +334,10 @@ func (cl *ConfigLoader) populateFromConfigFile(config *Config, profileName strin
 		config.WebIdentityTokenProcess = psection.WebIdentityTokenProcess
 	}
 
+	if config.CredentialProcess == "" {
+		config.CredentialProcess = psection.CredentialProcess
+	}
+
 	if psection.ParentProfile != "" {
 		fmt.Fprint(os.Stderr, "Warning: parent_profile is deprecated, please use include_profile instead in your AWS config")
 	}
@@ -509,6 +514,9 @@ type Config struct {
 
 	// SSORoleName specifies the AWS SSO Role name to target.
 	SSORoleName string
+
+	// CredentialProcess specifies the external process to call to retrieve credentials
+	CredentialProcess string
 }
 
 func (c *Config) IsChained() bool {
@@ -537,6 +545,10 @@ func (c *Config) HasWebIdentityTokenFile() bool {
 
 func (c *Config) HasWebIdentityTokenProcess() bool {
 	return c.WebIdentityTokenProcess != ""
+}
+
+func (c *Config) HasCredentialProcess() bool {
+	return c.CredentialProcess != ""
 }
 
 // CanUseGetSessionToken determines if GetSessionToken should be used, and if not returns a reason

--- a/vault/config.go
+++ b/vault/config.go
@@ -154,7 +154,7 @@ type ProfileSection struct {
 	SSORoleName             string `ini:"sso_role_name,omitempty"`
 	WebIdentityTokenFile    string `ini:"web_identity_token_file,omitempty"`
 	WebIdentityTokenProcess string `ini:"web_identity_token_process,omitempty"`
-	CredentialProcess        string `ini:"credential_process,omitempty"`
+	CredentialProcess       string `ini:"credential_process,omitempty"`
 }
 
 func (s ProfileSection) IsEmpty() bool {

--- a/vault/credentialprocessprovider.go
+++ b/vault/credentialprocessprovider.go
@@ -1,0 +1,53 @@
+package vault
+
+import (
+	"encoding/json"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type CredentialProcessProvider struct {
+	CredentialProcess string
+	ExpiryWindow      time.Duration
+	credentials.Expiry
+}
+
+type CredentialProcessResponse struct {
+	AccessKeyId     string    `json:"AccessKeyId"`
+	SecretAccessKey string    `json:"SecretAccessKey"`
+	SessionToken    string    `json:"SessionToken"`
+	Expiration      time.Time `json:"Expiration"`
+	Version         int       `json:"Version"`
+}
+
+// Retrieve fetch credentials from an external process
+func (p *CredentialProcessProvider) Retrieve() (credentials.Value, error) {
+	cred, err := p.callCredentialProcess()
+	if err != nil {
+		return credentials.Value{}, err
+	}
+
+	p.SetExpiration(cred.Expiration, p.ExpiryWindow)
+	return credentials.Value{
+		AccessKeyID:     cred.AccessKeyId,
+		SecretAccessKey: cred.SecretAccessKey,
+		SessionToken:    cred.SessionToken,
+	}, nil
+}
+
+func (p *CredentialProcessProvider) callCredentialProcess() (CredentialProcessResponse, error) {
+	params := strings.Split(p.CredentialProcess, " ")
+	cmd := exec.Command(params[0], params[1:]...)
+	out, err := cmd.Output()
+	if err != nil {
+		return CredentialProcessResponse{}, err
+	}
+	var cred CredentialProcessResponse
+	err = json.Unmarshal(out, &cred)
+	if err != nil {
+		return CredentialProcessResponse{}, err
+	}
+	return cred, nil
+}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -135,6 +135,16 @@ func NewAssumeRoleProvider(creds *credentials.Credentials, k keyring.Keyring, co
 	return p, nil
 }
 
+// NewCredentialProcessProvider returns a provider that retrieves
+// credentials from an external process
+func NewCredentialProcessProvider(config *Config) (credentials.Provider, error) {
+	p := &CredentialProcessProvider{
+		CredentialProcess: config.CredentialProcess,
+		ExpiryWindow:      defaultExpirationWindow,
+	}
+	return p, nil
+}
+
 // NewAssumeRoleWithWebIdentityProvider returns a provider that generates
 // credentials using AssumeRoleWithWebIdentity
 func NewAssumeRoleWithWebIdentityProvider(k keyring.Keyring, config *Config) (credentials.Provider, error) {
@@ -227,6 +237,8 @@ func (t *tempCredsCreator) provider(config *Config) (credentials.Provider, error
 		return NewSSORoleCredentialsProvider(t.keyring.Keyring, config)
 	} else if config.HasRole() && (config.HasWebIdentityTokenFile() || config.HasWebIdentityTokenProcess()) {
 		return NewAssumeRoleWithWebIdentityProvider(t.keyring.Keyring, config)
+	} else if config.HasCredentialProcess() {
+		return NewCredentialProcessProvider(config)
 	} else {
 		return nil, fmt.Errorf("profile %s: credentials missing", config.ProfileName)
 	}


### PR DESCRIPTION
Implements credential process as a new credential provider.

Based on the [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes)

aws-vault can be used as a source for credential_process but could not use one to retrieve credentials.