### PR TITLE
Use RFC3339 consistently for expiration times

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -226,7 +226,7 @@ func execCredentialHelper(input ExecCommandInput, config *vault.Config, creds *c
 		credentialData.SessionToken = val.SessionToken
 	}
 	if credsExpiresAt, err := creds.ExpiresAt(); err == nil {
-		credentialData.Expiration = credsExpiresAt.Format("2006-01-02T15:04:05Z")
+		credentialData.Expiration = credsExpiresAt.Format(time.RFC3339)
 	}
 
 	json, err := json.Marshal(&credentialData)

--- a/server/ec2.go
+++ b/server/ec2.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	awsTimeFormat            = "2006-01-02T15:04:05Z"
+	awsTimeFormat            = time.RFC3339
 	ec2MetadataEndpointIP    = "169.254.169.254"
 	ec2MetadataEndpointAddr  = "169.254.169.254:80"
 	ec2CredentialsServerAddr = "127.0.0.1:9099"

--- a/server/ecs.go
+++ b/server/ecs.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
@@ -71,7 +72,7 @@ func ecsCredsHandler(creds *credentials.Credentials) http.HandlerFunc {
 			"AccessKeyId":     val.AccessKeyID,
 			"SecretAccessKey": val.SecretAccessKey,
 			"Token":           val.SessionToken,
-			"Expiration":      credsExpiresAt.Format("2006-01-02T15:04:05Z"),
+			"Expiration":      credsExpiresAt.Format(time.RFC3339),
 		})
 		if err != nil {
 			writeErrorMessage(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Hi aws-vault maintainers, thanks for this lovely tool and the excellent recent additions in the v6 beta! I've got a minor update here to use RFC3339 for all `time.Format()` calls related to credential expiration.

`exec` was using RFC3339 in some places but `"2006-01-02T15:04:05Z"` in others. The latter format renders:

```
2020-06-04T13:14:44-04:00
```

as:

```
2020-06-04T13:09:44Z
```

and leads to `Credentials were refreshed, but the refreshed credentials are still expired` errors as noted in #331. In the v6 beta I've seen those errors with both the credential helper and `--ecs-server` functionality.