### PR TITLE
Add an arm7 binary target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ aws-vault-linux-amd64: $(SRC)
 aws-vault-linux-arm64: $(SRC)
 	GOOS=linux GOARCH=arm64 go build $(BUILD_FLAGS) -o $@ .
 
+aws-vault-linux-arm7: $(SRC)
+	GOOS=linux GOARM=7 GOARCH=arm go build $(BUILD_FLAGS) -o $@ .
+
 aws-vault-windows-386.exe: $(SRC)
 	GOOS=windows GOARCH=386 go build $(BUILD_FLAGS) -o $@ .
 


### PR DESCRIPTION
Allow users to easily download a binary release targeting arm7 architecture,
useful for users of raspberry pis and similar hardware

Note; sorry I've not really evaluated whether this is particularly desirable or not for the project, please feel free to discard it. It's trivial to build oneself but I thought it might be useful for folks hitting the repository with hobbyist use cases in mind!