### PR TITLE
Refresh cached credentials if already expired when calling Retrieve

### DIFF
--- a/vault/cachedsessionprovider.go
+++ b/vault/cachedsessionprovider.go
@@ -22,8 +22,15 @@ type CachedSessionProvider struct {
 // generates a new set of temporary credentials using the CredentialsFunc
 func (p *CachedSessionProvider) Retrieve() (credentials.Value, error) {
 	creds, err := p.Keyring.Get(p.SessionKey)
-	if err != nil {
-		// lookup missed, we need to create a new one.
+
+	if err != nil || time.Until(*creds.Expiration) < 0 {
+		if err != nil {
+			// lookup missed, we need to create a new one.
+			log.Printf("CachedSessionProvider creating new credentials")
+		} else {
+			// Cached credential expired; create a new one.
+			log.Printf("CachedSessionProvider creating new credentials to replace expired cache")
+		}
 		creds, err = p.CredentialsFunc()
 		if err != nil {
 			return credentials.Value{}, err

--- a/vault/cachedsessionprovider.go
+++ b/vault/cachedsessionprovider.go
@@ -23,14 +23,8 @@ type CachedSessionProvider struct {
 func (p *CachedSessionProvider) Retrieve() (credentials.Value, error) {
 	creds, err := p.Keyring.Get(p.SessionKey)
 
-	if err != nil || time.Until(*creds.Expiration) < 0 {
-		if err != nil {
-			// lookup missed, we need to create a new one.
-			log.Printf("CachedSessionProvider creating new credentials")
-		} else {
-			// Cached credential expired; create a new one.
-			log.Printf("CachedSessionProvider creating new credentials to replace expired cache")
-		}
+	if err != nil || time.Until(*creds.Expiration) < p.ExpiryWindow {
+		// lookup missed, we need to create a new one.
 		creds, err = p.CredentialsFunc()
 		if err != nil {
 			return credentials.Value{}, err

--- a/vault/sessionkeyring.go
+++ b/vault/sessionkeyring.go
@@ -99,7 +99,7 @@ type SessionKeyring struct {
 	isGarbageCollected bool
 }
 
-var ErrNotFound = fmt.Errorf("Key not found")
+var ErrNotFound = keyring.ErrKeyNotFound
 
 func (sk *SessionKeyring) lookupKeyName(key SessionMetadata) (string, error) {
 	allKeys, err := sk.Keyring.Keys()
@@ -138,7 +138,8 @@ func (sk *SessionKeyring) Get(key SessionMetadata) (val *sts.Credentials, err er
 		return val, err
 	}
 	if err = json.Unmarshal(item.Data, &val); err != nil {
-		return val, fmt.Errorf("Invalid data in keyring: %w", err)
+		log.Printf("SessionKeyring: Ignoring invalid data: %s", err.Error())
+		return val, ErrNotFound
 	}
 	return val, err
 }


### PR DESCRIPTION
I'm fairly certain this is a bug, but could be specific to one of my use cases.  In this case I have a credential `42lines-vault` that is restricted by MFA.  I have a profile I assume `qa-assume` from the first credential.  The `qa-assume` credential is used by the metadata server.

When the ec2 metadata server refreshes the expired `qa-assume` credentials, there is no check to see if the cached `42lines-vault` credentials are expired;  `cachedsessionprovider.go` only checks for existence.

Logs which include call tracing I added.  (I have set the expiration time on the assume credential to 15 minutes to reduce the testing window, but this same behavior happens if the expiration is one hour.)  Note the expiration time of the cached credential:
`Re-using cached credentials ****************F2EM from sts.GetSessionToken, expires in -8m44.905996s`

Current upstream:
```
bash-5.0$ curl -s http://169.254.169.254:80/latest/meta-data/iam/security-credentials/local-credentials
2020/06/29 23:19:23 server.go:2012 ServeHTTP() -> ec2.go:124 func1()
2020/06/29 23:19:23 Credentials.IsExpired() = true
2020/06/29 23:19:23 credentials.go:263 singleRetrieve() -> assumeroleprovider.go:28 Retrieve()
2020/06/29 23:19:23 assumeroleprovider.go:29 Retrieve() -> assumeroleprovider.go:55 assumeRole()
2020/06/29 23:19:23 assumeroleprovider.go:59 assumeRole() -> assumeroleprovider.go:43 roleSessionName()
2020/06/29 23:19:23 credentials.go:263 singleRetrieve() -> cachedsessionprovider.go:25 Retrieve()
2020/06/29 23:19:23 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/06/29 23:19:23 [keyring] Found 2 results
2020/06/29 23:19:23 [keyring] Querying keychain for service="aws-vault", account="sts.GetSessionToken,NDJsaW5lcy12YXVsdA,YXJuOmF3czppYW06OjY4OTM1NTQ5NjQ4MzptZmEvamJyb3duZQ,1593497446", keychain="aws-vault.keychain"
2020/06/29 23:19:30 [keyring] Found item "aws-vault session for 42lines-vault (expires 2020-06-30T06:10:46Z)"
2020/06/29 23:19:30 Re-using cached credentials ****************F2EM from sts.GetSessionToken, expires in -8m44.905996s
2020/06/29 23:19:31 credentials.go:263 singleRetrieve() -> cachedsessionprovider.go:25 Retrieve()
2020/06/29 23:19:31 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/06/29 23:19:31 [keyring] Found 2 results
2020/06/29 23:19:31 [keyring] Querying keychain for service="aws-vault", account="sts.GetSessionToken,NDJsaW5lcy12YXVsdA,YXJuOmF3czppYW06OjY4OTM1NTQ5NjQ4MzptZmEvamJyb3duZQ,1593497446", keychain="aws-vault.keychain"
2020/06/29 23:19:31 [keyring] Found item "aws-vault session for 42lines-vault (expires 2020-06-30T06:10:46Z)"
2020/06/29 23:19:31 Re-using cached credentials ****************F2EM from sts.GetSessionToken, expires in -8m45.384079s
2020/06/29 23:19:31 credentials.go:263 singleRetrieve() -> cachedsessionprovider.go:25 Retrieve()
2020/06/29 23:19:31 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/06/29 23:19:31 [keyring] Found 2 results
2020/06/29 23:19:31 [keyring] Querying keychain for service="aws-vault", account="sts.GetSessionToken,NDJsaW5lcy12YXVsdA,YXJuOmF3czppYW06OjY4OTM1NTQ5NjQ4MzptZmEvamJyb3duZQ,1593497446", keychain="aws-vault.keychain"
2020/06/29 23:19:31 [keyring] Found item "aws-vault session for 42lines-vault (expires 2020-06-30T06:10:46Z)"
2020/06/29 23:19:31 Re-using cached credentials ****************F2EM from sts.GetSessionToken, expires in -8m45.592094s
2020/06/29 23:19:31 credentials.go:263 singleRetrieve() -> cachedsessionprovider.go:25 Retrieve()
2020/06/29 23:19:31 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/06/29 23:19:31 [keyring] Found 2 results
2020/06/29 23:19:31 [keyring] Querying keychain for service="aws-vault", account="sts.GetSessionToken,NDJsaW5lcy12YXVsdA,YXJuOmF3czppYW06OjY4OTM1NTQ5NjQ4MzptZmEvamJyb3duZQ,1593497446", keychain="aws-vault.keychain"
2020/06/29 23:19:31 [keyring] Found item "aws-vault session for 42lines-vault (expires 2020-06-30T06:10:46Z)"
2020/06/29 23:19:31 Re-using cached credentials ****************F2EM from sts.GetSessionToken, expires in -8m45.902778s
2020/06/29 23:19:32 http: 127.0.0.1:55452: 504 GET /latest/meta-data/iam/security-credentials/local-credentials (8.673638634s)
ExpiredToken: The security token included in the request is expired
	status code: 403, request id: 4135598c-0cf4-47ae-bb24-6cfe1c65c3ff
```

With my change:
```
bash-5.0$ curl -s http://169.254.169.254:80/latest/meta-data/iam/security-credentials/local-credentials
2020/06/30 00:06:11 server.go:2012 ServeHTTP() -> ec2.go:124 func1()
2020/06/30 00:06:11 Credentials.IsExpired() = true
2020/06/30 00:06:11 credentials.go:263 singleRetrieve() -> assumeroleprovider.go:28 Retrieve()
2020/06/30 00:06:11 assumeroleprovider.go:29 Retrieve() -> assumeroleprovider.go:55 assumeRole()
2020/06/30 00:06:11 assumeroleprovider.go:59 assumeRole() -> assumeroleprovider.go:43 roleSessionName()
2020/06/30 00:06:11 credentials.go:263 singleRetrieve() -> cachedsessionprovider.go:25 Retrieve()
2020/06/30 00:06:11 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/06/30 00:06:11 [keyring] Found 2 results
2020/06/30 00:06:11 [keyring] Querying keychain for service="aws-vault", account="sts.GetSessionToken,NDJsaW5lcy12YXVsdA,YXJuOmF3czppYW06OjY4OTM1NTQ5NjQ4MzptZmEvamJyb3duZQ,1593500465", keychain="aws-vault.keychain"
2020/06/30 00:06:17 [keyring] Found item "aws-vault session for 42lines-vault (expires 2020-06-30T07:01:05Z)"
2020/06/30 00:06:17 CachedSessionProvider creating new credentials to replace expired cache
2020/06/30 00:06:17 cachedsessionprovider.go:36 Retrieve() -> sessiontokenprovider.go:42 GetSessionToken()
2020/06/30 00:06:17 sessiontokenprovider.go:49 GetSessionToken() -> vault.go:48 GetMfaToken()
2020/06/30 00:06:17 Fetching MFA code using `ykman oath code --single arn:aws:iam::8675309:mfa/user`
Touch your YubiKey...
2020/06/30 00:06:19 Looking up keyring for '42lines-vault'
2020/06/30 00:06:19 [keyring] Querying keychain for service="aws-vault", account="42lines-vault", keychain="aws-vault.keychain"
2020/06/30 00:06:19 [keyring] Found item "aws-vault (42lines-vault)"
2020/06/30 00:06:20 Generated credentials ****************2RV5 using GetSessionToken, expires in 7h59m26.614286s
2020/06/30 00:06:20 [keyring] Querying keychain for service="aws-vault", keychain="aws-vault.keychain"
2020/06/30 00:06:20 [keyring] Found 2 results
2020/06/30 00:06:20 [keyring] Removing keychain item service="aws-vault", account="sts.GetSessionToken,NDJsaW5lcy12YXVsdA,YXJuOmF3czppYW06OjY4OTM1NTQ5NjQ4MzptZmEvamJyb3duZQ,1593500465", keychain "aws-vault.keychain"
2020/06/30 00:06:20 [keyring] Checking keychain status
2020/06/30 00:06:20 [keyring] Keychain status returned nil, keychain exists
2020/06/30 00:06:20 [keyring] Keychain item trusts keyring
2020/06/30 00:06:20 [keyring] Adding service="aws-vault", label="aws-vault session for 42lines-vault (expires 2020-06-30T15:05:47Z)", account="sts.GetSessionToken,NDJsaW5lcy12YXVsdA,YXJuOmF3czppYW06OjY4OTM1NTQ5NjQ4MzptZmEvamJyb3duZQ,1593529547", trusted=true to osx keychain "aws-vault.keychain"
2020/06/30 00:06:20 Generated credentials ****************ABXS using AssumeRole, expires in 14m26.475616s
2020/06/30 00:06:20 Serving credentials via http ****************ABXS, expiration of 2020-06-30T07:15:47Z (9m26.47555s)
2020/06/30 00:06:20 http: 127.0.0.1:55712: 200 GET /latest/meta-data/iam/security-credentials/local-credentials (8.567801931s)
```