### PR TITLE
Add possibility to check for localised error messages, add localised …

### DIFF
--- a/server/ec2alias_windows.go
+++ b/server/ec2alias_windows.go
@@ -8,16 +8,39 @@ import (
 	"strings"
 )
 
+var alreadyRegisteredLocalised = []string{
+	"The object already exists",
+	"Das Objekt ist bereits vorhanden",
+}
+
+var runAsAdministratorLocalised = []string{
+	"Run as administrator",
+	// truncate before 'Umlaut' to avoid encoding problems coming from Windows cmd
+	"Als Administrator ausf",
+}
+
 func installEc2EndpointNetworkAlias() ([]byte, error) {
 	out, err := exec.Command("netsh", "interface", "ipv4", "add", "address", "Loopback Pseudo-Interface 1", "169.254.169.254", "255.255.0.0").CombinedOutput()
 
-	if err == nil || strings.Contains(string(out), "The object already exists") {
+	outMsg := string(out)
+
+	if err == nil || msgFound(alreadyRegisteredLocalised, outMsg) {
 		return []byte{}, nil
 	}
 
-	if strings.Contains(string(out), "Run as administrator") {
+	if msgFound(runAsAdministratorLocalised, outMsg) {
 		fmt.Println("Creation of network alias for server mode requires elevated permissions (Run as administrator).")
 	}
 
 	return out, err
+}
+
+func msgFound(localised []string, toTest string) bool {
+	for _, value := range localised {
+		if strings.Contains(toTest, value) {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
This fixes #607.
Added the possibility to internationalise/localise error messages from the `netsh` command via cmd. 

I also looked into the possibility of using Powershell instead of netsh, but didn't see any benefit as I did not find proper error codes either and the errors messages were also localised. 