### PR TITLE
Add a prompt that is native to Windows

### DIFF
--- a/prompt/credui_windows.go
+++ b/prompt/credui_windows.go
@@ -21,7 +21,7 @@ type creduiInfoA struct {
 	hbmBanner      uintptr
 }
 
-func WindowsMfaPrompt(mfaSerial string) (string, error) {
+func CredUiPrompt(mfaSerial string) (string, error) {
 	info := &creduiInfoA{
 		hwndParent:     0,
 		pszCaptionText: syscall.StringToUTF16Ptr("Enter token for aws-vault"),
@@ -54,5 +54,5 @@ func WindowsMfaPrompt(mfaSerial string) (string, error) {
 }
 
 func init() {
-	Methods["credui"] = WindowsMfaPrompt
+	Methods["credui"] = CredUiPrompt
 }

--- a/prompt/native_windows.go
+++ b/prompt/native_windows.go
@@ -1,0 +1,66 @@
+package prompt
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	credui = syscall.NewLazyDLL("credui.dll")
+
+	procCredUIPromptForCredentials = credui.NewProc("CredUIPromptForCredentialsW")
+
+	ErrFailed = errors.New("Failed.")
+)
+
+const (
+	CREDUI_FLAGS_ALWAYS_SHOW_UI      = 0x00080
+	CREDUI_FLAGS_GENERIC_CREDENTIALS = 0x40000
+	CREDUI_FLAGS_KEEP_USERNAME       = 0x100000
+)
+
+type CREDUI_INFO struct {
+	cbSize         uint32
+	hwndParent     uintptr
+	pszMessageText *uint16
+	pszCaptionText *uint16
+	hbmBanner      uintptr
+}
+
+func WindowsMfaPrompt(mfaSerial string) (string, error) {
+	info := &CREDUI_INFO{
+		hwndParent:     0,
+		pszCaptionText: syscall.StringToUTF16Ptr("Enter token for aws-vault"),
+		pszMessageText: syscall.StringToUTF16Ptr(mfaPromptMessage(mfaSerial)),
+		hbmBanner:      0,
+	}
+	info.cbSize = uint32(unsafe.Sizeof(*info))
+	passwordBuf := make([]uint16, 64)
+	save := false
+	flags := CREDUI_FLAGS_ALWAYS_SHOW_UI | CREDUI_FLAGS_KEEP_USERNAME | CREDUI_FLAGS_GENERIC_CREDENTIALS
+	shortSerial := strings.ReplaceAll(strings.ReplaceAll(mfaSerial, "arn:aws:iam::", ""), ":mfa", "")
+	ret, _, _ := procCredUIPromptForCredentials.Call(
+		uintptr(unsafe.Pointer(info)),
+		uintptr(unsafe.Pointer(syscall.StringBytePtr("aws-vault"))),
+		0,
+		0,
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(shortSerial))),
+		uintptr(len(shortSerial)+1),
+		uintptr(unsafe.Pointer(&passwordBuf[0])),
+		64,
+		uintptr(unsafe.Pointer(&save)),
+		uintptr(flags),
+	)
+
+	if ret != 0 {
+		return "", ErrFailed
+	}
+
+	return strings.TrimSpace(syscall.UTF16ToString(passwordBuf)), nil
+}
+
+func init() {
+	Methods["native"] = WindowsMfaPrompt
+}


### PR DESCRIPTION
This solved a pain point for me when using aws-vault on windows as a credential helper, since the console prompt doesn't work in that scenario. 

Forgive me, this is the first Go code that I've ever written. Hope it can be worked into something mergeable

Thanks