### PR TITLE
Add --force-new-session option to exec command

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -29,6 +29,7 @@ type ExecCommandInput struct {
 	Config           vault.Config
 	SessionDuration  time.Duration
 	NoSession        bool
+	ForceNewSession  bool
 }
 
 // AwsCredentialHelperData is metadata for AWS CLI credential process
@@ -56,6 +57,10 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 
 	cmd.Flag("region", "The AWS region").
 		StringVar(&input.Config.Region)
+
+	cmd.Flag("force-new-session", "Force a new session to be created and update cache").
+		Short('f').
+		BoolVar(&input.ForceNewSession)
 
 	cmd.Flag("mfa-token", "The MFA token to use").
 		Short('t').
@@ -129,8 +134,12 @@ func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Ke
 	if input.StartEcsServer && input.NoSession {
 		return fmt.Errorf("Can't use --ecs-server with --no-session")
 	}
+	if input.ForceNewSession && input.NoSession {
+		return fmt.Errorf("Can't use --force-new-session with --no-session")
+	}
 
 	vault.UseSession = !input.NoSession
+	vault.ForceNewSession = input.ForceNewSession
 
 	configLoader := vault.ConfigLoader{
 		File:          f,

--- a/vault/cachedsessionprovider.go
+++ b/vault/cachedsessionprovider.go
@@ -15,6 +15,7 @@ type CachedSessionProvider struct {
 	CredentialsFunc func() (*sts.Credentials, error)
 	Keyring         *SessionKeyring
 	ExpiryWindow    time.Duration
+	ForceNewSession bool
 	credentials.Expiry
 }
 
@@ -22,7 +23,7 @@ type CachedSessionProvider struct {
 // generates a new set of temporary credentials using the CredentialsFunc
 func (p *CachedSessionProvider) Retrieve() (credentials.Value, error) {
 	creds, err := p.Keyring.Get(p.SessionKey)
-	if err != nil {
+	if err != nil || p.ForceNewSession {
 		// lookup missed, we need to create a new one.
 		creds, err = p.CredentialsFunc()
 		if err != nil {

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -19,6 +19,7 @@ import (
 const defaultExpirationWindow = 5 * time.Minute
 
 var UseSessionCache = true
+var ForceNewSession = false
 
 func NewSession(creds *credentials.Credentials, region string) (*session.Session, error) {
 	return session.NewSessionWithOptions(session.Options{
@@ -92,6 +93,7 @@ func NewSessionTokenProvider(creds *credentials.Credentials, k keyring.Keyring, 
 			Keyring:         &SessionKeyring{Keyring: k},
 			ExpiryWindow:    defaultExpirationWindow,
 			CredentialsFunc: sessionTokenProvider.GetSessionToken,
+			ForceNewSession: ForceNewSession,
 		}, nil
 	}
 
@@ -129,6 +131,7 @@ func NewAssumeRoleProvider(creds *credentials.Credentials, k keyring.Keyring, co
 			Keyring:         &SessionKeyring{Keyring: k},
 			ExpiryWindow:    defaultExpirationWindow,
 			CredentialsFunc: p.assumeRole,
+			ForceNewSession: ForceNewSession,
 		}, nil
 	}
 
@@ -162,6 +165,7 @@ func NewAssumeRoleWithWebIdentityProvider(k keyring.Keyring, config *Config) (cr
 			Keyring:         &SessionKeyring{Keyring: k},
 			ExpiryWindow:    defaultExpirationWindow,
 			CredentialsFunc: p.assumeRole,
+			ForceNewSession: ForceNewSession,
 		}, nil
 	}
 
@@ -194,6 +198,7 @@ func NewSSORoleCredentialsProvider(k keyring.Keyring, config *Config) (credentia
 			Keyring:         &SessionKeyring{Keyring: k},
 			ExpiryWindow:    defaultExpirationWindow,
 			CredentialsFunc: ssoRoleCredentialsProvider.getRoleCredentialsAsStsCredemtials,
+			ForceNewSession: ForceNewSession,
 		}, nil
 	}
 


### PR DESCRIPTION
Addresses https://github.com/99designs/aws-vault/issues/122#issuecomment-661893667.  To prevent periods of expired credentials from the metadata server and to enable prompting a user for an MFA refresh at convenient times this additional option is needed.

Built by refactoring Ber Zoidberg's pull request https://github.com/99designs/aws-vault/pull/474 to work with current master.  I did not include the modification to the rotate command.
