### PR TITLE
Read Secret Access Key with terminal.ReadPassword()

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -70,7 +70,7 @@ func AddCommand(input AddCommandInput, keyring keyring.Keyring, awsConfigFile *v
 		if accessKeyId, err = prompt.TerminalPrompt("Enter Access Key ID: "); err != nil {
 			return fmt.Errorf(err.Error())
 		}
-		if secretKey, err = prompt.TerminalPrompt("Enter Secret Access Key: "); err != nil {
+		if secretKey, err = prompt.TerminalSecretPrompt("Enter Secret Access Key: "); err != nil {
 			return fmt.Errorf(err.Error())
 		}
 	}

--- a/prompt/terminal.go
+++ b/prompt/terminal.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func TerminalPrompt(message string) (string, error) {
@@ -17,6 +19,19 @@ func TerminalPrompt(message string) (string, error) {
 	}
 
 	return strings.TrimSpace(text), nil
+}
+
+func TerminalSecretPrompt(message string) (string, error) {
+	fmt.Fprint(os.Stderr, message)
+
+	text, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Println()
+
+	return strings.TrimSpace(string(text)), nil
 }
 
 func TerminalMfaPrompt(mfaSerial string) (string, error) {


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

This will prevent the secret output echoing back:

```
$ aws-vault add dev                                                                                 
Enter Access Key ID: BLABLA
Enter Secret Access Key: 🔒 
```

Fixes: https://github.com/99designs/aws-vault/issues/616