### PR TITLE
Handle OIDC caching for new keyring entries

### DIFF
--- a/vault/ssorolecredentialsprovider.go
+++ b/vault/ssorolecredentialsprovider.go
@@ -95,9 +95,11 @@ func (p *SSORoleCredentialsProvider) getOIDCToken() (token *ssooidc.CreateTokenO
 			return nil, err
 		}
 
-		err = p.OIDCTokenCache.Set(p.StartURL, token)
-		if err != nil {
-			return nil, err
+		if p.OIDCTokenCache != nil {
+			err = p.OIDCTokenCache.Set(p.StartURL, token)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return token, err

--- a/vault/ssorolecredentialsprovider.go
+++ b/vault/ssorolecredentialsprovider.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/99designs/keyring"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -84,7 +85,7 @@ func (p *SSORoleCredentialsProvider) getRoleCredentialsAsStsCredemtials() (*sts.
 func (p *SSORoleCredentialsProvider) getOIDCToken() (token *ssooidc.CreateTokenOutput, err error) {
 	if p.OIDCTokenCache != nil {
 		token, err = p.OIDCTokenCache.Get(p.StartURL)
-		if err != nil {
+		if err != nil && err != keyring.ErrKeyNotFound {
 			return nil, err
 		}
 	}
@@ -94,8 +95,8 @@ func (p *SSORoleCredentialsProvider) getOIDCToken() (token *ssooidc.CreateTokenO
 			return nil, err
 		}
 
-		if p.OIDCTokenCache != nil {
-			err = p.OIDCTokenCache.Set(p.StartURL, token)
+		err = p.OIDCTokenCache.Set(p.StartURL, token)
+		if err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
I was testing the new OIDC caching in #628 (yay!) and ran into some errors when I had no existing OIDC entry in my keychain.

First, aws-vault would die immediately with:

```
aws-vault: error: exec: Failed to get credentials for <my-profile>: The specified item could not be found in the keyring
```

After a tweak to fix that, it would go through _most_ of the normal credential flow but die later:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x45f99f8]

goroutine 6 [running]:
github.com/99designs/aws-vault/v6/vault.(*SSORoleCredentialsProvider).getRoleCredentials(0xc000314100, 0xc00014c000, 0x0, 0x0)
        github.com/99designs/aws-vault/v6/vault/ssorolecredentialsprovider.go:58 +0xf8
...
```

After erroring out once, I would see the OIDC entry in my keychain and subsequent runs would work as expected.

This PR is a first pass attempt to address both first-run errors. Happy to talk through it or make additional changes as needed.