### PR TITLE
When the `--json` flag is missing the process hangs

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -435,7 +435,7 @@ Note that `credential_process` is designed for retrieving master credentials, wh
 
 ```ini
 [profile jon]
-credential_process = aws-vault exec --no-session jon
+credential_process = aws-vault exec --no-session jon --json
 
 [profile work]
 mfa_serial = arn:aws:iam::123456789012:mfa/jonsmith


### PR DESCRIPTION
On OSX specifically the process hangs when the `--json` portion is excluded. From what I can tell running the command manually it opens a shell if you don't pass `--json`.