### PR TITLE
Return not found error for expired OIDC tokens

### DIFF
--- a/vault/oidctokenkeyring.go
+++ b/vault/oidctokenkeyring.go
@@ -37,7 +37,7 @@ func (o OIDCTokenKeyring) Get(startURL string) (*ssooidc.CreateTokenOutput, erro
 	if time.Now().After(val.Expiration) {
 		log.Printf("OIDC token for '%s' expired, removing", startURL)
 		_ = o.Remove(startURL)
-		return nil, fmt.Errorf("Token expired")
+		return nil, keyring.ErrKeyNotFound
 	}
 
 	secondsLeft := int64(time.Until(val.Expiration) / time.Second)


### PR DESCRIPTION
I ran into the issue raised in #639 and went peeking at the cause. It looks like with `SessionKeyring`, expired keys get cleared out via `GarbageCollectOnce` at the beginning of keyring management calls. So callers get a not found error when trying to fetch non-existent _or_ expired creds.

This change tries to bring the same approach to OIDC tokens, so aws-vault will automatically try to create a new token in either case.

I'm not sure if this is the "right" way to handle the expired token case, but it's a conversation starter at least.