### PR TITLE
Add AWS_MIN_TTL to set expiry window

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -127,6 +127,7 @@ To override session durations (used in `exec` and `login`):
 * `AWS_CHAINED_SESSION_TOKEN_TTL`: Expiration time for the `GetSessionToken` credentials when chaining profiles. Defaults to 8h
 * `AWS_ASSUME_ROLE_TTL`: Expiration time for the `AssumeRole` credentials. Defaults to 1h
 * `AWS_FEDERATION_TOKEN_TTL`: Expiration time for the `GetFederationToken` credentials. Defaults to 1h
+* `AWS_MIN_TTL`: The minimum expiration time allowed for a credential. Defaults to 5m
 
 Note that the session durations above expect a unit after the number (e.g. 12h or 43200s).
 

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/99designs/aws-vault/v6/prompt"
@@ -16,7 +17,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
-const defaultExpirationWindow = 5 * time.Minute
+var defaultExpirationWindow = 5 * time.Minute
+
+func init() {
+	if d, err := time.ParseDuration(os.Getenv("AWS_MIN_TTL")); err == nil {
+		defaultExpirationWindow = d
+	}
+}
 
 var UseSessionCache = true
 


### PR DESCRIPTION
Add an environment variable `AWS_MIN_TTL` to set the expiry window for credentials, or in other words the minimum duration allowed for a credential
