### PR TITLE
Store SSO expiration times as UTC

### DIFF
--- a/vault/oidctokenkeyring.go
+++ b/vault/oidctokenkeyring.go
@@ -73,7 +73,7 @@ func (o OIDCTokenKeyring) Get(startURL string) (*ssooidc.CreateTokenOutput, erro
 func (o OIDCTokenKeyring) Set(startURL string, token *ssooidc.CreateTokenOutput) error {
 	val := OIDCTokenData{
 		Token:      *token,
-		Expiration: time.Now().Add(time.Duration(*token.ExpiresIn) * time.Second),
+		Expiration: time.Now().Add(time.Duration(*token.ExpiresIn) * time.Second).UTC(),
 	}
 
 	valJson, err := json.Marshal(val)

--- a/vault/ssorolecredentialsprovider.go
+++ b/vault/ssorolecredentialsprovider.go
@@ -78,7 +78,7 @@ func (p *SSORoleCredentialsProvider) getRoleCredentialsAsStsCredemtials() (*sts.
 		AccessKeyId:     creds.AccessKeyId,
 		SecretAccessKey: creds.SecretAccessKey,
 		SessionToken:    creds.SessionToken,
-		Expiration:      aws.Time(aws.MillisecondsTimeValue(creds.Expiration)),
+		Expiration:      aws.Time(aws.MillisecondsTimeValue(creds.Expiration).UTC()),
 	}, nil
 }
 


### PR DESCRIPTION
Maintain consistency with session credential behavior by storing
token and credential expiration times as UTC.