### PR TITLE
Fixup shell-check error in Yubikey create script

### DIFF
--- a/contrib/scripts/aws-iam-create-yubikey-mfa.sh
+++ b/contrib/scripts/aws-iam-create-yubikey-mfa.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 # Adds a Yubikey TOTP device to IAM
 
-set -e
+set -eu
 
-if [ -n "$AWS_SESSION_TOKEN" ]; then
+if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
   echo "aws-vault must be run without a STS session, please run it with the --no-session flag" >&2
   exit 1
 fi


### PR DESCRIPTION
If you run shellcheck on this script, you get the following error message:

    In tpc/aws-yubikey-mfa/aws-iam-create-yubikey-mfa.sh line 6:
    if [ -n "$AWS_SESSION_TOKEN" ]; then
             ^----------------^ SC2154: AWS_SESSION_TOKEN is referenced but not assigned.

Setting `-u` causes the script to exit if AWS_SESSION_TOKEN is unset. Reading from
an empty value will allow the script to proceed correctly, even if `-u` is set.

Thanks for all the hard work that went into aws-vault. It's a great tool and I use
it everyday!