### PR TITLE
Handle additional username formats

### DIFF
--- a/contrib/scripts/aws-iam-create-yubikey-mfa.sh
+++ b/contrib/scripts/aws-iam-create-yubikey-mfa.sh
@@ -17,7 +17,9 @@ cleanup()
 trap cleanup EXIT
 
 ACCOUNT_ARN=$(aws sts get-caller-identity --query Arn --output text)
-USERNAME=$(echo "$ACCOUNT_ARN" | cut -d/ -f2)
+# Assume that the final portion of the ARN is the username
+# Works for ARNs like `users/<user>` and `users/engineers/<user>`
+USERNAME=$(echo "$ACCOUNT_ARN" | rev | cut -d/ -f1 | rev)
 
 OUTFILE=$(mktemp)
 SERIAL_NUMBER=$(aws iam create-virtual-mfa-device \


### PR DESCRIPTION
Not all AWS User ARNs have the username as the second field. Some may
have it as the 3rd or 4th field. However, it seems very likely that most accounts
have them as the last field in the ARN.

This patch changes the behavior to grab the last field in the username and I hope
that it is behavior preserving for the original use case as well.

This patch is required for the organization that I work in and it would be great if we
can get this merged upstream!

Thanks for all the hard work that went into aws-vault. It's a great tool and I use
it everyday!