### PR TITLE
Support sts_regional_endpoints configuration

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -118,6 +118,7 @@ To configure the default flag values of `aws-vault` and its subcommands:
 To override the AWS config file (used in the `exec`, `login` and `rotate` subcommands):
 * `AWS_REGION`: The AWS region
 * `AWS_DEFAULT_REGION`: The AWS region, applied only if `AWS_REGION` isn't set
+* `AWS_STS_REGIONAL_ENDPOINTS`: STS endpoint resolution logic, must be "regional" or "legacy"
 * `AWS_MFA_SERIAL`: The identification number of the MFA device to use
 * `AWS_ROLE_ARN`: Specifies the ARN of an IAM role in the active profile
 * `AWS_ROLE_SESSION_NAME`: Specifies the name to attach to the role session in the active profile

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -98,7 +98,7 @@ func RotateCommand(input RotateCommandInput, f *vault.ConfigFile, keyring keyrin
 		}
 	}
 
-	sess, err := vault.NewSessionWithCreds(sessCreds, config.Region)
+	sess, err := vault.NewSessionWithCreds(sessCreds, config.Region, config.STSRegionalEndpoints)
 	if err != nil {
 		return err
 	}

--- a/vault/assumeroleprovider.go
+++ b/vault/assumeroleprovider.go
@@ -67,6 +67,8 @@ func (p *AssumeRoleProvider) assumeRole() (*sts.Credentials, error) {
 		}
 	}
 
+	log.Printf("Using STS endpoint %s", p.StsClient.Endpoint)
+
 	resp, err := p.StsClient.AssumeRole(input)
 	if err != nil {
 		return nil, err

--- a/vault/config.go
+++ b/vault/config.go
@@ -471,7 +471,7 @@ type Config struct {
 	// Region is the AWS region
 	Region string
 
-	// Endpoint is the AWS STS endpoint URL
+	// STSRegionalEndpoints sets STS endpoint resolution logic, must be "regional" or "legacy"
 	STSRegionalEndpoints string
 
 	// Mfa config

--- a/vault/config.go
+++ b/vault/config.go
@@ -144,6 +144,7 @@ type ProfileSection struct {
 	SSORoleName             string `ini:"sso_role_name,omitempty"`
 	WebIdentityTokenFile    string `ini:"web_identity_token_file,omitempty"`
 	WebIdentityTokenProcess string `ini:"web_identity_token_process,omitempty"`
+	STSRegionalEndpoints    string `ini:"sts_regional_endpoints,omitempty"`
 }
 
 func (s ProfileSection) IsEmpty() bool {
@@ -322,6 +323,9 @@ func (cl *ConfigLoader) populateFromConfigFile(config *Config, profileName strin
 	if config.WebIdentityTokenProcess == "" {
 		config.WebIdentityTokenProcess = psection.WebIdentityTokenProcess
 	}
+	if config.STSRegionalEndpoints == "" {
+		config.STSRegionalEndpoints = psection.STSRegionalEndpoints
+	}
 
 	if psection.ParentProfile != "" {
 		fmt.Fprint(os.Stderr, "Warning: parent_profile is deprecated, please use include_profile instead in your AWS config\n")
@@ -361,6 +365,11 @@ func (cl *ConfigLoader) populateFromEnv(profile *Config) {
 	if region := os.Getenv("AWS_DEFAULT_REGION"); region != "" && profile.Region == "" {
 		log.Printf("Using region %q from AWS_DEFAULT_REGION", region)
 		profile.Region = region
+	}
+
+	if stsRegionalEndpoints := os.Getenv("AWS_STS_REGIONAL_ENDPOINTS"); stsRegionalEndpoints != "" && profile.STSRegionalEndpoints == "" {
+		log.Printf("Using %q from AWS_STS_REGIONAL_ENDPOINTS", stsRegionalEndpoints)
+		profile.STSRegionalEndpoints = stsRegionalEndpoints
 	}
 
 	if mfaSerial := os.Getenv("AWS_MFA_SERIAL"); mfaSerial != "" && profile.MfaSerial == "" {
@@ -461,6 +470,9 @@ type Config struct {
 
 	// Region is the AWS region
 	Region string
+
+	// Endpoint is the AWS STS endpoint URL
+	STSRegionalEndpoints string
 
 	// Mfa config
 	MfaSerial       string

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -32,6 +32,7 @@ Role_Arn=arn:aws:iam::4451234513441615400570:role/aws_admin
 mfa_Serial=arn:aws:iam::1234513441:mfa/blah
 Region=us-east-1
 duration_seconds=1200
+sts_regional_endpoints=legacy
 
 [profile testincludeprofile1]
 region=us-east-1
@@ -103,7 +104,7 @@ func TestConfigParsingProfiles(t *testing.T) {
 	}{
 		{vault.ProfileSection{Name: "user2", Region: "us-east-1"}, true},
 		{vault.ProfileSection{Name: "withsource", SourceProfile: "user2", Region: "us-east-1"}, true},
-		{vault.ProfileSection{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2"}, true},
+		{vault.ProfileSection{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"}, true},
 		{vault.ProfileSection{Name: "nopenotthere"}, false},
 	}
 
@@ -157,7 +158,7 @@ func TestProfilesFromConfig(t *testing.T) {
 		{Name: "default", Region: "us-west-2"},
 		{Name: "user2", Region: "us-east-1"},
 		{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
-		{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2"},
+		{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"},
 		{Name: "testincludeprofile1", Region: "us-east-1"},
 		{Name: "testincludeprofile2", IncludeProfile: "testincludeprofile1"},
 	}
@@ -191,7 +192,7 @@ func TestAddProfileToExistingConfig(t *testing.T) {
 		{Name: "default", Region: "us-west-2"},
 		{Name: "user2", Region: "us-east-1"},
 		{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
-		{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2"},
+		{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"},
 		{Name: "testincludeprofile1", Region: "us-east-1"},
 		{Name: "testincludeprofile2", IncludeProfile: "testincludeprofile1"},
 		{Name: "llamas", MfaSerial: "testserial", Region: "us-east-1", SourceProfile: "default"},

--- a/vault/sessiontokenprovider.go
+++ b/vault/sessiontokenprovider.go
@@ -49,6 +49,8 @@ func (p *SessionTokenProvider) GetSessionToken() (*sts.Credentials, error) {
 		}
 	}
 
+	log.Printf("Using STS endpoint %s", p.StsClient.Endpoint)
+
 	resp, err := p.StsClient.GetSessionToken(input)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Support the `sts_regional_endpoints` in the aws config file or via the `AWS_STS_REGIONAL_ENDPOINTS` env var.

Reference: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#aws-sts

This may help with #543
