### PR TITLE
Remove default value from backend flag

### DIFF
--- a/cli/global.go
+++ b/cli/global.go
@@ -85,7 +85,6 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 		BoolVar(&a.Debug)
 
 	app.Flag("backend", fmt.Sprintf("Secret backend to use %v", backendsAvailable)).
-		Default(backendsAvailable[0]).
 		Envar("AWS_VAULT_BACKEND").
 		EnumVar(&a.KeyringBackend, backendsAvailable...)
 


### PR DESCRIPTION
Addresses https://github.com/99designs/aws-vault/issues/670#issuecomment-706337487. To allow the keyring to find the `backend` automatically instead of making the `secret-service` default and throwing an error when not using `secret-service` as a `backend`.
Revert changes made by https://github.com/99designs/aws-vault/commit/7572b93daed03c44a3b984913bced6ebdb2dca80#diff-83de63909ead282862b13050fe347d68 in which the change was introduced.