### PR TITLE
STS AssumeRole Session Tags implementation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -102,6 +102,21 @@ include_profile = root
 role_arn=arn:aws:iam::123456789:role/administrators
 ```
 
+#### `session_tags` and `transitive_session_tags`
+
+It is possible to set [session tags](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html) when `AssumeRole` is used. Two custom config variables could be defined for that: `session_tags` and `transitive_session_tags`. The former defines a comma separated key=value list of tags and the latter is a comma separated list of tags that should be persited during role chaining:
+
+```ini
+[profile root]
+region=eu-west-1
+
+[profile order-dev]
+source_profile = root
+role_arn=arn:aws:iam::123456789:role/developers
+session_tags = key1=value1,key2=value2,key3=value3
+transitive_session_tags = key1,key2
+```
+
 
 ### Environment variables
 
@@ -131,6 +146,10 @@ To override session durations (used in `exec` and `login`):
 * `AWS_MIN_TTL`: The minimum expiration time allowed for a credential. Defaults to 5m
 
 Note that the session durations above expect a unit after the number (e.g. 12h or 43200s).
+
+To override or set session tagging (used in `exec`):
+* `AWS_ROLE_TAGS`: Comma separated key-value list of tags passed with the `AssumeRole` call, overrides `session_tags` profile config variable
+* `AWS_TRANSITIVE_TAGS`: Comma separated list of transitive tags passed with the `AssumeRole` call, overrides `transitive_session_tags` profile config variable
 
 
 ## Backends

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -377,3 +377,140 @@ source_profile=root
 		t.Fatalf("Expected '%s', got '%s'", expectedSourceProfileName, config.SourceProfileName)
 	}
 }
+
+func TestSessionTaggingFromIni(t *testing.T) {
+	os.Unsetenv("AWS_SESSION_TAGS")
+	os.Unsetenv("AWS_TRANSITIVE_TAGS")
+	f := newConfigFile(t, []byte(`
+[profile tagged]
+session_tags = tag1 = value1 , tag2=value2 ,tag3=value3
+transitive_session_tags = tagOne ,tagTwo,tagThree
+`))
+	defer os.Remove(f)
+
+	configFile, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: "tagged"}
+	config, err := configLoader.LoadFromProfile("tagged")
+	if err != nil {
+		t.Fatalf("Should have found a profile: %v", err)
+	}
+	expectedSessionTags := map[string]string{
+		"tag1": "value1",
+		"tag2": "value2",
+		"tag3": "value3",
+	}
+	if !reflect.DeepEqual(expectedSessionTags, config.SessionTags) {
+		t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, config.SessionTags)
+	}
+
+	expectedTransitiveSessionTags := []string{"tagOne", "tagTwo", "tagThree"}
+	if !reflect.DeepEqual(expectedTransitiveSessionTags, config.TransitiveSessionTags) {
+		t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, config.TransitiveSessionTags)
+	}
+}
+
+func TestSessionTaggingFromEnvironment(t *testing.T) {
+	os.Setenv("AWS_SESSION_TAGS", " tagA = val1 , tagB=val2 ,tagC=val3")
+	os.Setenv("AWS_TRANSITIVE_TAGS", " tagD ,tagE")
+	defer os.Unsetenv("AWS_SESSION_TAGS")
+	defer os.Unsetenv("AWS_TRANSITIVE_TAGS")
+
+	f := newConfigFile(t, []byte(`
+[profile tagged]
+session_tags = tag1 = value1 , tag2=value2 ,tag3=value3
+transitive_session_tags = tagOne ,tagTwo,tagThree
+`))
+	defer os.Remove(f)
+
+	configFile, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: "tagged"}
+	config, err := configLoader.LoadFromProfile("tagged")
+	if err != nil {
+		t.Fatalf("Should have found a profile: %v", err)
+	}
+	expectedSessionTags := map[string]string{
+		"tagA": "val1",
+		"tagB": "val2",
+		"tagC": "val3",
+	}
+	if !reflect.DeepEqual(expectedSessionTags, config.SessionTags) {
+		t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, config.SessionTags)
+	}
+
+	expectedTransitiveSessionTags := []string{"tagD", "tagE"}
+	if !reflect.DeepEqual(expectedTransitiveSessionTags, config.TransitiveSessionTags) {
+		t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, config.TransitiveSessionTags)
+	}
+}
+
+func TestSessionTaggingFromEnvironmentChainedRoles(t *testing.T) {
+	os.Setenv("AWS_SESSION_TAGS", "tagI=valI")
+	os.Setenv("AWS_TRANSITIVE_TAGS", " tagII")
+	defer os.Unsetenv("AWS_SESSION_TAGS")
+	defer os.Unsetenv("AWS_TRANSITIVE_TAGS")
+
+	f := newConfigFile(t, []byte(`
+[profile base]
+
+[profile interim]
+session_tags=tag1=value1
+transitive_session_tags=tag2
+source_profile = base
+
+[profile target]
+session_tags=tagA=valueA
+transitive_session_tags=tagB
+source_profile = interim
+`))
+	defer os.Remove(f)
+
+	configFile, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: "target"}
+	config, err := configLoader.LoadFromProfile("target")
+	if err != nil {
+		t.Fatalf("Should have found a profile: %v", err)
+	}
+
+	// Testing target profile, should have values populated from environment variables
+	expectedSessionTags := map[string]string{"tagI": "valI"}
+	if !reflect.DeepEqual(expectedSessionTags, config.SessionTags) {
+		t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, config.SessionTags)
+	}
+
+	expectedTransitiveSessionTags := []string{"tagII"}
+	if !reflect.DeepEqual(expectedTransitiveSessionTags, config.TransitiveSessionTags) {
+		t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, config.TransitiveSessionTags)
+	}
+
+	// Testing interim profile, parameters should come from the config, not environment
+	interimConfig := config.SourceProfile
+	expectedSessionTags = map[string]string{"tag1": "value1"}
+	if !reflect.DeepEqual(expectedSessionTags, interimConfig.SessionTags) {
+		t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, interimConfig.SessionTags)
+	}
+
+	expectedTransitiveSessionTags = []string{"tag2"}
+	if !reflect.DeepEqual(expectedTransitiveSessionTags, interimConfig.TransitiveSessionTags) {
+		t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, interimConfig.TransitiveSessionTags)
+	}
+
+	// Testing base profile, should have empty parameters
+	baseConfig := interimConfig.SourceProfile
+	if len(baseConfig.SessionTags) > 0 {
+		t.Fatalf("Expected session_tags to be empty, got %+v", baseConfig.SessionTags)
+	}
+
+	expectedTransitiveSessionTags = []string{}
+	if len(baseConfig.TransitiveSessionTags) > 0 {
+		t.Fatalf("Expected transitive_session_tags to be empty, got %+v", baseConfig.TransitiveSessionTags)
+	}
+}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -129,12 +129,14 @@ func NewAssumeRoleProvider(creds *credentials.Credentials, k keyring.Keyring, co
 	}
 
 	p := &AssumeRoleProvider{
-		StsClient:       sts.New(sess),
-		RoleARN:         config.RoleARN,
-		RoleSessionName: config.RoleSessionName,
-		ExternalID:      config.ExternalID,
-		Duration:        config.AssumeRoleDuration,
-		ExpiryWindow:    defaultExpirationWindow,
+		StsClient:         sts.New(sess),
+		RoleARN:           config.RoleARN,
+		RoleSessionName:   config.RoleSessionName,
+		ExternalID:        config.ExternalID,
+		Duration:          config.AssumeRoleDuration,
+		ExpiryWindow:      defaultExpirationWindow,
+		Tags:              config.SessionTags,
+		TransitiveTagKeys: config.TransitiveSessionTags,
 		Mfa: Mfa{
 			MfaSerial:       config.MfaSerial,
 			MfaToken:        config.MfaToken,


### PR DESCRIPTION
This PR is trying to resolve #684 and implements the way to set Session Tags and Transitive Session Tags when `AssumeRole()` provider is used.

- Two new profile configuration parameters are introduced: `session_tags` and `transitive_session_tags`
- Two new environment variables are introduced: `AWS_SESSION_TAGS` and `AWS_TRANSITIVE_TAGS`

It is possible to configure each profile in the chain individually, as well as the target profile with environment variables.