### PR TITLE
USAGE.md update to include GPG_TTY insight for pass backend

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -7,6 +7,7 @@
   * [Environment variables](#environment-variables)
 * [Backends](#backends)
   * [Keychain](#keychain)
+  * [Pass](#pass)
 * [Managing credentials](#managing-credentials)
   * [Using multiple profiles](#using-multiple-profiles)
   * [Listing profiles and credentials](#listing-profiles-and-credentials)
@@ -149,7 +150,7 @@ If you're looking to configure the amount of time between having to enter your K
 
 ![keychain-image](https://imgur.com/ARkr5Ba.png)
 
-<br>
+### Pass
 
 **Note:** If using `pass` backend and you're experiencing the below error, you may need to `export GPG_TTY=$(tty)`
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -149,6 +149,14 @@ If you're looking to configure the amount of time between having to enter your K
 
 ![keychain-image](https://imgur.com/ARkr5Ba.png)
 
+<br>
+
+**Note:** If using `pass` backend and you're experiencing the below error, you may need to `export GPG_TTY=$(tty)`
+```
+Error when retrieving credentials from custom-process: gpg: decryption failed: No secret key
+gpg: decryption failed: No secret key
+aws-vault: error: exec: Failed to get credentials for <your-profile>: exit status 2
+```
 
 ## Managing credentials
 


### PR DESCRIPTION
Update Usage Documentation to add hint to issue sometimes found with aws-vault interacting with pass without certain TTY options set for GPG.