### PR TITLE
added timed wait between code generations, added resync script

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -467,6 +467,8 @@ You can verify these prerequisites by running `ykman info` and checking `OATH` i
 
 A script can be found at [contrib/scripts/aws-iam-create-yubikey-mfa.sh](contrib/scripts/aws-iam-create-yubikey-mfa.sh) to automate the process.
 
+In case of TOTP being out of sync (AWS API doesn't accept MFA codes), yubikey resync script can be found at [contrib/scripts/aws-iam-resync-yubikey-mfa.sh](contrib/scripts/aws-iam-resync-yubikey-mfa.sh) to resync the yubikey with AWS.
+
 ### Usage
 Using the `ykman` prompt driver, aws-vault will execute `ykman` to generate tokens for any profile in your `.aws/config` using an `mfa_device`.
 ```shell

--- a/contrib/scripts/aws-iam-create-yubikey-mfa.sh
+++ b/contrib/scripts/aws-iam-create-yubikey-mfa.sh
@@ -16,6 +16,18 @@ cleanup()
 }
 trap cleanup EXIT
 
+waittime() {
+    # wait until next code can be generated
+    # if SECONDS are :00 or :30, generate right away
+    SECONDS=$(date +%S)
+    if (( ${SECONDS#0} >= 1 && ${SECONDS#0} <= 29 )); then
+        WAIT_SECONDS=$(( 30 - ${SECONDS#0} ))
+    elif (( ${SECONDS#0} >= 31 && ${SECONDS#0} <= 59 )); then
+        WAIT_SECONDS=$(( 60 - ${SECONDS#0} ))
+    fi
+    echo ${WAIT_SECONDS:-0}
+}
+
 ACCOUNT_ARN=$(aws sts get-caller-identity --query Arn --output text)
 # Assume that the final portion of the ARN is the username
 # Works for ARNs like `users/<user>` and `users/engineers/<user>`
@@ -34,17 +46,10 @@ rm "$OUTFILE"
 
 CODE1=$(ykman oath code -s "$SERIAL_NUMBER")
 
-# wait until next code can be generated
-# if SECONDS are :00 or :30, generate right away
-SECONDS=$(date +%S)
-if (( ${SECONDS#0} >= 1 && ${SECONDS#0} <= 29 )); then
-    WAIT_SECONDS=$(( 30 - ${SECONDS#0} ))
-elif (( ${SECONDS#0} >= 31 && ${SECONDS#0} <= 59 )); then
-    WAIT_SECONDS=$(( 60 - ${SECONDS#0} ))
-fi
+WAIT_TIME=$(waittime)
 
-echo "Waiting ${WAIT_SECONDS:-0}s before generating a second code" >&2
-sleep ${WAIT_SECONDS:-0}
+echo "Waiting ${WAIT_TIME}s before generating a second code" >&2
+sleep ${WAIT_TIME}
 
 CODE2=$(ykman oath code -s "$SERIAL_NUMBER")
 

--- a/contrib/scripts/aws-iam-resync-yubikey-mfa.sh
+++ b/contrib/scripts/aws-iam-resync-yubikey-mfa.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -eu
 

--- a/contrib/scripts/aws-iam-resync-yubikey-mfa.sh
+++ b/contrib/scripts/aws-iam-resync-yubikey-mfa.sh
@@ -2,6 +2,18 @@
 
 set -eu
 
+waittime() {
+    # wait until next code can be generated
+    # if SECONDS are :00 or :30, generate right away
+    SECONDS=$(date +%S)
+    if (( ${SECONDS#0} >= 1 && ${SECONDS#0} <= 29 )); then
+        WAIT_SECONDS=$(( 30 - ${SECONDS#0} ))
+    elif (( ${SECONDS#0} >= 31 && ${SECONDS#0} <= 59 )); then
+        WAIT_SECONDS=$(( 60 - ${SECONDS#0} ))
+    fi
+    echo ${WAIT_SECONDS:-0}
+}
+
 ACCOUNT_ARN=$(aws sts get-caller-identity --query Arn --output text)
 # Assume that the final portion of the ARN is the username
 # Works for ARNs like `users/<user>` and `users/engineers/<user>`
@@ -11,17 +23,10 @@ SERIAL_NUMBER="arn:aws:iam::${ACCOUNT_ID}:mfa/${USERNAME}"
 
 CODE1=$(ykman oath code -s "$SERIAL_NUMBER")
 
-# wait until next code can be generated
-# if SECONDS are :00 or :30, generate right away
-SECONDS=$(date +%S)
-if (( ${SECONDS#0} >= 1 && ${SECONDS#0} <= 29 )); then
-    WAIT_SECONDS=$(( 30 - ${SECONDS#0} ))
-elif (( ${SECONDS#0} >= 31 && ${SECONDS#0} <= 59 )); then
-    WAIT_SECONDS=$(( 60 - ${SECONDS#0} ))
-fi
+WAIT_TIME=$(waittime)
 
-echo "Waiting ${WAIT_SECONDS:-0}s before generating a second code" >&2
-sleep ${WAIT_SECONDS:-0}
+echo "Waiting ${WAIT_TIME}s before generating a second code" >&2
+sleep ${WAIT_TIME}
 
 CODE2=$(ykman oath code -s "$SERIAL_NUMBER")
 

--- a/contrib/scripts/aws-iam-resync-yubikey-mfa.sh
+++ b/contrib/scripts/aws-iam-resync-yubikey-mfa.sh
@@ -1,36 +1,13 @@
-#!/bin/sh
-# Adds a Yubikey TOTP device to IAM
+#!/usr/bin/env bash
 
 set -eu
-
-if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
-  echo "aws-vault must be run without a STS session, please run it with the --no-session flag" >&2
-  exit 1
-fi
-
-cleanup()
-{
-  if [ -z "$OUTFILE" ]; then
-    rm "$OUTFILE"
-  fi
-}
-trap cleanup EXIT
 
 ACCOUNT_ARN=$(aws sts get-caller-identity --query Arn --output text)
 # Assume that the final portion of the ARN is the username
 # Works for ARNs like `users/<user>` and `users/engineers/<user>`
 USERNAME=$(echo "$ACCOUNT_ARN" | rev | cut -d/ -f1 | rev)
-
-OUTFILE=$(mktemp)
-SERIAL_NUMBER=$(aws iam create-virtual-mfa-device \
-  --virtual-mfa-device-name "$USERNAME" \
-  --bootstrap-method Base32StringSeed \
-  --outfile "$OUTFILE" \
-  --query VirtualMFADevice.SerialNumber \
-  --output text)
-
-ykman oath add -t "$SERIAL_NUMBER" < "$OUTFILE" 2> /dev/null
-rm "$OUTFILE"
+ACCOUNT_ID=$(echo "$ACCOUNT_ARN" | cut -d: -f5)
+SERIAL_NUMBER="arn:aws:iam::${ACCOUNT_ID}:mfa/${USERNAME}"
 
 CODE1=$(ykman oath code -s "$SERIAL_NUMBER")
 
@@ -48,8 +25,8 @@ sleep ${WAIT_SECONDS:-0}
 
 CODE2=$(ykman oath code -s "$SERIAL_NUMBER")
 
-aws iam enable-mfa-device \
-  --user-name "$USERNAME" \
-  --serial-number "$SERIAL_NUMBER" \
-  --authentication-code1 "$CODE1" \
-  --authentication-code2 "$CODE2"
+aws iam resync-mfa-device \
+    --user-name "$USERNAME" \
+    --serial-number "$SERIAL_NUMBER" \
+    --authentication-code1 "$CODE1" \
+    --authentication-code2 "$CODE2"


### PR DESCRIPTION
This PR implements timed wait between code generation in aws mfa yubikey helper script `aws-iam-create-yubikey-mfa.sh`

as discussed here:
https://github.com/99designs/aws-vault/pull/559/files#r412054242

I also experienced some drifts in TOTP tokens - yubikey being out of sync with AWS and AWS not accepting codes. To address this issue and for convenient resync `aws-iam-resync-yubikey-mfa.sh` script was created.
