### PR TITLE
aws helper scripts fixed to work on more platforms

### DIFF
--- a/contrib/scripts/aws-iam-create-yubikey-mfa.sh
+++ b/contrib/scripts/aws-iam-create-yubikey-mfa.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 # Adds a Yubikey TOTP device to IAM
 
-set -e
+set -eu
 
 if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
   echo "aws-vault must be run without a STS session, please run it with the --no-session flag" >&2
   exit 1
 fi
 
-cleanup() { rm -f "$OUTFILE"; }
+cleanup() { rm -f "${OUTFILE:-}"; }
 trap cleanup EXIT
 
 waittime() {

--- a/contrib/scripts/aws-iam-resync-yubikey-mfa.sh
+++ b/contrib/scripts/aws-iam-resync-yubikey-mfa.sh
@@ -6,9 +6,9 @@ waittime() {
     # wait until next code can be generated
     # if SECONDS are :00 or :30, generate right away
     SECONDS=$(date +%S)
-    if (( ${SECONDS#0} >= 1 && ${SECONDS#0} <= 29 )); then
+    if [ ${SECONDS#0} -gt 0 ] && [ ${SECONDS#0} -lt 30 ]; then
         WAIT_SECONDS=$(( 30 - ${SECONDS#0} ))
-    elif (( ${SECONDS#0} >= 31 && ${SECONDS#0} <= 59 )); then
+    elif [ ${SECONDS#0} -gt 30 ] && [ ${SECONDS#0} -lt 60 ]; then
         WAIT_SECONDS=$(( 60 - ${SECONDS#0} ))
     fi
     echo ${WAIT_SECONDS:-0}


### PR DESCRIPTION
- removed bashisms from AWS helper scripts so they work under Linux / dash too
- forced (`-f`) `ykman` to overwrite MFA code on YubiKey if it exists already. this is useful when MFA config in AWS console has been deleted and setting up a new MFA using this script. `ykman` would otherwise fail silently and left AWS MFA in an inconsistent state (created but unactivated).
- fixed cleanup function to actually run on EXIT (`-z "$OUTFILE"` ?)
- removed `-u` (`nounset` ) to not fail with `unbound variable` if the script fails before setting `OUTFILE`