### PR TITLE
Fix ykman deprecated command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/aws/aws-sdk-go v1.34.13
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/danieljoos/wincred v1.1.0 // indirect
 	github.com/google/go-cmp v0.5.2
 	github.com/keybase/go-keychain v0.0.0-20200502122510-cda31fe0c86d // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2c
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws/aws-sdk-go v1.34.13 h1:wwNWSUh4FGJxXVOVVNj2lWI8wTe5hK8sGWlK7ziEcgg=
 github.com/aws/aws-sdk-go v1.34.13/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/danieljoos/wincred v1.1.0 h1:3RNcEpBg4IhIChZdFRSdlQt1QjCp1sMAPIrOnm7Yf8g=

--- a/prompt/ykman.go
+++ b/prompt/ykman.go
@@ -5,7 +5,10 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
+
+	"github.com/blang/semver"
 )
 
 // YkmanProvider runs ykman to generate a OATH-TOTP token from the Yubikey device
@@ -16,8 +19,26 @@ func YkmanMfaProvider(mfaSerial string) (string, error) {
 		yubikeyOathCredName = mfaSerial
 	}
 
-	log.Printf("Fetching MFA code using `ykman oath code --single %s`", yubikeyOathCredName)
-	cmd := exec.Command("ykman", "oath", "code", "--single", yubikeyOathCredName)
+	// Yubikey Manager v4 replaced ykman oauth code with ykman oath accounts code
+	versionCmd := exec.Command("ykman", "--version")
+	versionOut, err := versionCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("ykman: %w", err)
+	}
+	versionRegex := regexp.MustCompile(`^YubiKey Manager \(ykman\) version: (\d+\.\d+\.\d+)`)
+	version := versionRegex.FindStringSubmatch(string(versionOut))
+	log.Printf("ykman version: %s", version[1])
+	ykmanVersion, _ := semver.ParseTolerant(version[1])
+	v4, _ := semver.Make("4.0.0")
+	var ykmanArgs []string
+	if ykmanVersion.GTE(v4) {
+		ykmanArgs = []string{"oath", "accounts", "code", "--single", yubikeyOathCredName}
+	} else {
+		ykmanArgs = []string{"oath", "code", "--single", yubikeyOathCredName}
+	}
+
+	log.Printf("Fetching MFA code using `ykman %v`", strings.Join(ykmanArgs, " "))
+	cmd := exec.Command("ykman", ykmanArgs...)
 	cmd.Stderr = os.Stderr
 
 	out, err := cmd.Output()


### PR DESCRIPTION
Fixes https://github.com/99designs/aws-vault/issues/741

Alternate, non breaking version of https://github.com/99designs/aws-vault/pull/742.

As mentioned in the issue I think the breaking change is probably fine because it doesn't need merging immediately but this version would allow it to be merged as is and support Yubikey manager before v4 and remove the deprecated warning in v4+.