### PR TITLE
Set YKMAN_OATH_DEVICE_SERIAL to select Yubikey

### DIFF
--- a/prompt/ykman.go
+++ b/prompt/ykman.go
@@ -11,13 +11,25 @@ import (
 // YkmanProvider runs ykman to generate a OATH-TOTP token from the Yubikey device
 // To set up ykman, first run `ykman oath add`
 func YkmanMfaProvider(mfaSerial string) (string, error) {
+	args := []string{}
+
 	yubikeyOathCredName := os.Getenv("YKMAN_OATH_CREDENTIAL_NAME")
 	if yubikeyOathCredName == "" {
 		yubikeyOathCredName = mfaSerial
 	}
 
-	log.Printf("Fetching MFA code using `ykman oath code --single %s`", yubikeyOathCredName)
-	cmd := exec.Command("ykman", "oath", "code", "--single", yubikeyOathCredName)
+	// Get the serial number of the yubikey device to use.
+	yubikeyDeviceSerial := os.Getenv("YKMAN_OATH_DEVICE_SERIAL")
+	if yubikeyDeviceSerial != "" {
+		// If the env var was set, extend args to support passing the serial.
+		args = append(args, "--device", yubikeyDeviceSerial)
+	}
+
+	// Add the rest of the args as usual.
+	args = append(args, "oath", "code", "--single", yubikeyOathCredName)
+
+	log.Printf("Fetching MFA code using `ykman %s`", strings.Join(args, " "))
+	cmd := exec.Command("ykman", args...)
 	cmd.Stderr = os.Stderr
 
 	out, err := cmd.Output()


### PR DESCRIPTION
This change enables setting YKMAN_OATH_DEVICE_SERIAL to select a
particular Yubikey if more than one is attached to the device. It does
this by reading the serial from the env var, and adding the `--device
<serial>` to the `ykman` command.

Closes #638 