### PR TITLE
Allow specifying a browser to login with

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -24,6 +24,7 @@ type LoginCommandInput struct {
 	Config          vault.Config
 	SessionDuration time.Duration
 	NoSession       bool
+	BrowserName	string
 }
 
 func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
@@ -49,7 +50,7 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 	cmd.Flag("region", "The AWS region").
 		StringVar(&input.Config.Region)
 
-	cmd.Flag("stdout", "Print login URL to stdout instead of opening in default browser").
+	cmd.Flag("stdout", "Print login URL to stdout instead of opening in browser").
 		Short('s').
 		BoolVar(&input.UseStdout)
 
@@ -57,6 +58,9 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 		Required().
 		HintAction(a.MustGetProfileNames).
 		StringVar(&input.ProfileName)
+	
+	cmd.Arg("browser", "Name of the browser to open with").
+		StringVar(&input.BrowserName)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
 		input.Config.MfaPromptMethod = a.PromptDriver
@@ -167,7 +171,7 @@ func LoginCommand(input LoginCommandInput, f *vault.ConfigFile, keyring keyring.
 
 	if input.UseStdout {
 		fmt.Println(loginURL)
-	} else if err = open.Run(loginURL); err != nil {
+	} else if err = open.Run(loginURL, input.BrowserName); err != nil {
 		log.Println(err)
 		fmt.Println(loginURL)
 	}

--- a/cli/login.go
+++ b/cli/login.go
@@ -24,7 +24,7 @@ type LoginCommandInput struct {
 	Config          vault.Config
 	SessionDuration time.Duration
 	NoSession       bool
-	BrowserName	string
+	BrowserName     string
 }
 
 func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
@@ -54,13 +54,13 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 		Short('s').
 		BoolVar(&input.UseStdout)
 
+	cmd.Flag("browser", "Name of the browser to open with").
+		StringVar(&input.BrowserName)
+
 	cmd.Arg("profile", "Name of the profile").
 		Required().
 		HintAction(a.MustGetProfileNames).
 		StringVar(&input.ProfileName)
-	
-	cmd.Arg("browser", "Name of the browser to open with").
-		StringVar(&input.BrowserName)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
 		input.Config.MfaPromptMethod = a.PromptDriver
@@ -171,9 +171,20 @@ func LoginCommand(input LoginCommandInput, f *vault.ConfigFile, keyring keyring.
 
 	if input.UseStdout {
 		fmt.Println(loginURL)
-	} else if err = open.Run(loginURL, input.BrowserName); err != nil {
-		log.Println(err)
-		fmt.Println(loginURL)
+	} else {
+		if input.BrowserName != "" {
+			err = open.RunWith(loginURL, input.BrowserName)
+			if err != nil {
+				log.Println(err)
+				fmt.Println(loginURL)
+			}
+		} else {
+			err = open.Run(loginURL)
+			if err != nil {
+				log.Println(err)
+				fmt.Println(loginURL)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Instead of logging in through the default browser, this adds an optional `--browser` flag that, if specified, will update the browser to login with.

As an example of one use case, I use this to login to multiple different IAM Roles at one time.