### PR TITLE
Set flags to cross-compile darwin/arm64 on darwin/amd64 and vice versa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ release: binaries dmgs SHA256SUMS
 	@echo "\nTo update homebrew-cask run\n\n    brew bump-cask-pr --version $(shell echo $(VERSION) | sed 's/v\(.*\)/\1/') aws-vault\n"
 
 aws-vault-darwin-amd64: $(SRC)
-	GOOS=darwin GOARCH=amd64 go build $(BUILD_FLAGS) -o $@ .
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 SDKROOT=$(shell xcrun --sdk macosx --show-sdk-path) go build $(BUILD_FLAGS) -o $@ .
 
 aws-vault-darwin-arm64: $(SRC)
-	GOOS=darwin GOARCH=arm64 go build $(BUILD_FLAGS) -o $@ .
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 SDKROOT=$(shell xcrun --sdk macosx --show-sdk-path) go build $(BUILD_FLAGS) -o $@ .
 
 aws-vault-freebsd-amd64: $(SRC)
 	GOOS=freebsd GOARCH=amd64 go build $(BUILD_FLAGS) -o $@ .


### PR DESCRIPTION
Should fix https://github.com/99designs/aws-vault/issues/758, but comments definitely welcome from people with more understanding than me on Go cross-compilation and the build/release process for aws-vault (@mtibben!).

In order to try and validate this, I've compiled the native target on darwin/amd64 (Catalina 10.15.7) and  darwin/arm64 (Big Sur 11.2.3) and cross-compiled for the opposite architecture on both darwin/amd64 and darwin/arm64.

In all cases, I've run `aws-vault --debug` and checked for the presence of keychain in the list of backends.

Original commit message follows.

This is an attempt to fix a lack of keychain support in darwin/arm64
binaries that have been cross-compiled on other platforms as described
in https://github.com/99designs/aws-vault/issues/758 and hinted at in
the linked
https://github.com/99designs/keyring/commit/756c48deecbd97e8fe3581f20efbaa136689cf80

Given the keychain support from keyring[1] is provided by cgo, and CGO
is disabled by default in cross-compilation, we need to enable that,
and deal with dev tooling/libraries.

I dug this solution from the Go issues, specifically
https://github.com/golang/go/issues/44112

Be warned, I am not familiar with the ins and outs of Go compilation,
especially when it comes to cross-compilation of CGO code, but at
least in this case, this change allows for a functional cross-compiled
binary.

I fully expect that attempting to cross-compile darwin/arm64 on
anything other than darwin/amd64 (or the opposite way around) is going
to end badly.

[1] https://github.com/99designs/keyring