### PR TITLE
Use LookupEnv rather than Getenv for AWS_VAULT_FILE_PASSPHRASE

### DIFF
--- a/cli/global.go
+++ b/cli/global.go
@@ -129,7 +129,7 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 }
 
 func fileKeyringPassphrasePrompt(prompt string) (string, error) {
-	if password := os.Getenv("AWS_VAULT_FILE_PASSPHRASE"); password != "" {
+	if password, ok := os.LookupEnv("AWS_VAULT_FILE_PASSPHRASE"); ok {
 		return password, nil
 	}
 


### PR DESCRIPTION
Given one can simply press <kbd>Return</kbd> when prompted for a password in the terminal, I think we could also allow `AWS_VAULT_FILE_PASSPHRASE` to be empty.
This changes `fileKeyringPassphrasePrompt` in order to allow empty passphrases by using [`LookupEnv`](https://golang.org/pkg/os/#LookupEnv) instead of [`Getenv`](https://golang.org/pkg/os/#Getenv)