### PR TITLE
Add OpenSUSE update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can install AWS Vault:
 - on [Arch Linux](https://www.archlinux.org/packages/community/x86_64/aws-vault/): `pacman -S aws-vault`
 - on [FreeBSD](https://www.freshports.org/security/aws-vault/): `pkg install aws-vault`
 - with [Nix](https://nixos.org/nixos/packages.html?attr=aws-vault): `nix-env -i aws-vault`
+- on [OpenSUSE](https://software.opensuse.org/package/aws-vault): enable devel:languages:go repo then `zypper install aws-vault` (sometimes version lags)
 
 ## Documentation
 


### PR DESCRIPTION
The aws-vault software is packaged and built for OpenSUSE/SUSE, but the version update process is manual at the moment.  It would be fairly easy to set it to auto-build new versions, but that would require someone to enable a webhook on the repo which notifies the OpenBuildService when a new version is released.  I'd be happy to help set that up on the SUSE side if the repo owner is willing to add the hook and create an OBS account.  Otherwise, I suppose I could set up my own fork and add a scheduled action to sync mine from upstream.