### PR TITLE
Prevent osascript prompt code injection

### DIFF
--- a/prompt/osascript.go
+++ b/prompt/osascript.go
@@ -8,7 +8,7 @@ import (
 
 func OSAScriptMfaPrompt(mfaSerial string) (string, error) {
 	cmd := exec.Command("osascript", "-e", fmt.Sprintf(`
-		display dialog "%s" default answer "" buttons {"OK", "Cancel"} default button 1
+		display dialog %q default answer "" buttons {"OK", "Cancel"} default button 1
         text returned of the result
         return result`,
 		mfaPromptMessage(mfaSerial)))


### PR DESCRIPTION
Hi maintainers! I'm Josh and I work at Bison Trails. We're doing an internal hackathon this week.

Our team loves aws-vault, but it got flagged during a recent security review. Our team voted to use our hackathon time to patch vulnerabilities in our favorite OSS tools and specifically to try to get aws-vault approved for usage within our organization.

# What's here:
- Prevents AppleScript injections via the `~/.aws/config#serialMFA` configuration property 

# Impact:
These changes should improve aws-vault's security posture. We identified this vulnerability using [Salus](https://github.com/coinbase/salus) and the [OSSF scorecard](https://github.com/ossf/scorecard). The specific issues I am hoping to address here are:
- Preventing unintentional code execution by properly quoting and escaping the value for mfaSerial in the osascript prompt

What's next:
- an [additional PR](https://github.com/99designs/aws-vault/pull/792)  for prevent wrong script from executing on windows via relative pathing

