### PR TITLE
prevent windows exec unintentional relative pathing

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"log"
 	"os"
-	osexec "os/exec"
 	"os/signal"
 	"runtime"
 	"strings"
 	"syscall"
 	"time"
+
+	osexec "golang.org/x/sys/execabs"
 
 	"github.com/99designs/aws-vault/v6/iso8601"
 	"github.com/99designs/aws-vault/v6/server"

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
-	golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1 // indirect
+	golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1
 	golang.org/x/term v0.0.0-20210503060354-a79de5458b56
 	gopkg.in/ini.v1 v1.62.0
 )

--- a/prompt/kdialog.go
+++ b/prompt/kdialog.go
@@ -1,8 +1,9 @@
 package prompt
 
 import (
-	"os/exec"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 func KDialogMfaPrompt(mfaSerial string) (string, error) {

--- a/prompt/passotp.go
+++ b/prompt/passotp.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 // PassOTPProvider uses the pass otp extension to generate a OATH-TOTP token

--- a/prompt/ykman.go
+++ b/prompt/ykman.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 // YkmanProvider runs ykman to generate a OATH-TOTP token from the Yubikey device

--- a/prompt/zenity.go
+++ b/prompt/zenity.go
@@ -1,8 +1,9 @@
 package prompt
 
 import (
-	"os/exec"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 func ZenityMfaPrompt(mfaSerial string) (string, error) {

--- a/server/ec2alias_windows.go
+++ b/server/ec2alias_windows.go
@@ -4,8 +4,9 @@ package server
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 var alreadyRegisteredLocalised = []string{

--- a/server/ec2proxy_default.go
+++ b/server/ec2proxy_default.go
@@ -6,8 +6,9 @@ import (
 	"errors"
 	"log"
 	"os"
-	"os/exec"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 // StartEc2EndpointProxyServerProcess starts a `aws-vault proxy` process

--- a/vault/assumerolewithwebidentityprovider.go
+++ b/vault/assumerolewithwebidentityprovider.go
@@ -6,9 +6,10 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"runtime"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"


### PR DESCRIPTION
Hi maintainers! I'm Josh and I work at Bison Trails. We're doing an internal hackathon this week.

Our team loves aws-vault, but it got flagged during a recent security review. Our team voted to use our hackathon time to patch vulnerabilities in our favorite OSS tools and specifically to try to get aws-vault approved for usage within our organization.

# What's here:
- Prevent wrong executable for credential process and exec subcommand on windows by removing current working directory from the beginning of `$PATH`. see more here https://blog.golang.org/path-security

# Impact:
These changes should improve aws-vault's security posture. We identified this vulnerability using [Salus](https://github.com/coinbase/salus) and the [OSSF scorecard](https://github.com/ossf/scorecard). The specific issues I am hoping to address here are:
- Preventing wrong executable from being run by replacing `os/exec` with `golang.org/x/sys/execabs` on all go files that are built for windows.

What's next:
- an additional PR for respecting scripts execute permissions on `assumerolewithwebidentity`