### PR TITLE
Add support for session tags when creating a federated token

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -5,6 +5,7 @@
   * [AWS config file](#aws-config-file)
     * [`include_profile`](#include_profile)
     * [`session_tags` and `transitive_session_tags`](#session_tags-and-transitive_session_tags)
+    * [`federation_session_tags`](#federation_session_tags)
   * [Environment variables](#environment-variables)
 * [Backends](#backends)
   * [Keychain](#keychain)
@@ -118,6 +119,19 @@ session_tags = key1=value1,key2=value2,key3=value3
 transitive_session_tags = key1,key2
 ```
 
+#### `federation_session_tags`
+
+It is possible to set [session tags](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html) when `GetFederationToken` is used. The `federation_session_tags` defines a comma separated key=value list of tags
+
+```ini
+[profile root]
+region=eu-west-1
+
+[profile order-dev]
+source_profile = root
+role_arn=arn:aws:iam::123456789:role/developers
+federation_session_tags = key1=value1,key2=value2,key3=value3
+```
 
 ### Environment variables
 

--- a/vault/federationtokenprovider.go
+++ b/vault/federationtokenprovider.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 )
 
 const allowAllIAMPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`
@@ -16,6 +17,7 @@ type FederationTokenProvider struct {
 	StsClient *sts.Client
 	Name      string
 	Duration  time.Duration
+	Tags      []types.Tag
 }
 
 func (f *FederationTokenProvider) name() string {
@@ -32,6 +34,7 @@ func (f *FederationTokenProvider) Retrieve(ctx context.Context) (creds aws.Crede
 		Name:            aws.String(f.name()),
 		DurationSeconds: aws.Int32(int32(f.Duration.Seconds())),
 		Policy:          aws.String(allowAllIAMPolicy),
+		Tags:            f.Tags,
 	})
 	if err != nil {
 		return creds, err

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -286,6 +286,7 @@ func NewFederationTokenCredentialsProvider(profileName string, k *CredentialKeyr
 		StsClient: sts.NewFromConfig(cfg),
 		Name:      currentUsername,
 		Duration:  config.GetFederationTokenDuration,
+		Tags:      config.FederationSessionTags,
 	}, nil
 }
 


### PR DESCRIPTION
Using the session_tags functionality as a base, I added a new feature to allow adding session tags to the federation tokens that `aws-vault login` uses