### PR TITLE
Make it really clear that we're asking for an MFA token, rather than some other kind of token

### DIFF
--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -27,5 +27,5 @@ func Method(s string) PromptFunc {
 }
 
 func mfaPromptMessage(mfaSerial string) string {
-	return fmt.Sprintf("Enter token for %s: ", mfaSerial)
+	return fmt.Sprintf("Enter MFA token for MFA Device %s: ", mfaSerial)
 }


### PR DESCRIPTION
After rolling AWS Vault out at my org, i've run into a couple of issues where users aren't sure what's meant by `Enter token for <some arn>`. This PR makes it really clear that we're asking for their MFA token.