### PR TITLE
feature: eagerly fetch credentials when the ECS server starts

### DIFF
--- a/server/ecsserver.go
+++ b/server/ecsserver.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -42,6 +43,12 @@ func StartEcsCredentialServer(credsProvider aws.CredentialsProvider) (string, st
 		return "", "", err
 	}
 	credsCache := aws.NewCredentialsCache(credsProvider)
+
+	// Retrieve credentials eagerly to support MFA prompts
+	_, err = credsCache.Retrieve(context.Background())
+	if err != nil {
+		return "", "", err
+	}
 
 	go func() {
 		err := http.Serve(listener, withLogging(withAuthorizationCheck(token, ecsCredsHandler(credsCache))))


### PR DESCRIPTION
👋 I discovered the `--ecs-server` feature today and love it!

We use AWS SSO, which doesn't play nicely with the current `--ecs-server` behavior of lazily retrieving and caching credentials after the first request. While the server waits for us to complete the SSO prompt in the browser, commands using the AWS SDK time out, exiting the `aws-vault` subshell . See #615 for a description of the issue.

This PR retrieves and caches credentials eagerly at server start. This allows `aws-vault` to pause for manual prompts before running any commands in the subshell, guaranteeing that those commands will retrieve valid credentials from the ECS server. 

While this PR changes behavior, I'm not sure if any consumers rely on lazy fetching–if anything, it could be considered a bugfix, although the safest bet would be to consider it a breaking change.