### PR TITLE
Add support for source identity on sessions

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -118,6 +118,20 @@ session_tags = key1=value1,key2=value2,key3=value3
 transitive_session_tags = key1,key2
 ```
 
+#### `source_identity`
+
+It is possible to set [source identity](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_monitor.html) when `AssumeRole` is used. Custom config variable `source_identity` allows you to set the value.
+
+```ini
+[profile root]
+region=eu-west-1
+
+[profile order-dev]
+source_profile = root
+role_arn=arn:aws:iam::123456789:role/developers
+source_identity=your_user_name
+```
+
 
 ### Environment variables
 
@@ -153,6 +167,8 @@ To override or set session tagging (used in `exec`):
 * `AWS_SESSION_TAGS`: Comma separated key-value list of tags passed with the `AssumeRole` call, overrides `session_tags` profile config variable
 * `AWS_TRANSITIVE_TAGS`: Comma separated list of transitive tags passed with the `AssumeRole` call, overrides `transitive_session_tags` profile config variable
 
+To override or set the source identity (used in `exec` and `login`):
+* `AWS_SOURCE_IDENTITY`: Specifies the source identity for assumed role sessions
 
 ## Backends
 

--- a/vault/assumeroleprovider.go
+++ b/vault/assumeroleprovider.go
@@ -20,6 +20,7 @@ type AssumeRoleProvider struct {
 	Duration          time.Duration
 	Tags              map[string]string
 	TransitiveTagKeys []string
+	SourceIdentity    string
 	Mfa
 }
 
@@ -82,6 +83,10 @@ func (p *AssumeRoleProvider) assumeRole() (*ststypes.Credentials, error) {
 
 	if len(p.TransitiveTagKeys) > 0 {
 		input.TransitiveTagKeys = p.TransitiveTagKeys
+	}
+
+	if p.SourceIdentity != "" {
+		input.SourceIdentity = aws.String(p.SourceIdentity)
 	}
 
 	resp, err := p.StsClient.AssumeRole(context.TODO(), input)

--- a/vault/config.go
+++ b/vault/config.go
@@ -147,6 +147,7 @@ type ProfileSection struct {
 	STSRegionalEndpoints    string `ini:"sts_regional_endpoints,omitempty"`
 	SessionTags             string `ini:"session_tags,omitempty"`
 	TransitiveSessionTags   string `ini:"transitive_session_tags,omitempty"`
+	SourceIdentity          string `ini:"source_identity,omitempty"`
 }
 
 func (s ProfileSection) IsEmpty() bool {
@@ -328,6 +329,9 @@ func (cl *ConfigLoader) populateFromConfigFile(config *Config, profileName strin
 	if config.STSRegionalEndpoints == "" {
 		config.STSRegionalEndpoints = psection.STSRegionalEndpoints
 	}
+	if config.SourceIdentity == "" {
+		config.SourceIdentity = psection.SourceIdentity
+	}
 	if sessionTags := psection.SessionTags; sessionTags != "" && config.SessionTags == nil {
 		err := config.SetSessionTags(sessionTags)
 		if err != nil {
@@ -417,7 +421,7 @@ func (cl *ConfigLoader) populateFromEnv(profile *Config) {
 		}
 	}
 
-	// AWS_ROLE_ARN, AWS_ROLE_SESSION_NAME, AWS_SESSION_TAGS and AWS_TRANSITIVE_TAGS only apply to the target profile
+	// AWS_ROLE_ARN, AWS_ROLE_SESSION_NAME, AWS_SESSION_TAGS, AWS_TRANSITIVE_TAGS and AWS_SOURCE_IDENTITY only apply to the target profile
 	if profile.ProfileName == cl.ActiveProfile {
 		if roleARN := os.Getenv("AWS_ROLE_ARN"); roleARN != "" && profile.RoleARN == "" {
 			log.Printf("Using role_arn %q from AWS_ROLE_ARN", roleARN)
@@ -440,6 +444,11 @@ func (cl *ConfigLoader) populateFromEnv(profile *Config) {
 		if transitiveSessionTags := os.Getenv("AWS_TRANSITIVE_TAGS"); transitiveSessionTags != "" && profile.TransitiveSessionTags == nil {
 			profile.SetTransitiveSessionTags(transitiveSessionTags)
 			log.Printf("Using transitive_session_tags %v from AWS_TRANSITIVE_TAGS", profile.TransitiveSessionTags)
+		}
+
+		if sourceIdentity := os.Getenv("AWS_SOURCE_IDENTITY"); sourceIdentity != "" && profile.SourceIdentity == "" {
+			profile.SourceIdentity = sourceIdentity
+			log.Printf("Using source_identity %v from AWS_SOURCE_IDENTITY", profile.SourceIdentity)
 		}
 	}
 }
@@ -541,6 +550,9 @@ type Config struct {
 
 	// TransitiveSessionTags specifies assumed role Transitive Session Tags keys
 	TransitiveSessionTags []string
+
+	// SourceIdentity specifies assumed role Source Identity
+	SourceIdentity string
 }
 
 // SetSessionTags parses a comma separated key=vaue string and sets Config.SessionTags map

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -112,6 +112,7 @@ func NewAssumeRoleProvider(credsProvider aws.CredentialsProvider, k keyring.Keyr
 		Duration:          config.AssumeRoleDuration,
 		Tags:              config.SessionTags,
 		TransitiveTagKeys: config.TransitiveSessionTags,
+		SourceIdentity:    config.SourceIdentity,
 		Mfa: Mfa{
 			MfaSerial:       config.MfaSerial,
 			MfaToken:        config.MfaToken,


### PR DESCRIPTION
Added support for specifying source identity when assuming roles. Can be specified with `source_identity` in config file or `AWS_SOURCE_IDENTITY` environment variable.
Fixes #771