### PR TITLE
Make "file" backend directory configurable

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -128,6 +128,7 @@ To configure the default flag values of `aws-vault` and its subcommands:
 * `AWS_VAULT_PASS_PASSWORD_STORE_DIR`: Pass password store directory (see the flag `--pass-dir`)
 * `AWS_VAULT_PASS_CMD`: Name of the pass executable (see the flag `--pass-cmd`)
 * `AWS_VAULT_PASS_PREFIX`: Prefix to prepend to the item path stored in pass (see the flag `--pass-prefix`)
+* `AWS_VAULT_FILE_DIR`: Directory for the "file" password store (see the flag `--file-dir`)
 * `AWS_VAULT_FILE_PASSPHRASE`: Password for the "file" password store
 * `AWS_CONFIG_FILE`: The location of the AWS config file
 

--- a/cli/global.go
+++ b/cli/global.go
@@ -15,7 +15,6 @@ import (
 
 var keyringConfigDefaults = keyring.Config{
 	ServiceName:              "aws-vault",
-	FileDir:                  "~/.awsvault/keys/",
 	FilePasswordFunc:         fileKeyringPassphrasePrompt,
 	LibSecretCollectionName:  "awsvault",
 	KWalletAppID:             "aws-vault",
@@ -115,6 +114,11 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 	app.Flag("pass-prefix", "Prefix to prepend to the item path stored in pass").
 		Envar("AWS_VAULT_PASS_PREFIX").
 		StringVar(&a.KeyringConfig.PassPrefix)
+
+	app.Flag("file-dir", "Directory for the \"file\" password store").
+		Default("~/.awsvault/keys/").
+		Envar("AWS_VAULT_FILE_DIR").
+		StringVar(&a.KeyringConfig.FileDir)
 
 	app.PreAction(func(c *kingpin.ParseContext) error {
 		if !a.Debug {


### PR DESCRIPTION
This is a small PR to make the directory used by the "file" backend configurable. My use case is that I'd like to share the same file backend between Windows and WSL rather than duplicating credentials into both home directories.

The name for the env variable/flag were my best attempt to follow the existing naming conventions, though it comes out kind of vague. Open to suggestions on better names.