### PR TITLE
Fix hint message for unsetting env variable

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -122,7 +122,7 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 
 func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) error {
 	if os.Getenv("AWS_VAULT") != "" {
-		return fmt.Errorf("aws-vault sessions should be nested with care, unset $AWS_VAULT to force")
+		return fmt.Errorf("aws-vault sessions should be nested with care, unset AWS_VAULT to force")
 	}
 
 	err := input.validate()


### PR DESCRIPTION
You don't need the $ sign before the variable name when [unsetting an env variable](https://www.tecmint.com/set-unset-environment-variables-in-linux/).