### PR TITLE
Make MFA prompt input secret

### DIFF
--- a/prompt/terminal.go
+++ b/prompt/terminal.go
@@ -35,7 +35,7 @@ func TerminalSecretPrompt(message string) (string, error) {
 }
 
 func TerminalMfaPrompt(mfaSerial string) (string, error) {
-	return TerminalPrompt(mfaPromptMessage(mfaSerial))
+	return TerminalSecretPrompt(mfaPromptMessage(mfaSerial))
 }
 
 func init() {


### PR DESCRIPTION
This PR simply makes the terminal prompt for the MFA code secret for better security.

Signed-off-by: Ismayil Mirzali <ismayilmirzeli@gmail.com>