### PR TITLE
Add standalone ECS role server

### DIFF
--- a/cli/ecs-role-server.go
+++ b/cli/ecs-role-server.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/99designs/aws-vault/v6/server"
+	"github.com/99designs/aws-vault/v6/vault"
+	"github.com/99designs/keyring"
+	"github.com/alecthomas/kingpin"
+)
+
+type EcsServerCommandInput struct {
+	ProfileName         string
+	Config              vault.Config
+	AuthToken           string
+	Port                int
+	RoleSessionDuration time.Duration
+}
+
+func ConfigureEcsRoleServerCommand(app *kingpin.Application, a *AwsVault) {
+	input := EcsServerCommandInput{}
+
+	cmd := app.Command("ecs-role-server", "Starts a standalone ECS credential server")
+
+	cmd.Arg("profile", "Name of the source profile").
+		Required().
+		HintAction(a.MustGetProfileNames).
+		StringVar(&input.ProfileName)
+	cmd.Flag("auth-token", "Token required in the Authorization header of the request").
+		StringVar(&input.AuthToken)
+	cmd.Flag("port", "Port to listen on").
+		Short('p').
+		Default("55777").
+		IntVar(&input.Port)
+	cmd.Flag("duration", "Duration of the assume-role session. Defaults to 1h").
+		Short('d').
+		Default("1h").
+		DurationVar(&input.RoleSessionDuration)
+
+	cmd.Action(func(c *kingpin.ParseContext) (err error) {
+		f, err := a.AwsConfigFile()
+		if err != nil {
+			return err
+		}
+		keyring, err := a.Keyring()
+		if err != nil {
+			return err
+		}
+
+		err = EcsRoleServerCommand(input, f, keyring)
+		app.FatalIfError(err, "ecs-server")
+		return nil
+	})
+}
+
+func EcsRoleServerCommand(input EcsServerCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) error {
+	vault.UseSession = false
+
+	configLoader := vault.ConfigLoader{
+		File:          f,
+		BaseConfig:    input.Config,
+		ActiveProfile: input.ProfileName,
+	}
+	config, err := configLoader.LoadFromProfile(input.ProfileName)
+	if err != nil {
+		return fmt.Errorf("Error loading config: %w", err)
+	}
+
+	ckr := &vault.CredentialKeyring{Keyring: keyring}
+	credsProvider, err := vault.NewTempCredentialsProvider(config, ckr)
+	if err != nil {
+		return fmt.Errorf("Error getting temporary credentials: %w", err)
+	}
+
+	err = server.StartStandaloneEcsRoleCredentialServer(credsProvider, config, input.AuthToken, input.Port, input.RoleSessionDuration)
+	if err != nil {
+		return fmt.Errorf("Failed to start credential server: %w", err)
+	}
+
+	return nil
+}

--- a/cli/ecs-role-server.go
+++ b/cli/ecs-role-server.go
@@ -28,6 +28,7 @@ func ConfigureEcsRoleServerCommand(app *kingpin.Application, a *AwsVault) {
 		HintAction(a.MustGetProfileNames).
 		StringVar(&input.ProfileName)
 	cmd.Flag("auth-token", "Token required in the Authorization header of the request").
+		Envar("AWS_VAULT_ECS_ROLE_SERVER_AUTH_TOKEN").
 		StringVar(&input.AuthToken)
 	cmd.Flag("port", "Port to listen on").
 		Short('p').

--- a/cli/ecs-role-server.go
+++ b/cli/ecs-role-server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/99designs/aws-vault/v6/vault"
 	"github.com/99designs/keyring"
 	"github.com/alecthomas/kingpin"
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 type EcsServerCommandInput struct {
@@ -74,7 +75,8 @@ func EcsRoleServerCommand(input EcsServerCommandInput, f *vault.ConfigFile, keyr
 		return fmt.Errorf("Error getting temporary credentials: %w", err)
 	}
 
-	ecsServer, err := server.NewEcsServer(credsProvider, config, "", input.Port)
+	credsCache := aws.NewCredentialsCache(credsProvider)
+	ecsServer, err := server.NewEcsServer(credsCache, config, "", input.Port, false)
 	if err != nil {
 		return err
 	}
@@ -88,7 +90,7 @@ func EcsRoleServerCommand(input EcsServerCommandInput, f *vault.ConfigFile, keyr
 	fmt.Println("If you wish to use AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/role-arn/YOUR_ROLE_ARN instead of AWS_CONTAINER_CREDENTIALS_FULL_URI, use a reverse proxy on http://169.254.170.2:80")
 	fmt.Println("")
 
-	err = ecsServer.Start()
+	err = ecsServer.Serve()
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 	cli.ConfigureRemoveCommand(app, a)
 	cli.ConfigureLoginCommand(app, a)
 	cli.ConfigureProxyCommand(app, a)
+	cli.ConfigureEcsRoleServerCommand(app, a)
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }

--- a/server/ecsserver.go
+++ b/server/ecsserver.go
@@ -9,9 +9,13 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/99designs/aws-vault/v6/iso8601"
+	"github.com/99designs/aws-vault/v6/vault"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 func writeErrorMessage(w http.ResponseWriter, msg string, statusCode int) {
@@ -22,9 +26,9 @@ func writeErrorMessage(w http.ResponseWriter, msg string, statusCode int) {
 	}
 }
 
-func withAuthorizationCheck(token string, next http.HandlerFunc) http.HandlerFunc {
+func withAuthorizationCheck(authToken string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != token {
+		if r.Header.Get("Authorization") != authToken {
 			writeErrorMessage(w, "invalid Authorization token", http.StatusForbidden)
 			return
 		}
@@ -38,10 +42,7 @@ func StartEcsCredentialServer(credsProvider aws.CredentialsProvider) (string, st
 	if err != nil {
 		return "", "", err
 	}
-	token, err := generateRandomString()
-	if err != nil {
-		return "", "", err
-	}
+	authToken := generateRandomString()
 	credsCache := aws.NewCredentialsCache(credsProvider)
 
 	// Retrieve credentials eagerly to support MFA prompts
@@ -51,15 +52,14 @@ func StartEcsCredentialServer(credsProvider aws.CredentialsProvider) (string, st
 	}
 
 	go func() {
-		err := http.Serve(listener, withLogging(withAuthorizationCheck(token, ecsCredsHandler(credsCache))))
-		// returns ErrServerClosed on graceful close
-		if err != http.ErrServerClosed {
+		err := http.Serve(listener, withLogging(withAuthorizationCheck(authToken, ecsCredsHandler(credsCache))))
+		if err != http.ErrServerClosed { // ErrServerClosed is a graceful close
 			log.Fatalf("ecs server: %s", err.Error())
 		}
 	}()
 
 	uri := fmt.Sprintf("http://%s", listener.Addr().String())
-	return uri, token, nil
+	return uri, authToken, nil
 }
 
 func ecsCredsHandler(credsCache *aws.CredentialsCache) http.HandlerFunc {
@@ -70,23 +70,74 @@ func ecsCredsHandler(credsCache *aws.CredentialsCache) http.HandlerFunc {
 			return
 		}
 
-		err = json.NewEncoder(w).Encode(map[string]string{
-			"AccessKeyId":     creds.AccessKeyID,
-			"SecretAccessKey": creds.SecretAccessKey,
-			"Token":           creds.SessionToken,
-			"Expiration":      iso8601.Format(creds.Expires),
-		})
+		writeCredsToResponse(creds, w)
+	}
+}
+
+func writeCredsToResponse(creds aws.Credentials, w http.ResponseWriter) {
+	err := json.NewEncoder(w).Encode(map[string]string{
+		"AccessKeyId":     creds.AccessKeyID,
+		"SecretAccessKey": creds.SecretAccessKey,
+		"Token":           creds.SessionToken,
+		"Expiration":      iso8601.Format(creds.Expires),
+	})
+	if err != nil {
+		writeErrorMessage(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func generateRandomString() string {
+	b := make([]byte, 30)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func StartStandaloneEcsRoleCredentialServer(credsProvider aws.CredentialsProvider, config *vault.Config, authToken string, port int, roleDuration time.Duration) error {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return err
+	}
+
+	if authToken == "" {
+		authToken = generateRandomString()
+	}
+
+	fmt.Println("Starting standalone ECS credential server.")
+	fmt.Println("Set the following environment variables to use the ECS credential server:")
+	fmt.Println("")
+	fmt.Println("      AWS_CONTAINER_AUTHORIZATION_TOKEN=" + authToken)
+	fmt.Printf("      AWS_CONTAINER_CREDENTIALS_FULL_URI=http://127.0.0.1:%d/role-arn/YOUR_ROLE_ARN\n", port)
+	fmt.Println("")
+	fmt.Println("If you wish to use AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/role-arn/YOUR_ROLE_ARN instead of AWS_CONTAINER_CREDENTIALS_FULL_URI, use a reverse proxy on http://169.254.170.2:80")
+	fmt.Println("")
+
+	router := http.NewServeMux()
+
+	router.HandleFunc("/role-arn/", func(w http.ResponseWriter, r *http.Request) {
+		roleArn := strings.TrimPrefix(r.URL.Path, "/role-arn/")
+		cfg := vault.NewAwsConfigWithCredsProvider(credsProvider, config.Region, config.STSRegionalEndpoints)
+		roleProvider := &vault.AssumeRoleProvider{
+			StsClient: sts.NewFromConfig(cfg),
+			RoleARN:   roleArn,
+			Duration:  roleDuration,
+		}
+
+		creds, err := roleProvider.Retrieve(context.TODO())
 		if err != nil {
 			writeErrorMessage(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-	}
-}
 
-func generateRandomString() (string, error) {
-	b := make([]byte, 30)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
+		writeCredsToResponse(creds, w)
+	})
+
+	err = http.Serve(listener, withLogging(withAuthorizationCheck(authToken, router.ServeHTTP)))
+	if err != http.ErrServerClosed {
+		log.Fatalf("ecs server: %s", err.Error())
 	}
-	return base64.RawURLEncoding.EncodeToString(b), nil
+
+	return nil
 }


### PR DESCRIPTION
Adds a new command `aws-vault ecs-role-server` to start a standalone ECS role server.

The ECS server will respond to requests on `/role-arn/YOUR_ROLE_ARN`, making it usable with the `AWS_CONTAINER_CREDENTIALS_FULL_URI` or `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment 
variables. These environment variables are used by the AWS SDKs as part of the [default credential provider chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default).

The major use-case for this are applications where using `aws-vault exec` workflow is awkward. In particular, using aws-vault on the host with docker images running in a VM. While it's _possible_ to start a container with `aws-vault exec --ecs-server docker run ...`, management of the aws-vault server process does become awkward, and may be better delegated to launchd, brew services, or some other local init script. Using the default ECS IP address `169.254.170.2` means that apps in a docker container no longer need AWS keys at all - instead they just need to specify the role they want to assume, the same way they would in an actual ECS environment.

Here's a diagram with the envisioned architecture for accessing aws-vault from a docker container.

![Screen Shot 2022-03-03 at 12 16 15 pm](https://user-images.githubusercontent.com/980499/156477380-423f4eb9-f10e-4568-afa8-7fa525a1f3a3.png)

This use-case is similar to the goal of [amazon-ecs-local-container-endpoints](https://github.com/awslabs/amazon-ecs-local-container-endpoints/blob/mainline/docs/features.md#vend-credentials-to-containers), however the difference here is that the long-lived AWS credentials are getting sourced from your keychain via aws-vault.

The idea of a standalone server has been previously raised in #222, #345, #361, #733 and #740, so keen to also get feedback from folks who've previously requested something similar. I know this doesn't hit all the use-cases contained in those issues yet, but feedback on general direction and architecture of a standalone server would be good. 