### PR TITLE
Add a dynamic role route to ECS server

### DIFF
--- a/contrib/_aws-vault-proxy/Dockerfile
+++ b/contrib/_aws-vault-proxy/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.17
+WORKDIR /usr/src/aws-vault-proxy
+COPY . /usr/src/aws-vault-proxy
+RUN go build -v -o /usr/local/bin/aws-vault-proxy ./...
+CMD ["/usr/local/bin/aws-vault-proxy"]

--- a/contrib/_aws-vault-proxy/docker-compose.yml
+++ b/contrib/_aws-vault-proxy/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "2.4"
+networks:
+  aws-vault:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: "169.254.170.0/24"
+          gateway: "169.254.170.1"
+services:
+  aws-vault-proxy:
+    build: .
+    environment:
+     - AWS_CONTAINER_CREDENTIALS_FULL_URI
+     - AWS_CONTAINER_AUTHORIZATION_TOKEN
+    networks:
+      aws-vault:
+        ipv4_address: "169.254.170.2" # This special IP address is recognized by the AWS SDKs and AWS CLI
+    healthcheck:
+      test: pgrep aws-vault-proxy
+  testapp:
+    image: amazon/aws-cli
+    entrypoint: ""
+    command: /bin/bash
+    environment:
+      - AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+    networks:
+      aws-vault: {}
+      default: {}

--- a/contrib/_aws-vault-proxy/go.mod
+++ b/contrib/_aws-vault-proxy/go.mod
@@ -1,0 +1,7 @@
+module aws-vault-ecs-server-reverse-proxy
+
+go 1.17
+
+require github.com/gorilla/handlers v1.5.1
+
+require github.com/felixge/httpsnoop v1.0.1 // indirect

--- a/contrib/_aws-vault-proxy/go.sum
+++ b/contrib/_aws-vault-proxy/go.sum
@@ -1,0 +1,4 @@
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=

--- a/contrib/_aws-vault-proxy/main.go
+++ b/contrib/_aws-vault-proxy/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+
+	"github.com/gorilla/handlers"
+)
+
+func GetReverseProxyTarget() *url.URL {
+	url, err := url.Parse(os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"))
+	if err != nil {
+		log.Fatalln("Bad AWS_CONTAINER_CREDENTIALS_FULL_URI:", err.Error())
+	}
+	url.Host = "host.docker.internal:" + url.Port()
+	return url
+}
+
+func addAuthorizationHeader(authToken string, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Add("Authorization", authToken)
+		next.ServeHTTP(w, r)
+	}
+}
+
+func main() {
+	target := GetReverseProxyTarget()
+	authToken := os.Getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN")
+	log.Printf("reverse proxying target:%s auth:%s\n", target, authToken)
+
+	handler := handlers.LoggingHandler(os.Stderr,
+		addAuthorizationHeader(authToken,
+			httputil.NewSingleHostReverseProxy(target)))
+
+	_ = http.ListenAndServe(":80", handler)
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.15.0
 	github.com/google/go-cmp v0.5.7
+	github.com/gorilla/handlers v1.5.1
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838
 	golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a
@@ -32,6 +33,7 @@ require (
 	github.com/aws/smithy-go v1.11.0 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
+	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/mtibben/percent v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,10 +43,15 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
+github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/server/ecsserver.go
+++ b/server/ecsserver.go
@@ -9,9 +9,13 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
+	"sync"
 
 	"github.com/99designs/aws-vault/v6/iso8601"
+	"github.com/99designs/aws-vault/v6/vault"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 func writeErrorMessage(w http.ResponseWriter, msg string, statusCode int) {
@@ -22,9 +26,9 @@ func writeErrorMessage(w http.ResponseWriter, msg string, statusCode int) {
 	}
 }
 
-func withAuthorizationCheck(token string, next http.HandlerFunc) http.HandlerFunc {
+func withAuthorizationCheck(authToken string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != token {
+		if r.Header.Get("Authorization") != authToken {
 			writeErrorMessage(w, "invalid Authorization token", http.StatusForbidden)
 			return
 		}
@@ -32,61 +36,114 @@ func withAuthorizationCheck(token string, next http.HandlerFunc) http.HandlerFun
 	}
 }
 
-// StartEcsCredentialServer starts an ECS credential server on a random port
-func StartEcsCredentialServer(credsProvider aws.CredentialsProvider) (string, string, error) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+func writeCredsToResponse(creds aws.Credentials, w http.ResponseWriter) {
+	err := json.NewEncoder(w).Encode(map[string]string{
+		"AccessKeyId":     creds.AccessKeyID,
+		"SecretAccessKey": creds.SecretAccessKey,
+		"Token":           creds.SessionToken,
+		"Expiration":      iso8601.Format(creds.Expires),
+	})
 	if err != nil {
-		return "", "", err
-	}
-	token, err := generateRandomString()
-	if err != nil {
-		return "", "", err
-	}
-	credsCache := aws.NewCredentialsCache(credsProvider)
-
-	// Retrieve credentials eagerly to support MFA prompts
-	_, err = credsCache.Retrieve(context.Background())
-	if err != nil {
-		return "", "", err
-	}
-
-	go func() {
-		err := http.Serve(listener, withLogging(withAuthorizationCheck(token, ecsCredsHandler(credsCache))))
-		// returns ErrServerClosed on graceful close
-		if err != http.ErrServerClosed {
-			log.Fatalf("ecs server: %s", err.Error())
-		}
-	}()
-
-	uri := fmt.Sprintf("http://%s", listener.Addr().String())
-	return uri, token, nil
-}
-
-func ecsCredsHandler(credsCache *aws.CredentialsCache) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		creds, err := credsCache.Retrieve(r.Context())
-		if err != nil {
-			writeErrorMessage(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		err = json.NewEncoder(w).Encode(map[string]string{
-			"AccessKeyId":     creds.AccessKeyID,
-			"SecretAccessKey": creds.SecretAccessKey,
-			"Token":           creds.SessionToken,
-			"Expiration":      iso8601.Format(creds.Expires),
-		})
-		if err != nil {
-			writeErrorMessage(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		writeErrorMessage(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 
-func generateRandomString() (string, error) {
+func generateRandomString() string {
 	b := make([]byte, 30)
 	if _, err := rand.Read(b); err != nil {
-		return "", err
+		panic(err)
 	}
-	return base64.RawURLEncoding.EncodeToString(b), nil
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+type EcsServer struct {
+	listener          net.Listener
+	authToken         string
+	server            http.Server
+	cache             sync.Map
+	baseCredsProvider aws.CredentialsProvider
+	config            *vault.Config
+}
+
+func NewEcsServer(baseCredsProvider aws.CredentialsProvider, config *vault.Config, authToken string, port int, lazyLoadBaseCreds bool) (*EcsServer, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return nil, err
+	}
+	if authToken == "" {
+		authToken = generateRandomString()
+	}
+
+	credsCache := aws.NewCredentialsCache(baseCredsProvider)
+	if !lazyLoadBaseCreds {
+		_, err := credsCache.Retrieve(context.TODO())
+		if err != nil {
+			return nil, fmt.Errorf("Retrieving creds: %w", err)
+		}
+	}
+
+	e := &EcsServer{
+		listener:          listener,
+		authToken:         authToken,
+		baseCredsProvider: credsCache,
+		config:            config,
+	}
+
+	router := http.NewServeMux()
+	router.HandleFunc("/", e.DefaultRoute)
+	router.HandleFunc("/role-arn/", e.AssumeRoleArnRoute)
+	e.server.Handler = withLogging(withAuthorizationCheck(e.authToken, router.ServeHTTP))
+
+	return e, nil
+}
+
+func (e *EcsServer) BaseUrl() string {
+	return fmt.Sprintf("http://%s", e.listener.Addr().String())
+}
+func (e *EcsServer) AuthToken() string {
+	return e.authToken
+}
+
+func (e *EcsServer) Serve() error {
+	return e.server.Serve(e.listener)
+}
+
+func (e *EcsServer) DefaultRoute(w http.ResponseWriter, r *http.Request) {
+	creds, err := e.baseCredsProvider.Retrieve(r.Context())
+	if err != nil {
+		writeErrorMessage(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeCredsToResponse(creds, w)
+}
+
+func (e *EcsServer) getRoleProvider(roleArn string) aws.CredentialsProvider {
+	var roleProviderCache *aws.CredentialsCache
+
+	v, ok := e.cache.Load(roleArn)
+	if ok {
+		roleProviderCache = v.(*aws.CredentialsCache)
+	} else {
+		cfg := vault.NewAwsConfigWithCredsProvider(e.baseCredsProvider, e.config.Region, e.config.STSRegionalEndpoints)
+		roleProvider := &vault.AssumeRoleProvider{
+			StsClient: sts.NewFromConfig(cfg),
+			RoleARN:   roleArn,
+			Duration:  e.config.AssumeRoleDuration,
+		}
+		roleProviderCache = aws.NewCredentialsCache(roleProvider)
+		e.cache.Store(roleArn, roleProviderCache)
+	}
+	return roleProviderCache
+}
+
+func (e *EcsServer) AssumeRoleArnRoute(w http.ResponseWriter, r *http.Request) {
+	roleArn := strings.TrimPrefix(r.URL.Path, "/role-arn/")
+	roleProvider := e.getRoleProvider(roleArn)
+	creds, err := roleProvider.Retrieve(r.Context())
+	if err != nil {
+		writeErrorMessage(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeCredsToResponse(creds, w)
 }


### PR DESCRIPTION
Adds a new route to `aws-vault exec --ecs-server` to assume role credentials dynamically.

The ECS server now responds to requests on `/role-arn/YOUR_ROLE_ARN` with the role credentials, making it usable with the `AWS_CONTAINER_CREDENTIALS_FULL_URI` or `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment 
variables. These environment variables are used by the AWS SDKs as part of the [default credential provider chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default).

The major use-case for this are applications that may wish to assume a role dynamically, without the role specified in the aws config file.

In particular, this is designed to allow aws-vault to run on your local host while docker images access role credentials dynamically. This is achieved via a reverse-proxy container (started with `aws-vault exec --ecs-server --lazy PROFILE -- docker-compose up ...`) using the default ECS IP address `169.254.170.2`. Docker containers no longer need AWS keys at all - instead they can  specify the role they want to assume with `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`.

![Screen Shot 2022-03-03 at 12 16 15 pm](https://user-images.githubusercontent.com/980499/156477380-423f4eb9-f10e-4568-afa8-7fa525a1f3a3.png)

This use-case is similar to the goal of [amazon-ecs-local-container-endpoints](https://github.com/awslabs/amazon-ecs-local-container-endpoints/blob/mainline/docs/features.md#vend-credentials-to-containers), however the difference here is that the long-lived AWS credentials are getting sourced from your keychain via aws-vault.

A `--lazy` flag has also been added so that credentials are only retrieved when a request is actually made to the server.