### PR TITLE
With login, `SSOUseStdout` should follow `--stdout`

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -63,6 +63,7 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 		input.Config.NonChainedGetSessionTokenDuration = input.SessionDuration
 		input.Config.AssumeRoleDuration = input.SessionDuration
 		input.Config.GetFederationTokenDuration = input.SessionDuration
+		input.Config.SSOUseStdout = input.UseStdout
 		keyring, err := a.Keyring()
 		if err != nil {
 			return err


### PR DESCRIPTION
The logic is now similar to how exec handles this. This fixes the
`--stdout` option for SSO login, and should close #868.