### PR TITLE
[DRAFT] Added a key rotation warning on login and exec

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -145,6 +145,8 @@ func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Ke
 		return err
 	}
 
+	vault.CheckAccessKeyAge(&input.Config, keyring)
+
 	vault.UseSession = !input.NoSession
 
 	configLoader := vault.ConfigLoader{

--- a/cli/login.go
+++ b/cli/login.go
@@ -110,6 +110,8 @@ func LoginCommand(input LoginCommandInput, f *vault.ConfigFile, keyring keyring.
 		}
 	}
 
+	vault.CheckAccessKeyAge(config, keyring)
+
 	creds, err := credsProvider.Retrieve(context.TODO())
 	if err != nil {
 		return fmt.Errorf("Failed to get credentials: %w", err)

--- a/vault/checkaccesskeyage.go
+++ b/vault/checkaccesskeyage.go
@@ -1,0 +1,50 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/99designs/keyring"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+// GetUsernameFromSession returns the IAM username (or root) associated with the current aws session
+func getAccessKeyAge(cfg aws.Config) (time.Duration, error) {
+	iamClient := iam.NewFromConfig(cfg)
+
+	keys, err := iamClient.ListAccessKeys(
+		context.TODO(),
+		&iam.ListAccessKeysInput{},
+	)
+	if err != nil {
+		return 0, err
+	} else if len(keys.AccessKeyMetadata) == 0 {
+		return 0, fmt.Errorf("failed to retrieve access key")
+	}
+
+	keyCreationDate := keys.AccessKeyMetadata[0].CreateDate
+	keyAge := time.Now().UTC().Sub(*keyCreationDate)
+
+	return keyAge, nil
+}
+
+func CheckAccessKeyAge(config *Config, keyring keyring.Keyring) {
+	ckr := &CredentialKeyring{Keyring: keyring}
+	masterCredentialsName, err := FindMasterCredentialsNameFor(config.ProfileName, ckr, config)
+	if err != nil {
+		fmt.Println("Could not find master credentials")
+		return
+	}
+
+	credsProvider := NewMasterCredentialsProvider(ckr, masterCredentialsName)
+	cfg := NewAwsConfigWithCredsProvider(credsProvider, config.Region, config.STSRegionalEndpoints)
+	keyAge, err := getAccessKeyAge(cfg)
+
+	if err != nil {
+		fmt.Println("Failed to retrieve access key age")
+	} else if keyAge > config.AccessKeyLifetimeWarningAge {
+		fmt.Printf("Please rotate your access key by executing 'aws-vault rotate %s'\n", config.ProfileName)
+	}
+}


### PR DESCRIPTION
This PR is the first draft there is still a little to do such as tests, updating the README and checking other login flows such as SSO, environment variables and through a federation token provider (not sure it will work with this one). I decided to share it early to get feedback from people who know the repo better than me as they will catch some things I have missed.

This PR increases the security of aws-vault by warning the user when their access keys become older than desired.

This new feature extends the .aws/config with a new key `access_key_lifetime_warning_age` (in hours), defaulting to 90 days. Here is an example of a config file.

```ini
[profile baseAccount]
region = xxxx
mfa_serial = xxxx
access_key_lifetime_warning_age = 2160.   // 90 days

[profile anotherAccount]
region = xxxx
source_profile = baseAccount
role_arn = xxxx
```

Pros
- A warning will be displayed notifying the user to rotate their access key.

Cons
- Each login/exec will take a little longer as an extra request has to be made to was to check the access key age.

### Main Design Decisions
I decided to put the new config in the `.aws/config` file rather than in an environment variable so a default value can be easily shared between all users in an organisation (given their configs are generated in a predictable way). This could possibly cause a conflict as we do not own the config file so maybe a format such as `aws_vault_` prefix could be used but it has not been done on other custom configs so I have left it out.

I have put the check in the main login and exec command rather than in the vault as there was no easy way to stop this error from displaying on the rotate command.

I have made the timing in hours rather than days or seconds as seconds created a massive number which made the number hard to comprehend and days didn't give a lot of granularity.
