### PR TITLE
allow Host header with explicit :80 included

### DIFF
--- a/server/ec2server.go
+++ b/server/ec2server.go
@@ -81,7 +81,7 @@ func withSecurityChecks(next *http.ServeMux) http.HandlerFunc {
 		// Check that the request is to 169.254.169.254
 		// Without this it's possible for an attacker to mount a DNS rebinding attack
 		// See https://github.com/99designs/aws-vault/issues/578
-		if r.Host != ec2MetadataEndpointIP {
+		if r.Host != ec2MetadataEndpointIP && r.Host != ec2MetadataEndpointAddr {
 			http.Error(w, fmt.Sprintf("Access denied for host '%s'", r.Host), http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
A valid `Host` header may explicitly include the port, though it's optional for default ports ([ref](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host)). Had this come up as an issue WRT integrating https://github.com/fog/fog-aws into an application, which makes requests to http://169.254.169.254:80 as opposed to http://169.254.169.254. This is technically not incorrect, so seemed better to open a PR here than there.