### PR TITLE
Add 1password prompt

### DIFF
--- a/prompt/1password.go
+++ b/prompt/1password.go
@@ -1,0 +1,30 @@
+package prompt
+
+import (
+    "fmt"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func OnePasswordPrompt(mfaSerial string) (string, error) {
+    opTagName := os.Getenv("AWS_VAULT_OP_TAG_NAME")
+    if opTagName == "" {
+        opTagName = "AWS Vault"
+    }
+
+    cmd := exec.Command("sh", "-c", fmt.Sprintf(`
+        op item list --tags "%s" --format json | jq -c '[ .[] | select(.urls[] | select(.href == "%s")) ]' | op item get - --otp
+    `, opTagName, mfaSerial))
+
+    out, err := cmd.Output()
+    if err != nil {
+        return "", err
+    }
+
+    return strings.TrimSpace(string(out)), nil
+}
+
+func init() {
+    Methods["1password"] = OnePasswordPrompt
+}


### PR DESCRIPTION
Add `1password` prompt (which is for mfa otp).

- Set prompt
  - Use with environment: `AWS_VAULT_PROMPT=1password`
  - Use with flag: `--prompt=1password`
- Add 1password item with tag `AWS Vault` (or customize with environment variable: `AWS_VAULT_OP_TAG_NAME`)
  <img width="200" alt="image" src="https://user-images.githubusercontent.com/32478597/177051573-a60a7101-6ceb-4dce-a2d8-e66e654ad406.png">
- Update 1password item url with aws mfa serial
  <img width="742" alt="image" src="https://user-images.githubusercontent.com/32478597/177051626-1419a755-2448-40e6-b583-ed56a1bfa1e1.png">
- Also need one-time password section
  - https://support.1password.com/one-time-passwords/
