### PR TITLE
Add YKMAN_OATH_DEVICE_SERIAL to USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -528,6 +528,7 @@ Further config:
  - `AWS_VAULT_PROMPT=ykman`: to avoid specifying `--prompt` each time
  - `YKMAN_OATH_CREDENTIAL_NAME`: to use an alternative ykman credential
  - `AWS_VAULT_YKMAN_VERSION`: to set the major version of the ykman cli being used. Defaults to "4"
+ - `YKMAN_OATH_DEVICE_SERIAL`: to set the device serial of a specific Yubikey if you have multiple Yubikeys plugged into your computer.
 
 ## Shell completion
 


### PR DESCRIPTION
I have multiple Yubikeys plugged into my computer and I looked for the possibility to specify the `--device` flag to the `ykman` command. I found out this was already implemented in https://github.com/99designs/aws-vault/pull/748 though not added to the documentation, so this is what this PR does.