### PR TITLE
Update for rename of AWS SSO to “AWS IAM Identity Center”

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -26,7 +26,7 @@
     - [Temporary credentials limitations with STS, IAM](#temporary-credentials-limitations-with-sts-iam)
   - [MFA](#mfa)
     - [Gotchas with MFA config](#gotchas-with-mfa-config)
-  - [AWS Single Sign-On (AWS SSO)](#aws-single-sign-on-aws-sso)
+  - [Single sign on with AWS IAM Identity Center (formerly AWS SSO)](#aws-single-sign-on-aws-sso)
   - [Assuming roles with web identities](#assuming-roles-with-web-identities)
   - [Using `credential_process`](#using-credential_process)
   - [Using a Yubikey](#using-a-yubikey)
@@ -424,13 +424,15 @@ include_profile = jon
 
 ## AWS Single Sign-On (AWS SSO)
 
-If your organization uses AWS Single Sign-On ([AWS SSO](https://aws.amazon.com/single-sign-on/)), AWS Vault provides a method for using the credential information defined by [AWS SSO CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html). The configuration options are as follows:
-* `sso_start_url` The URL that points to the organization's AWS SSO user portal.
-* `sso_region` The AWS Region that contains the AWS SSO portal host. This is separate from, and can be a different region than the default CLI region parameter.
+_AWS IAM Identity Center provides single sign on, and was previously known as AWS SSO._
+
+If your organization uses [AWS IAM Identity Center](https://aws.amazon.com/iam/identity-center/) for single sign on, AWS Vault provides a method for using the credential information defined by [`aws sso`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html) from v2 of the AWS CLI. The configuration options are as follows:
+* `sso_start_url` The URL that points to the organization's AWS IAM Identity Center user portal.
+* `sso_region` The AWS Region that contains the AWS IAM Identity Center user portal host. This is separate from, and can be a different region than the default CLI region parameter.
 * `sso_account_id` The AWS account ID that contains the IAM role that you want to use with this profile.
 * `sso_role_name` The name of the IAM role that defines the user's permissions when using this profile.
 
-Here is an example configuration using AWS SSO.
+Here is an example configuration using AWS IAM Identity Center for single sign on.
 
 ```ini
 [profile Administrator-123456789012]

--- a/vault/config.go
+++ b/vault/config.go
@@ -532,16 +532,16 @@ type Config struct {
 	// GetFederationTokenDuration specifies the wanted duration for credentials generated with GetFederationToken
 	GetFederationTokenDuration time.Duration
 
-	// SSOStartURL specifies the URL for the AWS SSO user portal.
+	// SSOStartURL specifies the URL for the AWS IAM Identity Center user portal.
 	SSOStartURL string
 
-	// SSORegion specifies the region for the AWS SSO user portal.
+	// SSORegion specifies the region for the AWS IAM Identity Center user portal.
 	SSORegion string
 
 	// SSOAccountID specifies the AWS account ID for the profile.
 	SSOAccountID string
 
-	// SSORoleName specifies the AWS SSO Role name to target.
+	// SSORoleName specifies the AWS IAM Role name to target.
 	SSORoleName string
 
 	// SSOUseStdout specifies that the system browser should not be automatically opened


### PR DESCRIPTION
AWS SSO was too easy to pronounce, so it's now AWS IAM IC. Update docs and code comments to match.

I have left https://github.com/99designs/aws-vault/blob/master/USAGE.md#aws-single-sign-on-aws-sso working so any that existing inbound hyperlinks don't break.