### PR TITLE
Add 1password prompt driver

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -33,6 +33,7 @@
     - [Prerequisites](#prerequisites)
     - [Setup](#setup)
     - [Usage](#usage-1)
+  - [Using 1password](#using-1password)
   - [Shell completion](#shell-completion)
   - [Desktop apps](#desktop-apps)
   - [Docker](#docker)
@@ -528,6 +529,33 @@ Further config:
  - `AWS_VAULT_PROMPT=ykman`: to avoid specifying `--prompt` each time
  - `YKMAN_OATH_CREDENTIAL_NAME`: to use an alternative ykman credential
  - `AWS_VAULT_YKMAN_VERSION`: to set the major version of the ykman cli being used. Defaults to "4"
+
+## Using 1password
+
+1password an be used with AWS Vault to generate MFA codes.
+
+### Prerequisites
+ 1. [1password CLI v2](https://1password.com/downloads/command-line/)
+
+You can check the version of the CLI tool you have by running `op --version`.
+
+### Setup
+ 1. Log into the AWS web console with your IAM user credentials, and navigate to  _My Security Credentials_
+ 2. Under _Multi-factor authentication (MFA)_, click `Manage MFA device` and add a Virtual MFA device
+ 3. Save the MFA token to 1password using the QR code
+ 4. Add the tag "aws-vault" to the 1password item
+ 5. Add the MFA ARN to the URLs for the 1password item
+
+### Usage
+Using the `1password` prompt driver, aws-vault will execute `op` to find a matching entry and then generate a OTP.
+
+```shell
+aws-vault exec --prompt 1password ${AWS_VAULT_PROFILE_USING_MFA} -- aws sts get-caller-identity
+```
+
+Futher config:
+ - `AWS_VAULT_PROMPT=1password`: to avoid specifying `--prompt` each time
+ - `AWS_VAULT_OP_TAG_NAME`: to find items using a tag different from the default `aws-vault`
 
 ## Shell completion
 

--- a/prompt/onepassword.go
+++ b/prompt/onepassword.go
@@ -1,0 +1,86 @@
+package prompt
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"strings"
+
+	exec "golang.org/x/sys/execabs"
+)
+
+// onePasswordUrl represents the type of the `urls`
+type onePasswordUrl struct {
+	Href string `json:"href"`
+}
+
+type onePasswordItem struct {
+	Id   string            `json:"id"`
+	Urls *[]onePasswordUrl `json:"urls"`
+}
+
+// OnePasswordMfaProvider runs `op` to generate a OATH-TOTP token from a
+// 1password item
+func OnePasswordMfaProvider(mfaSerial string) (string, error) {
+	acc, err := getAccount(mfaSerial)
+	if err != nil {
+		return "", err
+	}
+	if acc == nil {
+		return "", fmt.Errorf("no item found in 1Password for %s", mfaSerial)
+	}
+
+	log.Println("Retrieving OTP")
+	cmd := exec.Command("op", "item", "get", "--otp", acc.Id)
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("op: %w", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+func getAccount(mfaSerial string) (*onePasswordItem, error) {
+	onePassTagName := os.Getenv("AWS_VAULT_OP_TAG_NAME")
+	if onePassTagName == "" {
+		onePassTagName = "aws-vault"
+	}
+
+	log.Println("Listing available items in 1password")
+	cmd := exec.Command("op", "item", "list", "--format", "json", "--tags", onePassTagName)
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("op: %w", err)
+	}
+
+	list := []onePasswordItem{}
+
+	err = json.Unmarshal(out, &list)
+	if err != nil {
+		return nil, fmt.Errorf("op: %w", err)
+	}
+
+	for _, item := range list {
+		if item.Urls == nil {
+			continue
+		}
+
+		for _, url := range *item.Urls {
+			if url.Href == mfaSerial {
+				return &item, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func init() {
+	Methods["1password"] = OnePasswordMfaProvider
+}


### PR DESCRIPTION
Add support for `--prompt=1password` via the 1password CLI v2.

This is partly inspired by #968 but is cross-platform. I've also added docs. I don't have access to windows so can't test it there.