### PR TITLE
Add support for consuming credential_process in 'aws-vault exec'.

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -262,7 +262,7 @@ Deleted credentials.
 
 ### Rotating credentials
 
-Regularly rotating your access keys is a critical part of credential management. You can do this with the `aws-vault rotate <profile>` command as often as you like. [Restrictions on IAM access](#temporary-credentials-limitations-with-sts-iam) using `GetSessionToken` means you will need to have [configured MFA](#mfa) or use the `--no-session` flag. 
+Regularly rotating your access keys is a critical part of credential management. You can do this with the `aws-vault rotate <profile>` command as often as you like. [Restrictions on IAM access](#temporary-credentials-limitations-with-sts-iam) using `GetSessionToken` means you will need to have [configured MFA](#mfa) or use the `--no-session` flag.
 
 The minimal IAM policy required to rotate your own credentials is:
 
@@ -381,7 +381,7 @@ $ aws-vault exec <iam_user_profile> -- aws iam get-user
 An error occurred (InvalidClientTokenId) when calling the GetUser operation: The security token included in the request is invalid
 ```
 
-For restricted IAM operation you can add MFA to the IAM User and update your ~/.aws/config file with [MFA configuration](#mfa). Alternately you may avoid the temporary session entirely by using `--no-session`. 
+For restricted IAM operation you can add MFA to the IAM User and update your ~/.aws/config file with [MFA configuration](#mfa). Alternately you may avoid the temporary session entirely by using `--no-session`.
 
 
 ## MFA
@@ -476,6 +476,8 @@ web_identity_token_process = oidccli raw
 
 The [AWS CLI config](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes) supports sourcing credentials directly from an external process, using `credential_process`.
 
+### Invoking `aws-vault` via `credential_process`
+
 ```ini
 [profile home]
 credential_process = aws-vault exec home --json
@@ -501,8 +503,11 @@ role_arn = arn:aws:iam::33333333333:role/role2
 source_profile = jon
 ```
 
-If you're using `credential_process` in your config you should not use `aws-vault exec` on the command line to execute commands directly - the AWS SDK executes `aws-vault` for you.
+If you're using `credential_process` in your config to invoke `aws-vault exec` you should not use `aws-vault exec` on the command line to execute commands directly - the AWS SDK executes `aws-vault` for you.
 
+### Invoking `credential_process` via `aws-vault`
+
+When executing a profile via `aws-vault exec` that has `credential_process` set, `aws-vault` will execute the specified command to obtain a credential.  This will allow `aws-vault` to cache credentials obtained via `credential_process`.
 
 ## Using a Yubikey
 

--- a/vault/assumerolewithwebidentityprovider.go
+++ b/vault/assumerolewithwebidentityprovider.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
-	"runtime"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -85,22 +83,5 @@ func (p *AssumeRoleWithWebIdentityProvider) webIdentityToken() (string, error) {
 	}
 
 	// Exec WebIdentityTokenProcess to retrieve OpenID Connect token
-	var cmdArgs []string
-	if runtime.GOOS == "windows" {
-		cmdArgs = []string{"cmd.exe", "/C", p.WebIdentityTokenProcess}
-	} else {
-		cmdArgs = []string{"/bin/sh", "-c", p.WebIdentityTokenProcess}
-	}
-
-	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
-	cmd.Env = os.Environ()
-	cmd.Stdin = os.Stdin
-	cmd.Stderr = os.Stderr
-
-	b, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to run command %q: %v", p.WebIdentityTokenProcess, err)
-	}
-
-	return string(b), err
+	return executeProcess(p.WebIdentityTokenProcess)
 }

--- a/vault/config.go
+++ b/vault/config.go
@@ -148,6 +148,7 @@ type ProfileSection struct {
 	SessionTags             string `ini:"session_tags,omitempty"`
 	TransitiveSessionTags   string `ini:"transitive_session_tags,omitempty"`
 	SourceIdentity          string `ini:"source_identity,omitempty"`
+	CredentialProcess       string `ini:"credential_process,omitempty"`
 }
 
 // SSOSessionSection is a [sso-session] section of the config file
@@ -374,6 +375,9 @@ func (cl *ConfigLoader) populateFromConfigFile(config *Config, profileName strin
 	}
 	if config.SourceIdentity == "" {
 		config.SourceIdentity = psection.SourceIdentity
+	}
+	if config.CredentialProcess == "" {
+		config.CredentialProcess = psection.CredentialProcess
 	}
 	if sessionTags := psection.SessionTags; sessionTags != "" && config.SessionTags == nil {
 		err := config.SetSessionTags(sessionTags)
@@ -605,6 +609,9 @@ type Config struct {
 
 	// SourceIdentity specifies assumed role Source Identity
 	SourceIdentity string
+
+	// CredentialProcess specifies external command to run to get an AWS credential
+	CredentialProcess string
 }
 
 // SetSessionTags parses a comma separated key=vaue string and sets Config.SessionTags map
@@ -656,6 +663,10 @@ func (c *Config) HasSSOStartURL() bool {
 
 func (c *Config) HasWebIdentity() bool {
 	return c.WebIdentityTokenFile != "" || c.WebIdentityTokenProcess != ""
+}
+
+func (c *Config) HasCredentialProcess() bool {
+	return c.CredentialProcess != ""
 }
 
 // CanUseGetSessionToken determines if GetSessionToken should be used, and if not returns a reason

--- a/vault/credentialprocessprovider.go
+++ b/vault/credentialprocessprovider.go
@@ -1,0 +1,79 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+)
+
+var credentialProcessRequiredFields = []string{"AccessKeyId", "Expiration", "SecretAccessKey", "SessionToken"}
+
+// CredentialProcessProvider implements interface aws.CredentialsProvider to retrieve credentials from an external executable
+// as described in https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
+type CredentialProcessProvider struct {
+	CredentialProcess string
+}
+
+func (p *CredentialProcessProvider) validateJSONCredential(cred *ststypes.Credentials) error {
+	var missing []string
+
+	h := reflect.ValueOf(cred).Elem()
+	for _, requiredField := range credentialProcessRequiredFields {
+		if h.FieldByName(requiredField).IsNil() {
+			missing = append(missing, requiredField)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("JSON credential from command %q missing the following fields: %v", p.CredentialProcess, missing)
+	}
+
+	return nil
+}
+
+// Retrieve obtains a new set of temporary credentials using an external process, required to satisfy interface aws.CredentialsProvider
+func (p *CredentialProcessProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+	return p.retrieveWith(ctx, executeProcess)
+}
+
+func (p *CredentialProcessProvider) retrieveWith(ctx context.Context, fn func(string) (string, error)) (aws.Credentials, error) {
+	creds, err := p.callCredentialProcessWith(ctx, fn)
+	if err != nil {
+		return aws.Credentials{}, err
+	}
+
+	return aws.Credentials{
+		AccessKeyID:     aws.ToString(creds.AccessKeyId),
+		SecretAccessKey: aws.ToString(creds.SecretAccessKey),
+		SessionToken:    aws.ToString(creds.SessionToken),
+		CanExpire:       true,
+		Expires:         aws.ToTime(creds.Expiration),
+	}, nil
+}
+
+func (p *CredentialProcessProvider) callCredentialProcess(ctx context.Context) (*ststypes.Credentials, error) {
+	return p.callCredentialProcessWith(ctx, executeProcess)
+}
+
+func (p *CredentialProcessProvider) callCredentialProcessWith(_ context.Context, fn func(string) (string, error)) (*ststypes.Credentials, error) {
+	// Exec CredentialProcess to retrieve AWS creds in JSON format as described in
+	// https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
+	output, err := fn(p.CredentialProcess)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the JSON into a ststypes.Credentials object
+	var value ststypes.Credentials
+	if err := json.Unmarshal([]byte(output), &value); err != nil {
+		return &ststypes.Credentials{}, fmt.Errorf("invalid JSON format from command %q: %v", p.CredentialProcess, err)
+	}
+
+	// Validate that all required fields were present in JSON before returning
+	return &value, p.validateJSONCredential(&value)
+}

--- a/vault/credentialprocessprovider_test.go
+++ b/vault/credentialprocessprovider_test.go
@@ -1,0 +1,109 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+)
+
+func executeFail(process string) (string, error) {
+	return "", errors.New("executing process failed")
+}
+
+func executeGetBadJSON(process string) (string, error) {
+	return "Junk", nil
+}
+
+func executeGetCredential(accessKeyID *string, expiration *time.Time, secretAccesKey *string, sessionToken *string) (string, error) {
+	v, err := json.Marshal(ststypes.Credentials{
+		AccessKeyId:     accessKeyID,
+		Expiration:      expiration,
+		SecretAccessKey: secretAccesKey,
+		SessionToken:    sessionToken,
+	})
+	return string(v), err
+}
+
+func TestCredentialProcessProvider_Retrieve(t *testing.T) {
+	accessKeyID := "abcd"
+	expiration := time.Time{}
+	secretAccessKey := "0123"
+	sessionToken := "4567"
+
+	want := aws.Credentials{
+		AccessKeyID:     accessKeyID,
+		Expires:         expiration,
+		CanExpire:       true,
+		SecretAccessKey: secretAccessKey,
+		SessionToken:    sessionToken,
+	}
+
+	tests := []struct {
+		name                string
+		execFunc            func(string) (string, error)
+		wantErr             bool
+		expectMissingFields bool
+	}{
+		{
+			name:                "process execution fails",
+			execFunc:            executeFail,
+			wantErr:             true,
+			expectMissingFields: false,
+		},
+		{
+			name:                "bad json",
+			execFunc:            executeGetBadJSON,
+			wantErr:             true,
+			expectMissingFields: false,
+		},
+		{
+			name: "successful execution, good cred",
+			execFunc: func(string) (string, error) {
+				return executeGetCredential(&accessKeyID, &expiration, &secretAccessKey, &sessionToken)
+			},
+			wantErr:             false,
+			expectMissingFields: false,
+		},
+		{
+			name: "fields missing",
+			execFunc: func(string) (string, error) {
+				return executeGetCredential(nil, nil, nil, nil)
+			},
+			wantErr:             true,
+			expectMissingFields: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			provider := CredentialProcessProvider{
+				CredentialProcess: "",
+			}
+			got, err := provider.retrieveWith(ctx, tt.execFunc)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CredentialProcessProvider.Retrieve() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && !reflect.DeepEqual(got, want) {
+				t.Errorf("CredentialProcessProvider.Retrieve() = %v, want %v", got, want)
+			}
+
+			if tt.wantErr && tt.expectMissingFields {
+				for _, expectedMissingField := range credentialProcessRequiredFields {
+					if !strings.Contains(err.Error(), expectedMissingField) {
+						t.Errorf("expected field '%v' not present in error: %v'", expectedMissingField, err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/vault/executeprocess.go
+++ b/vault/executeprocess.go
@@ -1,0 +1,28 @@
+package vault
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+func executeProcess(process string) (string, error) {
+	var cmdArgs []string
+	if runtime.GOOS == "windows" {
+		cmdArgs = []string{"cmd.exe", "/C", process}
+	} else {
+		cmdArgs = []string{"/bin/sh", "-c", process}
+	}
+
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd.Env = os.Environ()
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("running command %q: %v", process, err)
+	}
+	return string(output), nil
+}


### PR DESCRIPTION
The AWS CLI supports calling an external credential provider via the `credential_process` configuration option.  However, as stated in the [AWS CLI Docs](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes):

> NOTE: Unlike with assume role credentials, the AWS CLI will NOT cache process credentials. If caching is needed, it must be implemented in the external process.

I have a use case where I must call an external process to obtain a credential.  I wish to cache this credential to avoid repeated API calls and 2FA prompts.  Rather than rolling my own caching, I would prefer to make use of `aws-vault` for this purpose.

This PR implements the equivalent `credential_process` logic in `aws-vault exec`.  I am aware of the existing use case of using `credential_process` from the AWS CLI to invoke `aws-vault`; I have attempted to differentiate these use cases in my edits to [USAGE.md](https://github.com/jmczerk/aws-vault/blob/feature/credential_process/USAGE.md#using-credential_process).