### PR TITLE
Remove golang.org/x/sys/execabs

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	osexec "os/exec"
 	"os/signal"
 	"runtime"
 	"strings"
@@ -19,7 +20,6 @@ import (
 	"github.com/99designs/keyring"
 	"github.com/alecthomas/kingpin"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	osexec "golang.org/x/sys/execabs"
 )
 
 type ExecCommandInput struct {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.7
 	github.com/google/go-cmp v0.5.8
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
-	golang.org/x/sys v0.3.0
 	golang.org/x/term v0.3.0
 	gopkg.in/ini.v1 v1.67.0
 )
@@ -34,4 +33,5 @@ require (
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
+	golang.org/x/sys v0.3.0 // indirect
 )

--- a/prompt/kdialog.go
+++ b/prompt/kdialog.go
@@ -1,9 +1,8 @@
 package prompt
 
 import (
+	"os/exec"
 	"strings"
-
-	exec "golang.org/x/sys/execabs"
 )
 
 func KDialogMfaPrompt(mfaSerial string) (string, error) {

--- a/prompt/passotp.go
+++ b/prompt/passotp.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
-
-	exec "golang.org/x/sys/execabs"
 )
 
 // PassOTPProvider uses the pass otp extension to generate a OATH-TOTP token

--- a/prompt/ykman.go
+++ b/prompt/ykman.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
-
-	exec "golang.org/x/sys/execabs"
 )
 
 // YkmanProvider runs ykman to generate a OATH-TOTP token from the Yubikey device

--- a/prompt/zenity.go
+++ b/prompt/zenity.go
@@ -1,9 +1,8 @@
 package prompt
 
 import (
+	"os/exec"
 	"strings"
-
-	exec "golang.org/x/sys/execabs"
 )
 
 func ZenityMfaPrompt(mfaSerial string) (string, error) {

--- a/server/ec2alias_windows.go
+++ b/server/ec2alias_windows.go
@@ -5,9 +5,8 @@ package server
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
-
-	exec "golang.org/x/sys/execabs"
 )
 
 var alreadyRegisteredLocalised = []string{

--- a/server/ec2proxy_default.go
+++ b/server/ec2proxy_default.go
@@ -7,9 +7,8 @@ import (
 	"errors"
 	"log"
 	"os"
+	"os/exec"
 	"time"
-
-	exec "golang.org/x/sys/execabs"
 )
 
 // StartEc2EndpointProxyServerProcess starts a `aws-vault proxy` process

--- a/vault/assumerolewithwebidentityprovider.go
+++ b/vault/assumerolewithwebidentityprovider.go
@@ -6,10 +6,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"runtime"
 	"time"
-
-	exec "golang.org/x/sys/execabs"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"


### PR DESCRIPTION
As of Go 1.19, the changes in execabs have been incorporated into os/exec