### PR TITLE
Update Documentation to reflect new Multi-MFA per IAM User functionality on AWS.

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -522,7 +522,7 @@ You can verify these prerequisites by running `ykman info` and checking `OATH` i
     ykman oath accounts add -t arn:aws:iam::${ACCOUNT_ID}:mfa/${MFA_DEVICE_NAME}
     ```
     replacing `${ACCOUNT_ID}` with your AWS account ID and `${MFA_DEVICE_NAME}` with the name you gave to the MFA device. It will prompt you for a base32 text and you can input the key from step 3. Notice the above command uses `-t` which requires you to touch your YubiKey to generate authentication codes.
- 5. Now you have to enter two consecutive MFA codes into the AWS website to assign your key to your AWS login. Just run `ykman oath accounts code arn:aws:iam::${ACCOUNT_ID}:mfa/${MFA_NAME}` to get an authentication code. The codes are re-generated every 30 seconds, so you have to run this command twice with about 30 seconds in between to get two distinct codes. Enter the two codes in the AWS form and click `Assign MFA`.
+ 5. Now you have to enter two consecutive MFA codes into the AWS website to assign your key to your AWS login. Just run `ykman oath accounts code arn:aws:iam::${ACCOUNT_ID}:mfa/${MFA_DEVICE_NAME}` to get an authentication code. The codes are re-generated every 30 seconds, so you have to run this command twice with about 30 seconds in between to get two distinct codes. Enter the two codes in the AWS form and click `Assign MFA`.
 
 A script can be found at [contrib/scripts/aws-iam-create-yubikey-mfa.sh](contrib/scripts/aws-iam-create-yubikey-mfa.sh) to automate the process. Note that this script requires your `$MFA_DEVICE_NAME` to be your IAM username as the `aws iam enable-mfa-device` command in the CLI does not yet offer specifying the name. When only one MFA device was allowed per IAM user, the `$MFA_DEVICE_NAME` would always be your IAM username.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -386,9 +386,9 @@ For restricted IAM operation you can add MFA to the IAM User and update your ~/.
 
 ## MFA
 
-To enable MFA for a profile, specify the `mfa_serial` in `~/.aws/config`. You can retrieve the MFA's serial (ARN) in the web console, or you can usually derive it pretty easily using the format `arn:aws:iam::[account-id]:mfa/[your-iam-username]`. If you have an account with an MFA associated, but you don't provide the ARN, you are unable to call IAM services, even if you have the correct permissions to do so.
+To enable MFA for a profile, specify the `mfa_serial` in `~/.aws/config`. You can retrieve the MFA's serial (ARN) in the web console, under IAM > Users > `<User>` > Security Configuration. If you have an account with an MFA associated, but you don't provide the ARN, you are unable to call IAM services, even if you have the correct permissions to do so.
 
-AWS Vault will attempt to re-use a `GetSessionToken` between profiles that share a common `mfa_serial`. In the following example, aws-vault will cache and re-use sessions between role1 and role2. This means you don't have to continually enter MFA codes if the user is the same.
+AWS Vault will attempt to re-use a `GetSessionToken` between profiles that share a common `mfa_serial`. In the following example, aws-vault will cache and re-use sessions between role1 and role2. This means you don't have to continually enter MFA codes if the MFA method is the same.
 
 ```ini
 [profile tom]
@@ -405,7 +405,7 @@ role_arn = arn:aws:iam::33333333333:role/role2
 mfa_serial = arn:aws:iam::111111111111:mfa/tom
 ```
 
-Be sure to specify the `mfa_serial` for the source profile (in the above example `tom`) so that aws-vault can match the common `mfa_serial`.
+For aws-vault <=v4, be sure to specify the `mfa_serial` for the source profile (in the above example `tom`) so that aws-vault can match the common `mfa_serial`.
 
 You can also set the `mfa_serial` with the environment variable `AWS_MFA_SERIAL`.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -405,7 +405,7 @@ role_arn = arn:aws:iam::33333333333:role/role2
 mfa_serial = arn:aws:iam::111111111111:mfa/tom
 ```
 
-For aws-vault <=v4, be sure to specify the `mfa_serial` for the source profile (in the above example `tom`) so that aws-vault can match the common `mfa_serial`.
+Be sure to specify the `mfa_serial` for the source profile (in the above example `tom`) so that aws-vault can match the common `mfa_serial`.
 
 You can also set the `mfa_serial` with the environment variable `AWS_MFA_SERIAL`.
 

--- a/contrib/scripts/aws-iam-create-yubikey-mfa.sh
+++ b/contrib/scripts/aws-iam-create-yubikey-mfa.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Adds a Yubikey TOTP device to IAM
+# Adds a Yubikey TOTP device to IAM using your IAM User as the $MFA_DEVICE_NAME
+# Currently, aws iam enable-mfa-device doesn't support specifying your MFA Device Name.
 
 set -eu
 

--- a/contrib/scripts/aws-iam-resync-yubikey-mfa.sh
+++ b/contrib/scripts/aws-iam-resync-yubikey-mfa.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Resync a Yubikey TOTP device to IAM
+# Resync a Yubikey TOTP device to IAM using your IAM User as the $MFA_DEVICE_NAME
+# Currently, aws iam resync-mfa-device doesn't support specifying your MFA Device Name.
 
 set -eu
 


### PR DESCRIPTION
See https://github.com/99designs/aws-vault/issues/1100

I've gotten AWS Vault to work using a Yubikey and a virtual TOTP device, using AWS' new feature for multiple MFA devices. I've updated the documentation to be consistent with this new capability, and have explained how to get both a Yubikey and a Virtual TOTP device working with the same IAM User.