### PR TITLE
Revert "With login, `SSOUseStdout` should follow `--stdout`"

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -63,7 +63,6 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 		input.Config.NonChainedGetSessionTokenDuration = input.SessionDuration
 		input.Config.AssumeRoleDuration = input.SessionDuration
 		input.Config.GetFederationTokenDuration = input.SessionDuration
-		input.Config.SSOUseStdout = input.UseStdout
 		keyring, err := a.Keyring()
 		if err != nil {
 			return err


### PR DESCRIPTION
Reverts 99designs/aws-vault#892 due to [regression](https://github.com/99designs/aws-vault/issues/1102#issuecomment-1378061497)