### PR TITLE
Add aws_vault_credential_process config option

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -26,9 +26,10 @@
     - [Temporary credentials limitations with STS, IAM](#temporary-credentials-limitations-with-sts-iam)
   - [MFA](#mfa)
     - [Gotchas with MFA config](#gotchas-with-mfa-config)
-  - [Single sign on with AWS IAM Identity Center (formerly AWS SSO)](#aws-single-sign-on-aws-sso)
+  - [AWS Single Sign-On (AWS SSO)](#aws-single-sign-on-aws-sso)
   - [Assuming roles with web identities](#assuming-roles-with-web-identities)
   - [Using `credential_process`](#using-credential_process)
+  - [Using `aws_vault_credential_process`](#using-aws_vault_credential_process)
   - [Using a Yubikey](#using-a-yubikey)
     - [Prerequisites](#prerequisites)
     - [Setup](#setup)
@@ -502,6 +503,22 @@ source_profile = jon
 
 If you're using `credential_process` in your config you should not use `aws-vault exec` on the command line to execute commands directly - the AWS SDK executes `aws-vault` for you.
 
+## Using `aws_vault_credential_process`
+
+Using `aws_vault_credential_process` in your config allows you to specify a command that will be executed to generate credentials. This is useful for supporting ad-hoc scenarios such as using as custom implementation of IAM Identity Provider logic that requires calling identity vendor specific APIs. This is not to be confused with `credential_process` which is a supported by AWS CLI. This allows for using the security advantages of aws-vault while using a custom credentials source.
+
+MFA is not supported in the profile section as it is expected to be handled externally. A profile using `aws_vault_credential_process` can be used as source profile for another profile specifying a role. Usage example:
+
+```ini
+[profile jon]
+aws_vault_credential_process=auth-client sts-creds --json
+
+[profile jon-admin]
+role_arn = arn:aws:iam::33333333333:role/role2
+source_profile=jon
+```
+
+In this example, when using jon-admin profile aws-vault gets credentials from jon (running the process if they are not cached) and then assumes the role for jon-admin using credentials for jon.
 
 ## Using a Yubikey
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -26,7 +26,7 @@
     - [Temporary credentials limitations with STS, IAM](#temporary-credentials-limitations-with-sts-iam)
   - [MFA](#mfa)
     - [Gotchas with MFA config](#gotchas-with-mfa-config)
-  - [AWS Single Sign-On (AWS SSO)](#aws-single-sign-on-aws-sso)
+  - [Single sign on with AWS IAM Identity Center (formerly AWS SSO)](#single-sign-on-with-aws-iam-identity-center-formerly-aws-sso)
   - [Assuming roles with web identities](#assuming-roles-with-web-identities)
   - [Using `credential_process`](#using-credential_process)
   - [Using `aws_vault_credential_process`](#using-aws_vault_credential_process)
@@ -430,9 +430,7 @@ role_arn = arn:aws:iam::33333333333:role/role2
 include_profile = jon
 ```
 
-## AWS Single Sign-On (AWS SSO)
-
-_AWS IAM Identity Center provides single sign on, and was previously known as AWS SSO._
+## Single sign on with AWS IAM Identity Center (formerly AWS SSO)
 
 If your organization uses [AWS IAM Identity Center](https://aws.amazon.com/iam/identity-center/) for single sign on, AWS Vault provides a method for using the credential information defined by [`aws sso`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html) from v2 of the AWS CLI. The configuration options are as follows:
 * `sso_start_url` The URL that points to the organization's AWS IAM Identity Center user portal.
@@ -505,7 +503,7 @@ If you're using `credential_process` in your config you should not use `aws-vaul
 
 ## Using `aws_vault_credential_process`
 
-Using `aws_vault_credential_process` in your config allows you to specify a command that will be executed to generate credentials. This is useful for supporting ad-hoc scenarios such as using as custom implementation of IAM Identity Provider logic that requires calling identity vendor specific APIs. This is not to be confused with `credential_process` which is a supported by AWS CLI. This allows for using the security advantages of aws-vault while using a custom credentials source.
+Using `aws_vault_credential_process` in your config allows you to specify a command that will be executed to generate credentials. This is useful for supporting ad-hoc scenarios such as using as custom implementation of IAM Identity Provider logic that requires calling identity vendor specific APIs. This allows for using the security advantages of aws-vault while using a custom credentials source. This is not to be confused with `credential_process` which is supported by AWS CLI.
 
 MFA is not supported in the profile section as it is expected to be handled externally. A profile using `aws_vault_credential_process` can be used as source profile for another profile specifying a role. Usage example:
 

--- a/cli/login.go
+++ b/cli/login.go
@@ -102,6 +102,8 @@ func LoginCommand(input LoginCommandInput, f *vault.ConfigFile, keyring keyring.
 		if config.HasRole() || config.HasSSOStartURL() {
 			// If AssumeRole or sso.GetRoleCredentials isn't used, GetFederationToken has to be used for IAM credentials
 			credsProvider, err = vault.NewTempCredentialsProvider(config, ckr)
+		} else if config.HasAWSVaultCredentialProcess() {
+			credsProvider, err = vault.NewAssumeRoleWithCredentialProcessProvider(keyring, config)
 		} else {
 			credsProvider, err = vault.NewFederationTokenCredentialsProvider(context.TODO(), input.ProfileName, ckr, config)
 		}

--- a/vault/assumerolewithcredentialprocessprovider.go
+++ b/vault/assumerolewithcredentialprocessprovider.go
@@ -1,0 +1,80 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+)
+
+// CredentialFromProcessProvider retrieves credentials by running aws_vault_credential_process
+type CredentialFromProcessProvider struct {
+	StsClient                 *sts.Client
+	RoleARN                   string
+	AWSVaultCredentialProcess string
+	Duration                  time.Duration
+}
+
+// Retrieve generates a new set of credentials using the credential provider
+func (p *CredentialFromProcessProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+	creds, err := p.assumeRole(ctx)
+	if err != nil {
+		return aws.Credentials{}, err
+	}
+
+	return aws.Credentials{
+		AccessKeyID:     aws.ToString(creds.AccessKeyId),
+		SecretAccessKey: aws.ToString(creds.SecretAccessKey),
+		SessionToken:    aws.ToString(creds.SessionToken),
+		CanExpire:       true,
+		Expires:         aws.ToTime(creds.Expiration),
+	}, nil
+}
+
+func (p *CredentialFromProcessProvider) assumeRole(ctx context.Context) (*ststypes.Credentials, error) {
+	var err error
+
+	output, err := p.runCredentialProcess()
+	if err != nil {
+		return nil, err
+	}
+	var creds ststypes.Credentials
+	err = json.Unmarshal(output, &creds)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to prase credential process output: %v", err)
+	}
+
+	return &creds, nil
+}
+
+// Execute AWSVaultCredentialProcess to retrieve credentials
+func (p *CredentialFromProcessProvider) runCredentialProcess() ([]byte, error) {
+	var cmdArgs []string
+	if runtime.GOOS == "windows" {
+		cmdArgs = []string{"cmd.exe", "/C", p.AWSVaultCredentialProcess}
+	} else {
+		cmdArgs = []string{"/bin/sh", "-c", p.AWSVaultCredentialProcess}
+	}
+
+	log.Printf("Executing credential process %q", p.AWSVaultCredentialProcess)
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd.Env = os.Environ()
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	b, err := cmd.Output()
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to run command %q: %v", p.AWSVaultCredentialProcess, err)
+	}
+
+	return b, err
+}

--- a/vault/config.go
+++ b/vault/config.go
@@ -127,26 +127,27 @@ func (c *ConfigFile) parseFile() error {
 
 // ProfileSection is a profile section of the config file
 type ProfileSection struct {
-	Name                    string `ini:"-"`
-	MfaSerial               string `ini:"mfa_serial,omitempty"`
-	RoleARN                 string `ini:"role_arn,omitempty"`
-	ExternalID              string `ini:"external_id,omitempty"`
-	Region                  string `ini:"region,omitempty"`
-	RoleSessionName         string `ini:"role_session_name,omitempty"`
-	DurationSeconds         uint   `ini:"duration_seconds,omitempty"`
-	SourceProfile           string `ini:"source_profile,omitempty"`
-	ParentProfile           string `ini:"parent_profile,omitempty"` // deprecated
-	IncludeProfile          string `ini:"include_profile,omitempty"`
-	SSOStartURL             string `ini:"sso_start_url,omitempty"`
-	SSORegion               string `ini:"sso_region,omitempty"`
-	SSOAccountID            string `ini:"sso_account_id,omitempty"`
-	SSORoleName             string `ini:"sso_role_name,omitempty"`
-	WebIdentityTokenFile    string `ini:"web_identity_token_file,omitempty"`
-	WebIdentityTokenProcess string `ini:"web_identity_token_process,omitempty"`
-	STSRegionalEndpoints    string `ini:"sts_regional_endpoints,omitempty"`
-	SessionTags             string `ini:"session_tags,omitempty"`
-	TransitiveSessionTags   string `ini:"transitive_session_tags,omitempty"`
-	SourceIdentity          string `ini:"source_identity,omitempty"`
+	Name                      string `ini:"-"`
+	MfaSerial                 string `ini:"mfa_serial,omitempty"`
+	RoleARN                   string `ini:"role_arn,omitempty"`
+	ExternalID                string `ini:"external_id,omitempty"`
+	Region                    string `ini:"region,omitempty"`
+	RoleSessionName           string `ini:"role_session_name,omitempty"`
+	DurationSeconds           uint   `ini:"duration_seconds,omitempty"`
+	SourceProfile             string `ini:"source_profile,omitempty"`
+	ParentProfile             string `ini:"parent_profile,omitempty"` // deprecated
+	IncludeProfile            string `ini:"include_profile,omitempty"`
+	SSOStartURL               string `ini:"sso_start_url,omitempty"`
+	SSORegion                 string `ini:"sso_region,omitempty"`
+	SSOAccountID              string `ini:"sso_account_id,omitempty"`
+	SSORoleName               string `ini:"sso_role_name,omitempty"`
+	WebIdentityTokenFile      string `ini:"web_identity_token_file,omitempty"`
+	WebIdentityTokenProcess   string `ini:"web_identity_token_process,omitempty"`
+	AWSVaultCredentialProcess string `ini:"aws_vault_credential_process,omitempty"`
+	STSRegionalEndpoints      string `ini:"sts_regional_endpoints,omitempty"`
+	SessionTags               string `ini:"session_tags,omitempty"`
+	TransitiveSessionTags     string `ini:"transitive_session_tags,omitempty"`
+	SourceIdentity            string `ini:"source_identity,omitempty"`
 }
 
 func (s ProfileSection) IsEmpty() bool {
@@ -321,6 +322,9 @@ func (cl *ConfigLoader) populateFromConfigFile(config *Config, profileName strin
 	}
 	if config.WebIdentityTokenFile == "" {
 		config.WebIdentityTokenFile = psection.WebIdentityTokenFile
+	}
+	if config.AWSVaultCredentialProcess == "" {
+		config.AWSVaultCredentialProcess = psection.AWSVaultCredentialProcess
 	}
 	if config.WebIdentityTokenProcess == "" {
 		config.WebIdentityTokenProcess = psection.WebIdentityTokenProcess
@@ -520,6 +524,9 @@ type Config struct {
 	WebIdentityTokenFile    string
 	WebIdentityTokenProcess string
 
+	// AWSVaultCredentialProcess config
+	AWSVaultCredentialProcess string
+
 	// GetSessionTokenDuration specifies the wanted duration for credentials generated with AssumeRole
 	AssumeRoleDuration time.Duration
 
@@ -602,6 +609,10 @@ func (c *Config) HasSSOStartURL() bool {
 
 func (c *Config) HasWebIdentityTokenFile() bool {
 	return c.WebIdentityTokenFile != ""
+}
+
+func (c *Config) HasAWSVaultCredentialProcess() bool {
+	return c.AWSVaultCredentialProcess != ""
 }
 
 func (c *Config) HasWebIdentityTokenProcess() bool {


### PR DESCRIPTION
Adding `aws_vault_credential_process` as a configuration option in aws config. It allows specifying a command that will be executed to generate credentials. This is useful for supporting ad-hoc scenarios such as using as custom implementation of IAM Identity Provider logic that requires calling identity vendor specific APIs. This allows for using the security advantages of aws-vault while using a custom credentials source such as IDP CLI.