### PR TITLE
Simplify creation of temporary creds

### DIFF
--- a/vault/config.go
+++ b/vault/config.go
@@ -600,25 +600,17 @@ func (c *Config) HasSSOStartURL() bool {
 	return c.SSOStartURL != ""
 }
 
-func (c *Config) HasWebIdentityTokenFile() bool {
-	return c.WebIdentityTokenFile != ""
-}
-
-func (c *Config) HasWebIdentityTokenProcess() bool {
-	return c.WebIdentityTokenProcess != ""
+func (c *Config) HasWebIdentity() bool {
+	return c.WebIdentityTokenFile != "" || c.WebIdentityTokenProcess != ""
 }
 
 // CanUseGetSessionToken determines if GetSessionToken should be used, and if not returns a reason
 func (c *Config) CanUseGetSessionToken() (bool, string) {
 	if !UseSession {
-		return false, "disabled"
+		return false, "sessions are disabled"
 	}
 
-	if c.HasRole() {
-		if c.AssumeRoleDuration > roleChainingMaximumDuration {
-			return false, fmt.Sprintf("duration %s is greater than the AWS maximum %s for chaining MFA", c.AssumeRoleDuration, roleChainingMaximumDuration)
-		}
-	} else if c.IsChained() {
+	if c.IsChained() {
 		if !c.ChainedFromProfile.HasMfaSerial() {
 			return false, fmt.Sprintf("profile '%s' has no MFA serial defined", c.ChainedFromProfile.ProfileName)
 		}


### PR DESCRIPTION
Refactor `tempCredsCreator`, which was a particularly tricky part of the code to understand. This should make the logic much simpler to understand

on master:
```
$ gocyclo vault/vault.go
19 vault (*tempCredsCreator).provider vault/vault.go:204:1
```
on this branch:
```
$ gocyclo vault/vault.go
8 vault (*tempCredsCreator).GetProviderForProfile vault/vault.go:223:1
4 vault (*tempCredsCreator).getSourceCreds vault/vault.go:204:1
```