### PR TITLE
Add new expiration env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ AWS Vault then exposes the temporary credentials to the sub-process in one of tw
    AWS_SECRET_ACCESS_KEY=%%%
    AWS_SESSION_TOKEN=%%%
    AWS_SECURITY_TOKEN=%%%
+   AWS_CREDENTIAL_EXPIRATION=2020-04-16T11:16:27Z
    AWS_SESSION_EXPIRATION=2020-04-16T11:16:27Z
    ```
 2. **Local [EC2 Instance Metadata server](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)** is started. This approach has the advantage that anything that uses Amazon's SDKs will automatically refresh credentials as needed, so session times can be as short as possible. The downside is that only one can run per host and because it binds to `169.254.169.254:80`, your sudo password is required.

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -287,7 +287,8 @@ func execEnvironment(input ExecCommandInput, config *vault.Config, credsProvider
 		env.Set("AWS_SECURITY_TOKEN", creds.SessionToken)
 	}
 	if creds.CanExpire {
-		log.Println("Setting subprocess env: AWS_SESSION_EXPIRATION")
+		log.Println("Setting subprocess env: AWS_CREDENTIAL_EXPIRATION, AWS_SESSION_EXPIRATION")
+		env.Set("AWS_CREDENTIAL_EXPIRATION", iso8601.Format(creds.Expires))
 		env.Set("AWS_SESSION_EXPIRATION", iso8601.Format(creds.Expires))
 	}
 


### PR DESCRIPTION
Support `AWS_CREDENTIAL_EXPIRATION`, the new env var used by aws cli in https://github.com/aws/aws-cli/pull/7398

Fixes #1103