### PR TITLE
Automatically select the best prompt driver

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -61,6 +61,10 @@ func (input ExecCommandInput) validate() error {
 	return nil
 }
 
+func CanExecUseTerminal(input ExecCommandInput) bool {
+	return !input.StartEcsServer && !input.StartEc2Server
+}
+
 func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 	input := ExecCommandInput{}
 
@@ -114,7 +118,7 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 		StringsVar(&input.Args)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
-		input.Config.MfaPromptMethod = a.PromptDriver
+		input.Config.MfaPromptMethod = a.PromptDriver(CanExecUseTerminal(input))
 		input.Config.NonChainedGetSessionTokenDuration = input.SessionDuration
 		input.Config.AssumeRoleDuration = input.SessionDuration
 		input.Config.SSOUseStdout = input.UseStdout

--- a/cli/export.go
+++ b/cli/export.go
@@ -63,7 +63,7 @@ func ConfigureExportCommand(app *kingpin.Application, a *AwsVault) {
 		StringVar(&input.ProfileName)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
-		input.Config.MfaPromptMethod = a.PromptDriver
+		input.Config.MfaPromptMethod = a.PromptDriver(true)
 		input.Config.NonChainedGetSessionTokenDuration = input.SessionDuration
 		input.Config.AssumeRoleDuration = input.SessionDuration
 		input.Config.SSOUseStdout = input.UseStdout

--- a/cli/login.go
+++ b/cli/login.go
@@ -59,7 +59,7 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 		StringVar(&input.ProfileName)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
-		input.Config.MfaPromptMethod = a.PromptDriver
+		input.Config.MfaPromptMethod = a.PromptDriver(true)
 		input.Config.NonChainedGetSessionTokenDuration = input.SessionDuration
 		input.Config.AssumeRoleDuration = input.SessionDuration
 		input.Config.GetFederationTokenDuration = input.SessionDuration

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -34,7 +34,7 @@ func ConfigureRotateCommand(app *kingpin.Application, a *AwsVault) {
 		StringVar(&input.ProfileName)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
-		input.Config.MfaPromptMethod = a.PromptDriver
+		input.Config.MfaPromptMethod = a.PromptDriver(true)
 		keyring, err := a.Keyring()
 		if err != nil {
 			return err


### PR DESCRIPTION
When `--prompt` is not specified, automatically select the best prompt driver to use. By default `terminal` will be selected, but an alternative will be chosen if `--ecs-server` or `--ec2-server` are being used 

Fixes #888