### PR TITLE
Remove use of old env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,21 +75,17 @@ AWS Vault then exposes the temporary credentials to the sub-process in one of tw
    ```shell
    $ aws-vault exec jonsmith -- env | grep AWS
    AWS_VAULT=jonsmith
-   AWS_DEFAULT_REGION=us-east-1
    AWS_REGION=us-east-1
    AWS_ACCESS_KEY_ID=%%%
    AWS_SECRET_ACCESS_KEY=%%%
    AWS_SESSION_TOKEN=%%%
-   AWS_SECURITY_TOKEN=%%%
    AWS_CREDENTIAL_EXPIRATION=2020-04-16T11:16:27Z
-   AWS_SESSION_EXPIRATION=2020-04-16T11:16:27Z
    ```
 2. **Local metadata server** is started. This approach has the advantage that anything that uses Amazon's SDKs will automatically refresh credentials as needed, so session times can be as short as possible.
    ```shell
    $ aws-vault exec --server jonsmith -- env | grep AWS
    aws-vault: Starting an ECS credential server; your app\'s AWS sdk must support AWS_CONTAINER_CREDENTIALS_FULL_URI.
    AWS_VAULT=jonsmith
-   AWS_DEFAULT_REGION=us-east-1
    AWS_REGION=us-east-1
    AWS_CONTAINER_CREDENTIALS_FULL_URI=%%%
    AWS_CONTAINER_AUTHORIZATION_TOKEN=%%%

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -203,8 +203,7 @@ func updateEnvForAwsVault(env environ, profileName string, region string) enviro
 	env.Set("AWS_VAULT", profileName)
 
 	if region != "" {
-		log.Printf("Setting subprocess env: AWS_DEFAULT_REGION=%s, AWS_REGION=%s", region, region)
-		env.Set("AWS_DEFAULT_REGION", region)
+		log.Printf("Setting subprocess env: AWS_REGION=%s", region)
 		env.Set("AWS_REGION", region)
 	}
 
@@ -260,14 +259,12 @@ func execEnvironment(input ExecCommandInput, config *vault.Config, credsProvider
 	env.Set("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey)
 
 	if creds.SessionToken != "" {
-		log.Println("Setting subprocess env: AWS_SESSION_TOKEN, AWS_SECURITY_TOKEN")
+		log.Println("Setting subprocess env: AWS_SESSION_TOKEN")
 		env.Set("AWS_SESSION_TOKEN", creds.SessionToken)
-		env.Set("AWS_SECURITY_TOKEN", creds.SessionToken)
 	}
 	if creds.CanExpire {
-		log.Println("Setting subprocess env: AWS_CREDENTIAL_EXPIRATION, AWS_SESSION_EXPIRATION")
+		log.Println("Setting subprocess env: AWS_CREDENTIAL_EXPIRATION")
 		env.Set("AWS_CREDENTIAL_EXPIRATION", iso8601.Format(creds.Expires))
-		env.Set("AWS_SESSION_EXPIRATION", iso8601.Format(creds.Expires))
 	}
 
 	if !supportsExecSyscall() {


### PR DESCRIPTION
Remove use of unnecessary env vars.

 - `AWS_DEFAULT_REGION`: use `AWS_REGION` instead. `AWS_DEFAULT_REGION` set the "default" region, and is unnecessary
 - `AWS_SECURITY_TOKEN`: use `AWS_SESSION_TOKEN` instead
 - `AWS_SESSION_EXPIRATION`: use `AWS_CREDENTIAL_EXPIRATION` instead