### PR TITLE
Revert removal of AWS_DEFAULT_REGION

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ AWS Vault then exposes the temporary credentials to the sub-process in one of tw
    ```shell
    $ aws-vault exec jonsmith -- env | grep AWS
    AWS_VAULT=jonsmith
+   AWS_DEFAULT_REGION=us-east-1
    AWS_REGION=us-east-1
    AWS_ACCESS_KEY_ID=%%%
    AWS_SECRET_ACCESS_KEY=%%%
@@ -92,6 +93,7 @@ AWS Vault then exposes the temporary credentials to the sub-process in one of tw
    ```shell
    $ aws-vault exec --server jonsmith -- env | grep AWS
    AWS_VAULT=jonsmith
+   AWS_DEFAULT_REGION=us-east-1
    AWS_REGION=us-east-1
    AWS_CONTAINER_CREDENTIALS_FULL_URI=%%%
    AWS_CONTAINER_AUTHORIZATION_TOKEN=%%%

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -203,8 +203,11 @@ func updateEnvForAwsVault(env environ, profileName string, region string) enviro
 	env.Set("AWS_VAULT", profileName)
 
 	if region != "" {
-		log.Printf("Setting subprocess env: AWS_REGION=%s", region)
+		// AWS_REGION is used by most SDKs. But boto3 (Python SDK) uses AWS_DEFAULT_REGION
+		// See https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html
+		log.Printf("Setting subprocess env: AWS_REGION=%s, AWS_DEFAULT_REGION=%s", region, region)
 		env.Set("AWS_REGION", region)
+		env.Set("AWS_DEFAULT_REGION", region)
 	}
 
 	return env

--- a/cli/export.go
+++ b/cli/export.go
@@ -210,6 +210,7 @@ func printEnv(input ExportCommandInput, credsProvider aws.CredentialsProvider, r
 	}
 	if region != "" {
 		fmt.Printf("%sAWS_REGION=%s\n", prefix, region)
+		fmt.Printf("%sAWS_DEFAULT_REGION=%s\n", prefix, region)
 	}
 
 	return nil


### PR DESCRIPTION
It turns out boto3 (the python SDK) still uses `AWS_DEFAULT_REGION`.

This reverts the recent removal of this env var in #1143
