### PR TITLE
Fix prompts required in non-tty processes

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -61,8 +61,8 @@ func (input ExecCommandInput) validate() error {
 	return nil
 }
 
-func CanExecUseTerminal(input ExecCommandInput) bool {
-	return !input.StartEcsServer && !input.StartEc2Server
+func hasBackgroundServer(input ExecCommandInput) bool {
+	return input.StartEcsServer || input.StartEc2Server
 }
 
 func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
@@ -118,7 +118,7 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 		StringsVar(&input.Args)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
-		input.Config.MfaPromptMethod = a.PromptDriver(CanExecUseTerminal(input))
+		input.Config.MfaPromptMethod = a.PromptDriver(hasBackgroundServer(input))
 		input.Config.NonChainedGetSessionTokenDuration = input.SessionDuration
 		input.Config.AssumeRoleDuration = input.SessionDuration
 		input.Config.SSOUseStdout = input.UseStdout

--- a/cli/export.go
+++ b/cli/export.go
@@ -65,7 +65,7 @@ func ConfigureExportCommand(app *kingpin.Application, a *AwsVault) {
 		StringVar(&input.ProfileName)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
-		input.Config.MfaPromptMethod = a.PromptDriver(true)
+		input.Config.MfaPromptMethod = a.PromptDriver(false)
 		input.Config.NonChainedGetSessionTokenDuration = input.SessionDuration
 		input.Config.AssumeRoleDuration = input.SessionDuration
 		input.Config.SSOUseStdout = input.UseStdout

--- a/cli/global.go
+++ b/cli/global.go
@@ -10,6 +10,7 @@ import (
 	"github.com/99designs/aws-vault/v7/vault"
 	"github.com/99designs/keyring"
 	"github.com/alecthomas/kingpin"
+	isatty "github.com/mattn/go-isatty"
 	"golang.org/x/term"
 )
 
@@ -33,15 +34,20 @@ type AwsVault struct {
 	awsConfigFile *vault.ConfigFile
 }
 
-func (a *AwsVault) PromptDriver(canUseTerminal bool) string {
+func isATerminal() bool {
+	return isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+}
+
+func (a *AwsVault) PromptDriver(avoidTerminalPrompt bool) string {
 	if a.promptDriver == "" {
-		if canUseTerminal {
-			return "terminal"
-		}
-		for _, driver := range prompt.Available() {
-			a.promptDriver = driver
-			if driver != "terminal" {
-				break
+		a.promptDriver = "terminal"
+
+		if !isATerminal() || avoidTerminalPrompt {
+			for _, driver := range prompt.Available() {
+				a.promptDriver = driver
+				if driver != "terminal" {
+					break
+				}
 			}
 		}
 	}

--- a/cli/login.go
+++ b/cli/login.go
@@ -59,7 +59,7 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 		StringVar(&input.ProfileName)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
-		input.Config.MfaPromptMethod = a.PromptDriver(true)
+		input.Config.MfaPromptMethod = a.PromptDriver(false)
 		input.Config.NonChainedGetSessionTokenDuration = input.SessionDuration
 		input.Config.AssumeRoleDuration = input.SessionDuration
 		input.Config.GetFederationTokenDuration = input.SessionDuration

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -34,7 +34,7 @@ func ConfigureRotateCommand(app *kingpin.Application, a *AwsVault) {
 		StringVar(&input.ProfileName)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
-		input.Config.MfaPromptMethod = a.PromptDriver(true)
+		input.Config.MfaPromptMethod = a.PromptDriver(false)
 		keyring, err := a.Keyring()
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.3
 	github.com/google/go-cmp v0.5.9
+	github.com/mattn/go-isatty v0.0.17
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	golang.org/x/term v0.5.0
 	gopkg.in/ini.v1 v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
+github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
@@ -70,6 +72,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.5.0 h1:n2a8QNdAb0sZNpU9R1ALUXBbY+w51fCQDN+7EdxNBsY=


### PR DESCRIPTION
If a TTY is not detected, prefer to use a non-terminal prompt method

Fixes #1015
