### PR TITLE
Env var to disable help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jonsmith                 jonsmith                 -
 
 # Start a subshell with temporary credentials
 $ aws-vault exec jonsmith
-aws-vault: Starting a subshell /bin/zsh, use `exit` to exit the subshell
+Starting subshell /bin/zsh, use `exit` to exit the subshell
 $ aws s3 ls
 bucket_1
 bucket_2

--- a/cli/export.go
+++ b/cli/export.go
@@ -92,12 +92,7 @@ func ExportCommand(input ExportCommandInput, f *vault.ConfigFile, keyring keyrin
 
 	vault.UseSession = !input.NoSession
 
-	configLoader := vault.ConfigLoader{
-		File:          f,
-		BaseConfig:    input.Config,
-		ActiveProfile: input.ProfileName,
-	}
-	config, err := configLoader.LoadFromProfile(input.ProfileName)
+	config, err := vault.NewConfigLoader(input.Config, f, input.ProfileName).LoadFromProfile(input.ProfileName)
 	if err != nil {
 		return fmt.Errorf("Error loading config: %w", err)
 	}

--- a/cli/global.go
+++ b/cli/global.go
@@ -35,7 +35,8 @@ type AwsVault struct {
 }
 
 func isATerminal() bool {
-	return isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+	fd := os.Stdout.Fd()
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
 }
 
 func (a *AwsVault) PromptDriver(avoidTerminalPrompt bool) string {

--- a/cli/login.go
+++ b/cli/login.go
@@ -83,12 +83,7 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 func LoginCommand(input LoginCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) error {
 	vault.UseSession = !input.NoSession
 
-	configLoader := vault.ConfigLoader{
-		File:          f,
-		BaseConfig:    input.Config,
-		ActiveProfile: input.ProfileName,
-	}
-	config, err := configLoader.LoadFromProfile(input.ProfileName)
+	config, err := vault.NewConfigLoader(input.Config, f, input.ProfileName).LoadFromProfile(input.ProfileName)
 	if err != nil {
 		return fmt.Errorf("Error loading config: %w", err)
 	}

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -55,11 +55,7 @@ func RotateCommand(input RotateCommandInput, f *vault.ConfigFile, keyring keyrin
 	vault.UseSession = !input.NoSession
 	vault.UseSessionCache = false
 
-	configLoader := &vault.ConfigLoader{
-		File:          f,
-		BaseConfig:    input.Config,
-		ActiveProfile: input.ProfileName,
-	}
+	configLoader := vault.NewConfigLoader(input.Config, f, input.ProfileName)
 	config, err := configLoader.LoadFromProfile(input.ProfileName)
 	if err != nil {
 		return fmt.Errorf("Error loading config: %w", err)

--- a/vault/config.go
+++ b/vault/config.go
@@ -278,6 +278,14 @@ type ConfigLoader struct {
 	visitedProfiles []string
 }
 
+func NewConfigLoader(baseConfig Config, file *ConfigFile, activeProfile string) *ConfigLoader {
+	return &ConfigLoader{
+		BaseConfig:    baseConfig,
+		File:          file,
+		ActiveProfile: activeProfile,
+	}
+}
+
 func (cl *ConfigLoader) visitProfile(name string) bool {
 	for _, p := range cl.visitedProfiles {
 		if p == name {


### PR DESCRIPTION
Adds an an env var `AWS_VAULT_DISABLE_HELP_MESSAGE` to disable terminal help messages.

Ended up requiring a bit of refactoring to make handling this consistent

Fixes #1156