### PR TITLE
Shut down ec2 proxy automatically

### DIFF
--- a/server/ec2proxy.go
+++ b/server/ec2proxy.go
@@ -45,7 +45,7 @@ func StartProxy() error {
 	return http.Serve(l, handler)
 }
 
-func isProxyRunning() bool {
+func IsProxyRunning() bool {
 	_, err := net.DialTimeout("tcp", ec2MetadataEndpointAddr, time.Millisecond*10)
 	return err == nil
 }

--- a/server/ec2server.go
+++ b/server/ec2server.go
@@ -17,12 +17,6 @@ const ec2CredentialsServerAddr = "127.0.0.1:9099"
 
 // StartEc2CredentialsServer starts a EC2 Instance Metadata server and endpoint proxy
 func StartEc2CredentialsServer(ctx context.Context, credsProvider aws.CredentialsProvider, region string) error {
-	if !isProxyRunning() {
-		if err := StartEc2EndpointProxyServerProcess(); err != nil {
-			return err
-		}
-	}
-
 	credsCache := aws.NewCredentialsCache(credsProvider)
 
 	// pre-fetch credentials so that we can respond quickly to the first request


### PR DESCRIPTION
Shut down the proxy when the aws-vault process ends.

Fixes #1133