### PR TITLE
Web identity profiles with role ARNs are valid

### DIFF
--- a/vault/config.go
+++ b/vault/config.go
@@ -698,7 +698,12 @@ func (c *ProfileConfig) Validate() error {
 	}
 	if c.HasSourceProfile() {
 		n++
-	} else if c.HasRole() {
+	}
+	if c.HasRole() &&
+		// these cases require the role to be set in addition, so it's part of
+		// their credential.
+		!c.HasSourceProfile() &&
+		!c.HasWebIdentity() {
 		n++
 	}
 	if n > 1 {

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -635,6 +635,10 @@ source_profile = foo
 region         = eu-west-2
 mfa_serial     = arn:aws:iam::9999999999999:mfa/david
 credential_process = true
+
+[profile withwebidentity]
+role_arn = arn:aws:iam::123457890:role/foo
+web_identity_token_process = oidccli -issuer=https://example.com -client-id=aws -client-secret=localonly raw
 `))
 	defer os.Remove(f)
 	configFile, _ := vault.LoadConfig(f)
@@ -650,5 +654,11 @@ credential_process = true
 	err = config.Validate()
 	if err == nil {
 		t.Fatalf("Should have failed validation: %v", err)
+	}
+
+	config, _ = configLoader.GetProfileConfig("withwebidentity")
+	err = config.Validate()
+	if err != nil {
+		t.Fatalf("Should have validated withwebidentity: %v", err)
 	}
 }


### PR DESCRIPTION
Profiles that specify web identity process or files require the role ARN to be set as well. Since the 7.0.0 release, this has been failing validation because it is now considered to have two sources of credentials. This fixes the validation to correctly consider this as a profile with one source credential.

Fixes #1177