### PR TITLE
Fix hang on invisible tty when using 2FA where prompt=terminal in some edge cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
+	github.com/mattn/go-tty v0.0.4 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/xhit/go-str2duration v1.2.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,14 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-tty v0.0.4 h1:NVikla9X8MN0SQAqCYzpGyXv0jY7MNl3HOWD2dkle7E=
+github.com/mattn/go-tty v0.0.4/go.mod h1:u5GGXBtZU6RQoKV8gY5W6UhMudbR5vXnUe7j3pxse28=
 github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
@@ -70,6 +76,9 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/xhit/go-str2duration v1.2.0 h1:BcV5u025cITWxEQKGWr1URRzrcXtu7uk8+luz3Yuhwc=
 github.com/xhit/go-str2duration v1.2.0/go.mod h1:3cPSlfZlUHVlneIVfePFWcJZsuwf+P1v2SRTV4cUmp4=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=

--- a/prompt/terminal.go
+++ b/prompt/terminal.go
@@ -1,19 +1,22 @@
 package prompt
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
-	"golang.org/x/term"
+	"github.com/mattn/go-tty"
 )
 
 func TerminalPrompt(message string) (string, error) {
-	fmt.Fprint(os.Stderr, message)
+	tty, err := tty.Open()
+	if err != nil {
+		return "", err
+	}
+	defer tty.Close()
 
-	reader := bufio.NewReader(os.Stdin)
-	text, err := reader.ReadString('\n')
+	fmt.Fprint(tty.Output(), message)
+
+	text, err := tty.ReadString()
 	if err != nil {
 		return "", err
 	}
@@ -22,14 +25,18 @@ func TerminalPrompt(message string) (string, error) {
 }
 
 func TerminalSecretPrompt(message string) (string, error) {
-	fmt.Fprint(os.Stderr, message)
-
-	text, err := term.ReadPassword(int(os.Stdin.Fd()))
+	tty, err := tty.Open()
 	if err != nil {
 		return "", err
 	}
+	defer tty.Close()
 
-	fmt.Println()
+	fmt.Fprint(tty.Output(), message)
+
+	text, err := tty.ReadPassword()
+	if err != nil {
+		return "", err
+	}
 
 	return strings.TrimSpace(string(text)), nil
 }

--- a/prompt/terminal.go
+++ b/prompt/terminal.go
@@ -38,7 +38,7 @@ func TerminalSecretPrompt(message string) (string, error) {
 		return "", err
 	}
 
-	return strings.TrimSpace(string(text)), nil
+	return strings.TrimSpace(text), nil
 }
 
 func TerminalMfaPrompt(mfaSerial string) (string, error) {


### PR DESCRIPTION
This implements the fix suggested by @ngyuki in https://github.com/99designs/aws-vault/issues/1054. When using `prompt=terminal` (which we use to support both Linux and Mac using the same workflow and config, without `osascript` involvement), we used to have a workaround in `.aws/config` that would redirect the terminal prompt to stdout in most cases by adding ` 2> $(tty)` to the end of the `aws-vault` `credential_process` call, like this:

```
credential_process=sh -c 'aws-vault --prompt terminal export base --duration 12h --format=json 2> $(tty)'
```

With this patch we can remove that redirect and the prompt always shows up, even when called through the SDK via `aws --profile somerole s3 ls`, for example. Also removes the creation of spurious files named `not a tty` when `prompt=terminal` is forced. 

This expands on https://github.com/99designs/aws-vault/pull/1149 a bit, where instead of just preferring a non-terminal prompt without an active tty it should show up in all cases anyway when specifically requested.