### PR TITLE
Fix credential type detection for login

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/skratchdot/open-golang/open"
 )
 
@@ -74,106 +75,97 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 			return err
 		}
 
-		err = LoginCommand(input, f, keyring)
+		err = LoginCommand(context.Background(), input, f, keyring)
 		app.FatalIfError(err, "login")
 		return nil
 	})
 }
 
-func LoginCommand(input LoginCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) error {
+func getCredsProvider(input LoginCommandInput, config *vault.ProfileConfig, keyring keyring.Keyring) (credsProvider aws.CredentialsProvider, err error) {
+	if input.ProfileName == "" {
+		// When no profile is specified, source credentials from the environment
+		configFromEnv, err := awsconfig.NewEnvConfig()
+		if err != nil {
+			return nil, fmt.Errorf("unable to authenticate to AWS through your environment variables: %w", err)
+		}
+
+		if configFromEnv.Credentials.AccessKeyID == "" {
+			return nil, fmt.Errorf("argument 'profile' not provided, nor any AWS env vars found. Try --help")
+		}
+
+		credsProvider = credentials.StaticCredentialsProvider{Value: configFromEnv.Credentials}
+	} else {
+		// Use a profile from the AWS config file
+		ckr := &vault.CredentialKeyring{Keyring: keyring}
+		t := vault.TempCredentialsCreator{
+			Keyring:                   ckr,
+			DisableSessions:           input.NoSession,
+			DisableSessionsForProfile: config.ProfileName,
+		}
+		credsProvider, err = t.GetProviderForProfile(config)
+		if err != nil {
+			return nil, fmt.Errorf("profile %s: %w", input.ProfileName, err)
+		}
+	}
+
+	return credsProvider, err
+}
+
+// LoginCommand creates a login URL for the AWS Management Console using the method described at
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
+func LoginCommand(ctx context.Context, input LoginCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) error {
 	config, err := vault.NewConfigLoader(input.Config, f, input.ProfileName).GetProfileConfig(input.ProfileName)
 	if err != nil {
 		return fmt.Errorf("Error loading config: %w", err)
 	}
 
-	var credsProvider aws.CredentialsProvider
-
-	if input.ProfileName == "" {
-		// When no profile is specified, source credentials from the environment
-		configFromEnv, err := awsconfig.NewEnvConfig()
-		if err != nil {
-			return fmt.Errorf("unable to authenticate to AWS through your environment variables: %w", err)
-		}
-		credsProvider = credentials.StaticCredentialsProvider{Value: configFromEnv.Credentials}
-		if configFromEnv.Credentials.SessionToken == "" {
-			credsProvider, err = vault.NewFederationTokenProvider(context.TODO(), credsProvider, config)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		// Use a profile from the AWS config file
-		ckr := &vault.CredentialKeyring{Keyring: keyring}
-		if config.HasRole() || config.HasSSOStartURL() || config.HasCredentialProcess() || config.HasWebIdentity() {
-			// If AssumeRole or sso.GetRoleCredentials isn't used, GetFederationToken has to be used for IAM credentials
-			credsProvider, err = vault.NewTempCredentialsProvider(config, ckr, input.NoSession, false)
-		} else {
-			credsProvider, err = vault.NewFederationTokenCredentialsProvider(context.TODO(), input.ProfileName, ckr, config)
-		}
-		if err != nil {
-			return fmt.Errorf("profile %s: %w", input.ProfileName, err)
-		}
-	}
-
-	creds, err := credsProvider.Retrieve(context.TODO())
-	if err != nil {
-		return fmt.Errorf("Failed to get credentials: %w", err)
-	}
-	if creds.AccessKeyID == "" && input.ProfileName == "" {
-		return fmt.Errorf("argument 'profile' not provided, nor any AWS env vars found. Try --help")
-	}
-
-	jsonBytes, err := json.Marshal(map[string]string{
-		"sessionId":    creds.AccessKeyID,
-		"sessionKey":   creds.SecretAccessKey,
-		"sessionToken": creds.SessionToken,
-	})
+	credsProvider, err := getCredsProvider(input, config, keyring)
 	if err != nil {
 		return err
 	}
 
-	loginURLPrefix, destination := generateLoginURL(config.Region, input.Path)
+	// if we already know the type of credentials being created, avoid calling isCallerIdentityAssumedRole
+	canCredsBeUsedInLoginURL, err := canProviderBeUsedForLogin(credsProvider)
+	if err != nil {
+		return err
+	}
 
-	req, err := http.NewRequestWithContext(context.TODO(), "GET", loginURLPrefix, nil)
+	if !canCredsBeUsedInLoginURL {
+		// use a static creds provider so that we don't request credentials from AWS more than once
+		credsProvider, err = createStaticCredentialsProvider(ctx, credsProvider)
+		if err != nil {
+			return err
+		}
+
+		// if the credentials have come from an unknown source like credential_process, check the
+		// caller identity to see if it's an assumed role
+		isAssumedRole, err := isCallerIdentityAssumedRole(ctx, credsProvider, config)
+		if err != nil {
+			return err
+		}
+
+		if !isAssumedRole {
+			log.Println("Creating a federated session")
+			credsProvider, err = vault.NewFederationTokenProvider(ctx, credsProvider, config)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	creds, err := credsProvider.Retrieve(ctx)
 	if err != nil {
 		return err
 	}
 
 	if creds.CanExpire {
-		log.Printf("Creating login token, expires in %s", time.Until(creds.Expires))
+		log.Printf("Requesting a signin token for session expiring in %s", time.Until(creds.Expires))
 	}
 
-	q := req.URL.Query()
-	q.Add("Action", "getSigninToken")
-	q.Add("Session", string(jsonBytes))
-	req.URL.RawQuery = q.Encode()
-
-	resp, err := http.DefaultClient.Do(req)
+	loginURLPrefix, destination := generateLoginURL(config.Region, input.Path)
+	signinToken, err := requestSigninToken(ctx, creds, loginURLPrefix)
 	if err != nil {
 		return err
-	}
-
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		log.Printf("Response body was %s", body)
-		return fmt.Errorf("Call to getSigninToken failed with %v", resp.Status)
-	}
-
-	var respParsed map[string]string
-
-	err = json.Unmarshal(body, &respParsed)
-	if err != nil {
-		return err
-	}
-
-	signinToken, ok := respParsed["SigninToken"]
-	if !ok {
-		return fmt.Errorf("Expected a response with SigninToken")
 	}
 
 	loginURL := fmt.Sprintf("%s?Action=login&Issuer=aws-vault&Destination=%s&SigninToken=%s",
@@ -211,4 +203,100 @@ func generateLoginURL(region string, path string) (string, string) {
 		}
 	}
 	return loginURLPrefix, destination
+}
+
+func isCallerIdentityAssumedRole(ctx context.Context, credsProvider aws.CredentialsProvider, config *vault.ProfileConfig) (bool, error) {
+	cfg := vault.NewAwsConfigWithCredsProvider(credsProvider, config.Region, config.STSRegionalEndpoints)
+	client := sts.NewFromConfig(cfg)
+	id, err := client.GetCallerIdentity(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	arn := aws.ToString(id.Arn)
+	arnParts := strings.Split(arn, ":")
+	if len(arnParts) < 6 {
+		return false, fmt.Errorf("unable to parse ARN: %s", arn)
+	}
+	if strings.HasPrefix(arnParts[5], "assumed-role") {
+		return true, nil
+	}
+	return false, nil
+}
+
+func createStaticCredentialsProvider(ctx context.Context, credsProvider aws.CredentialsProvider) (sc credentials.StaticCredentialsProvider, err error) {
+	creds, err := credsProvider.Retrieve(ctx)
+	if err != nil {
+		return sc, err
+	}
+	return credentials.StaticCredentialsProvider{Value: creds}, nil
+}
+
+// canProviderBeUsedForLogin returns true if the credentials produced by the provider is known to be usable by the login URL endpoint
+func canProviderBeUsedForLogin(credsProvider aws.CredentialsProvider) (bool, error) {
+	if _, ok := credsProvider.(*vault.AssumeRoleProvider); ok {
+		return true, nil
+	}
+	if _, ok := credsProvider.(*vault.SSORoleCredentialsProvider); ok {
+		return true, nil
+	}
+	if _, ok := credsProvider.(*vault.AssumeRoleWithWebIdentityProvider); ok {
+		return true, nil
+	}
+	if c, ok := credsProvider.(*vault.CachedSessionProvider); ok {
+		return canProviderBeUsedForLogin(c.SessionProvider)
+	}
+
+	return false, nil
+}
+
+// Create a signin token
+func requestSigninToken(ctx context.Context, creds aws.Credentials, loginURLPrefix string) (string, error) {
+	jsonSession, err := json.Marshal(map[string]string{
+		"sessionId":    creds.AccessKeyID,
+		"sessionKey":   creds.SecretAccessKey,
+		"sessionToken": creds.SessionToken,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", loginURLPrefix, nil)
+	if err != nil {
+		return "", err
+	}
+
+	q := req.URL.Query()
+	q.Add("Action", "getSigninToken")
+	q.Add("Session", string(jsonSession))
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("Response body was %s", body)
+		return "", fmt.Errorf("Call to getSigninToken failed with %v", resp.Status)
+	}
+
+	var respParsed map[string]string
+
+	err = json.Unmarshal(body, &respParsed)
+	if err != nil {
+		return "", err
+	}
+
+	signinToken, ok := respParsed["SigninToken"]
+	if !ok {
+		return "", fmt.Errorf("Expected a response with SigninToken")
+	}
+
+	return signinToken, nil
 }

--- a/vault/assumeroleprovider.go
+++ b/vault/assumeroleprovider.go
@@ -26,7 +26,7 @@ type AssumeRoleProvider struct {
 
 // Retrieve generates a new set of temporary credentials using STS AssumeRole
 func (p *AssumeRoleProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
-	role, err := p.assumeRole(ctx)
+	role, err := p.RetrieveStsCredentials(ctx)
 	if err != nil {
 		return aws.Credentials{}, err
 	}
@@ -49,7 +49,7 @@ func (p *AssumeRoleProvider) roleSessionName() string {
 	return p.RoleSessionName
 }
 
-func (p *AssumeRoleProvider) assumeRole(ctx context.Context) (*ststypes.Credentials, error) {
+func (p *AssumeRoleProvider) RetrieveStsCredentials(ctx context.Context) (*ststypes.Credentials, error) {
 	var err error
 
 	input := &sts.AssumeRoleInput{

--- a/vault/assumerolewithwebidentityprovider.go
+++ b/vault/assumerolewithwebidentityprovider.go
@@ -25,7 +25,7 @@ type AssumeRoleWithWebIdentityProvider struct {
 
 // Retrieve generates a new set of temporary credentials using STS AssumeRoleWithWebIdentity
 func (p *AssumeRoleWithWebIdentityProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
-	creds, err := p.assumeRole(ctx)
+	creds, err := p.RetrieveStsCredentials(ctx)
 	if err != nil {
 		return aws.Credentials{}, err
 	}
@@ -48,7 +48,7 @@ func (p *AssumeRoleWithWebIdentityProvider) roleSessionName() string {
 	return p.RoleSessionName
 }
 
-func (p *AssumeRoleWithWebIdentityProvider) assumeRole(ctx context.Context) (*ststypes.Credentials, error) {
+func (p *AssumeRoleWithWebIdentityProvider) RetrieveStsCredentials(ctx context.Context) (*ststypes.Credentials, error) {
 	var err error
 
 	webIdentityToken, err := p.webIdentityToken()

--- a/vault/cachedsessionprovider.go
+++ b/vault/cachedsessionprovider.go
@@ -9,32 +9,46 @@ import (
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 )
 
+type StsSessionProvider interface {
+	aws.CredentialsProvider
+	RetrieveStsCredentials(ctx context.Context) (*ststypes.Credentials, error)
+}
+
 // CachedSessionProvider retrieves cached credentials from the keyring, or if no credentials are cached
 // retrieves temporary credentials using the CredentialsFunc
 type CachedSessionProvider struct {
 	SessionKey      SessionMetadata
-	CredentialsFunc func(context.Context) (*ststypes.Credentials, error)
+	SessionProvider StsSessionProvider
 	Keyring         *SessionKeyring
 	ExpiryWindow    time.Duration
+}
+
+func (p *CachedSessionProvider) RetrieveStsCredentials(ctx context.Context) (*ststypes.Credentials, error) {
+	creds, err := p.Keyring.Get(p.SessionKey)
+
+	if err != nil || time.Until(*creds.Expiration) < p.ExpiryWindow {
+		// lookup missed, we need to create a new one.
+		creds, err = p.SessionProvider.RetrieveStsCredentials(ctx)
+		if err != nil {
+			return nil, err
+		}
+		err = p.Keyring.Set(p.SessionKey, creds)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		log.Printf("Re-using cached credentials %s from %s, expires in %s", FormatKeyForDisplay(*creds.AccessKeyId), p.SessionKey.Type, time.Until(*creds.Expiration).String())
+	}
+
+	return creds, nil
 }
 
 // Retrieve returns cached credentials from the keyring, or if no credentials are cached
 // generates a new set of temporary credentials using the CredentialsFunc
 func (p *CachedSessionProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
-	creds, err := p.Keyring.Get(p.SessionKey)
-
-	if err != nil || time.Until(*creds.Expiration) < p.ExpiryWindow {
-		// lookup missed, we need to create a new one.
-		creds, err = p.CredentialsFunc(ctx)
-		if err != nil {
-			return aws.Credentials{}, err
-		}
-		err = p.Keyring.Set(p.SessionKey, creds)
-		if err != nil {
-			return aws.Credentials{}, err
-		}
-	} else {
-		log.Printf("Re-using cached credentials %s from %s, expires in %s", FormatKeyForDisplay(*creds.AccessKeyId), p.SessionKey.Type, time.Until(*creds.Expiration).String())
+	creds, err := p.RetrieveStsCredentials(ctx)
+	if err != nil {
+		return aws.Credentials{}, err
 	}
 
 	return aws.Credentials{

--- a/vault/credentialprocessprovider.go
+++ b/vault/credentialprocessprovider.go
@@ -55,7 +55,7 @@ func (p *CredentialProcessProvider) retrieveWith(ctx context.Context, fn func(st
 	}, nil
 }
 
-func (p *CredentialProcessProvider) callCredentialProcess(ctx context.Context) (*ststypes.Credentials, error) {
+func (p *CredentialProcessProvider) RetrieveStsCredentials(ctx context.Context) (*ststypes.Credentials, error) {
 	return p.callCredentialProcessWith(ctx, executeProcess)
 }
 

--- a/vault/sessiontokenprovider.go
+++ b/vault/sessiontokenprovider.go
@@ -19,7 +19,7 @@ type SessionTokenProvider struct {
 
 // Retrieve generates a new set of temporary credentials using STS GetSessionToken
 func (p *SessionTokenProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
-	creds, err := p.GetSessionToken(ctx)
+	creds, err := p.RetrieveStsCredentials(ctx)
 	if err != nil {
 		return aws.Credentials{}, err
 	}
@@ -34,7 +34,7 @@ func (p *SessionTokenProvider) Retrieve(ctx context.Context) (aws.Credentials, e
 }
 
 // GetSessionToken generates a new set of temporary credentials using STS GetSessionToken
-func (p *SessionTokenProvider) GetSessionToken(ctx context.Context) (*ststypes.Credentials, error) {
+func (p *SessionTokenProvider) RetrieveStsCredentials(ctx context.Context) (*ststypes.Credentials, error) {
 	var err error
 
 	input := &sts.GetSessionTokenInput{

--- a/vault/ssorolecredentialsprovider.go
+++ b/vault/ssorolecredentialsprovider.go
@@ -93,6 +93,10 @@ func (p *SSORoleCredentialsProvider) getRoleCredentials(ctx context.Context) (*s
 	return resp.RoleCredentials, nil
 }
 
+func (p *SSORoleCredentialsProvider) RetrieveStsCredentials(ctx context.Context) (*ststypes.Credentials, error) {
+	return p.getRoleCredentialsAsStsCredemtials(ctx)
+}
+
 // getRoleCredentialsAsStsCredemtials returns getRoleCredentials as sts.Credentials because sessions.Store expects it
 func (p *SSORoleCredentialsProvider) getRoleCredentialsAsStsCredemtials(ctx context.Context) (*ststypes.Credentials, error) {
 	creds, err := p.getRoleCredentials(ctx)


### PR DESCRIPTION
If credentials are sourced from the environment or credential_process, check the caller ID to see if the session is an assumed role, or create a federated login if master credentials are found.

Fixes #1191