### PR TITLE
Support for aws-vault exec --server on WSL

### DIFF
--- a/cli/proxy.go
+++ b/cli/proxy.go
@@ -1,8 +1,13 @@
 package cli
 
 import (
+	"fmt"
+	"net"
 	"os"
+	"os/exec"
 	"os/signal"
+	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/99designs/aws-vault/v7/server"
@@ -11,7 +16,8 @@ import (
 
 func ConfigureProxyCommand(app *kingpin.Application) {
 	stop := false
-
+	isWsl := false
+	serverAddress := ""
 	cmd := app.Command("proxy", "Start a proxy for the ec2 instance role server locally.").
 		Alias("server").
 		Hidden()
@@ -19,14 +25,45 @@ func ConfigureProxyCommand(app *kingpin.Application) {
 	cmd.Flag("stop", "Stop the proxy").
 		BoolVar(&stop)
 
+	cmd.Flag("credentials-server-address", "Server address").
+		Default(server.DefaultEc2CredentialsServerAddr).
+		Hidden().
+		StringVar(&serverAddress)
+
+	//goland:noinspection GoBoolExpressions
+	if runtime.GOOS == "linux" {
+		cmd.Flag("wsl", "Proxy to credentials server running on Windows host").
+			BoolVar(&isWsl)
+	}
+
 	cmd.Action(func(*kingpin.ParseContext) error {
 		if stop {
 			server.StopProxy()
 			return nil
 		}
 		handleSigTerm()
-		return server.StartProxy()
+		if (serverAddress == server.DefaultEc2CredentialsServerAddr) && isWsl {
+			ip, err := getWslHost()
+			if err != nil {
+				return err
+			}
+			serverAddress = ip.String() + ":" + server.DefaultEc2CredentialsServerPort
+		}
+		return server.StartProxy(serverAddress)
 	})
+}
+
+func getWslHost() (net.IP, error) {
+	out, err := exec.Command("ip", "route").CombinedOutput()
+	if err != nil {
+		return net.IP{}, err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, "default") {
+			return net.ParseIP(strings.Split(line, " ")[2]), nil
+		}
+	}
+	return nil, fmt.Errorf("unable to find default gateway")
 }
 
 func handleSigTerm() {

--- a/server/ec2alias_bsd.go
+++ b/server/ec2alias_bsd.go
@@ -5,6 +5,10 @@ package server
 
 import "os/exec"
 
+func GetWslAddressAndNetwork() (net.IP, *net.IPNet, error) {
+	return net.IP{}, net.IPNet{}, fmt.Errorf("WSL is a Windows only feature")
+}
+
 func installEc2EndpointNetworkAlias() ([]byte, error) {
 	return exec.Command("ifconfig", "lo0", "alias", "169.254.169.254").CombinedOutput()
 }

--- a/server/ec2alias_linux.go
+++ b/server/ec2alias_linux.go
@@ -3,7 +3,15 @@
 
 package server
 
-import "os/exec"
+import (
+	"fmt"
+	"net"
+	"os/exec"
+)
+
+func GetWslAddressAndNetwork() (net.IP, *net.IPNet, error) {
+	return net.IP{}, net.IPNet{}, fmt.Errorf("WSL is a Windows only feature")
+}
 
 func installEc2EndpointNetworkAlias() ([]byte, error) {
 	return exec.Command("ip", "addr", "add", "169.254.169.254/24", "dev", "lo", "label", "lo:0").CombinedOutput()

--- a/server/ec2proxy.go
+++ b/server/ec2proxy.go
@@ -19,8 +19,8 @@ const (
 
 // StartProxy starts a http proxy server that listens on the standard EC2 Instance Metadata endpoint http://169.254.169.254:80/
 // and forwards requests through to the running `aws-vault exec` command
-func StartProxy() error {
-	var localServerURL, err = url.Parse(fmt.Sprintf("http://%s/", ec2CredentialsServerAddr))
+func StartProxy(serverAddress string) error {
+	var localServerURL, err = url.Parse(fmt.Sprintf("http://%s/", serverAddress))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently when running on WSL the only supported prompt driver is terminal Terminal prompt is not compatible with the server mode

To workaround we run credentials server on windows host and take advantage of windows cred storage and UX 
On WSL linux we run proxy command that talks to the credentials server running on host Because we don't need to run proxy on the windows host we made it optional If proxy is disabled we would not need privilege elevation

On windows:
```
aws-vault exec --ec2-server --wsl --no-proxy ${PROFILE_NAME}
```
On linux:
```
aws-vault proxy --wsl
```
After that all linux processes will be authenticate through windows host