### PR TITLE
Add ability to specify keyctl scope.

### DIFF
--- a/cli/global.go
+++ b/cli/global.go
@@ -162,6 +162,10 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 		Envar("AWS_VAULT_FILE_DIR").
 		StringVar(&a.KeyringConfig.FileDir)
 
+	app.Flag("keyctl-scope", "Scope to use when using keyctl backend").
+		Envar("AWS_VAULT_KEYCTL_SCOPE").
+		StringVar(&a.KeyringConfig.KeyCtlScope)
+
 	app.PreAction(func(c *kingpin.ParseContext) error {
 		if !a.Debug {
 			log.SetOutput(io.Discard)


### PR DESCRIPTION
Resolves the issue described in [this comment](https://github.com/99designs/aws-vault/issues/890#issuecomment-1067456322), enabling `keyctl` backend to work in Linux by allowing a user to specify a keyctl scope.

Current behavior:
```
sh-4.2$ ./aws-vault login --debug --backend keyctl default
2023/04/06 22:07:45 aws-vault dev
2023/04/06 22:07:45 Using prompt driver: terminal
2023/04/06 22:07:45 [keyring] Considering backends: [keyctl]
2023/04/06 22:07:45 [keyring] Failed backend keyctl: accessing "" keyring failed: unknown scope ""
aws-vault: error: Specified keyring backend not available, try --help
```

With new `--keyctl-scope` flag (SUCCESS):

```
sh-4.2$ ./aws-vault login --debug --backend keyctl --keyctl-scope user default
2023/04/06 22:08:22 aws-vault dev
2023/04/06 22:08:22 Using prompt driver: terminal
2023/04/06 22:08:22 [keyring] Considering backends: [keyctl]
2023/04/06 22:08:22 Loading config file /home/ec2-user/.aws/config
2023/04/06 22:08:22 Parsing config file /home/ec2-user/.aws/config
2023/04/06 22:08:22 profile default: using credential process
2023/04/06 22:08:22 Re-using cached credentials ****************UNZD from credential_process, expires in 14m54.11233509s
2023/04/06 22:08:22 Requesting a signin token for session expiring in 14m54.056822686s
```

With new `AWS_VAULT_KEYCTL_SCOPE` environment variable (SUCCESS):
```
sh-4.2$ AWS_VAULT_KEYCTL_SCOPE=user ./aws-vault login --debug --backend keyctl default
2023/04/06 22:10:07 aws-vault dev
2023/04/06 22:10:07 Using prompt driver: terminal
2023/04/06 22:10:07 [keyring] Considering backends: [keyctl]
2023/04/06 22:10:07 Loading config file /home/ec2-user/.aws/config
2023/04/06 22:10:07 Parsing config file /home/ec2-user/.aws/config
2023/04/06 22:10:07 profile default: using credential process
2023/04/06 22:10:07 Re-using cached credentials ****************UNZD from credential_process, expires in 13m9.003402192s
2023/04/06 22:10:08 Requesting a signin token for session expiring in 13m8.951533886s
```