### PR TITLE
fix region query endpoint

### DIFF
--- a/server/ec2server.go
+++ b/server/ec2server.go
@@ -47,7 +47,7 @@ func startEc2CredentialsServer(credsProvider aws.CredentialsProvider, region str
 	})
 
 	// used by AWS SDK to determine region
-	router.HandleFunc("/latest/meta-data/dynamic/instance-identity/document", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/latest/dynamic/instance-identity/document", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `{"region": "`+region+`"}`)
 	})
 


### PR DESCRIPTION
I suspect this was just typo'd initially, and it breaks e.g. the java sdk.

On ec2, old:
```
[josh@i-0600ab71d7a519927 ~]$ curl -v 169.254.169.254/latest/meta-data/dynamic/instance-identity/document > /dev/null
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET /latest/meta-data/dynamic/instance-identity/document HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Content-Type: text/html
< Content-Length: 339
< Date: Mon, 15 May 2023 10:49:36 GMT
< Server: EC2ws
< Connection: close
< 
{ [339 bytes data]
```

New:
```
[josh@i-0600ab71d7a519927 ~]$ curl -v 169.254.169.254/latest/dynamic/instance-identity/document > /dev/null
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET /latest/dynamic/instance-identity/document HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: text/plain
< Accept-Ranges: none
< Last-Modified: Mon, 15 May 2023 10:41:58 GMT
< Content-Length: 474
< Date: Mon, 15 May 2023 10:49:52 GMT
< Server: EC2ws
< Connection: close
< 
{ [474 bytes data]
```