### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Some of the GitHub actions used in the `go.yml` workflow are out-of-date. For example, the `actions/setup-go@v3` action is now at version 4, which introduces caching.

Rather than submitting a PR to update individual actions one time, this PR introduces a Dependabot config that will submit PRs regularly as actions are updated.

If this PR merges, expect Dependabot to immediately submit two PRs (by my count) to update individual actions to their latest versions.