### PR TITLE
specify resource path for ecs credential url

### DIFF
--- a/server/ecsserver.go
+++ b/server/ecsserver.go
@@ -67,7 +67,7 @@ type EcsServer struct {
 }
 
 func NewEcsServer(ctx context.Context, baseCredsProvider aws.CredentialsProvider, config *vault.ProfileConfig, authToken string, port int, lazyLoadBaseCreds bool) (*EcsServer, error) {
-	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d/%s", port, "get-credentials"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Problem

According to the [AWS Documentation](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html) it is expected that the `AWS_CONTAINER_CREDENTIALS_FULL_URI` env var contains the `get-credentials` path for example: `http://localhost/get-credentials`. 

We use aws vault exclusively for our AWS access at highwing.io and it works flawlessly when connecting with the SDK or using short-term credentials in a subshell like `aws-vault exec account` and the `--server` works fine when using the cli, using vscode AWS Toolkit, etc. 

When using the Ruby SDK, the ECS credential server is not being picked up by default, even though the `AWS_CONTAINER_CREDENTIALS_FULL_URI` is [supported by the Ruby SDK](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECSCredentials.html) (see the `:endpoint` option). 

The ECS credentials are picked up if we override the existing env var:

```shell
% export AWS_CONTAINER_CREDENTIALS_FULL_URI=http://127.0.0.1:<port>/get-credentials
% irb
irb(main):001:0> require 'aws-sdk-core'
=> true
irb(main):002:0> client = Aws::STS::Client.new
=> #<Aws::STS::Client>
irb(main):003:0> client.get_caller_identity
=>
#<struct Aws::STS::Types::GetCallerIdentityResponse <redacted>>
```

and the `get-credentials` route does not seem to break the cli:

```shell
% ENV | grep FULL_URI
AWS_CONTAINER_CREDENTIALS_FULL_URI=http://127.0.0.1:<port>/get-credentials
% aws sts get-caller-identity
{
   <redacted>
}
```

# Suggested Change

I added the `get-credentials` path to the server address. 

This change would prevent a bit of ceremony I need to manage on my side when using the Ruby SDK for localhost development, I'd really appreciate if you would consider the change.

# Caution I don't know Go

I ran the tests and had 3 failures before and after the change.

I rake the make task and it failed to build because I don't have a local signing cert (I think).

I'm happy to make any changes to the PR to meet the process of the project, or if its easier, please feel free to take this contribution and run with it. Thanks for such a great tool and I hope this helps adoption! 