### PR TITLE
contrib: aws-vault proxy listen on 169.254.170.2

### DIFF
--- a/contrib/_aws-vault-proxy/main.go
+++ b/contrib/_aws-vault-proxy/main.go
@@ -35,5 +35,6 @@ func main() {
 		addAuthorizationHeader(authToken,
 			httputil.NewSingleHostReverseProxy(target)))
 
-	_ = http.ListenAndServe(":80", handler)
+	err := http.ListenAndServe("169.254.170.2:80", handler)
+	log.Fatalf("http.ListenAndServe failed: %s", err)
 }


### PR DESCRIPTION
Hey!

Since this endpoint exposes AWS credentials directly to any callers, it is of utmost importance that it not be called by unauthorized 3rd parties. By listening only on 169.254.170.2, instead of all available interfaces, we ensure that it's only possible for callers that have access to that IP address to retrieve credentials. This avoids the potential mistake of e.g. hosting this with Docker's host networking and potentially making it publicly available.