### PR TITLE
use MFA config of SourceProfile

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -313,21 +313,21 @@ func (t *TempCredentialsCreator) canUseGetSessionToken(c *ProfileConfig) (bool, 
 		return false, "sessions are disabled for this profile"
 	}
 
-	if c.IsChained() {
-		if !c.ChainedFromProfile.HasMfaSerial() {
-			return false, fmt.Sprintf("profile '%s' has no MFA serial defined", c.ChainedFromProfile.ProfileName)
+	if c.HasSourceProfile() {
+		if !c.SourceProfile.HasMfaSerial() {
+			return false, fmt.Sprintf("profile '%s' has no MFA serial defined", c.SourceProfile.ProfileName)
 		}
 
-		if !c.HasMfaSerial() && c.ChainedFromProfile.HasMfaSerial() {
+		if !c.HasMfaSerial() && c.SourceProfile.HasMfaSerial() {
 			return false, fmt.Sprintf("profile '%s' has no MFA serial defined", c.ProfileName)
 		}
 
-		if c.ChainedFromProfile.MfaSerial != c.MfaSerial {
-			return false, fmt.Sprintf("MFA serial doesn't match profile '%s'", c.ChainedFromProfile.ProfileName)
+		if c.SourceProfile.MfaSerial != c.MfaSerial {
+			return false, fmt.Sprintf("MFA serial doesn't match profile '%s'", c.SourceProfile.ProfileName)
 		}
 
-		if c.ChainedFromProfile.AssumeRoleDuration > roleChainingMaximumDuration {
-			return false, fmt.Sprintf("duration %s in profile '%s' is greater than the AWS maximum %s for chaining MFA", c.ChainedFromProfile.AssumeRoleDuration, c.ChainedFromProfile.ProfileName, roleChainingMaximumDuration)
+		if c.SourceProfile.AssumeRoleDuration > roleChainingMaximumDuration {
+			return false, fmt.Sprintf("duration %s in profile '%s' is greater than the AWS maximum %s for chaining MFA", c.SourceProfile.AssumeRoleDuration, c.SourceProfile.ProfileName, roleChainingMaximumDuration)
 		}
 	}
 


### PR DESCRIPTION
My profile file:
```
[profile root]
mfa_serial=arn:aws-cn:iam::xxxxxxxxxxxx:mfa/mfa
region=cn-north-1
credential_process=aws-vault export --prompt=osascript --format=json root

[profile work]
role_arn = arn:aws-cn:iam::xxxxxxxxxxxx:role/to-assume
region=cn-north-1
source_profile = root
```

then I run:
```
av login work -s --debug
```
I got error:
```
2024/07/24 15:24:30 profile root: skipping GetSessionToken because profile 'work' has no MFA serial defined
...
2024/07/24 15:24:30 [keyring] Found item "aws-vault (root)"
aws-vault: error: login: operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: 392da53b-2cc1-43dc-ac66-e8e0bed4ed84, api error AccessDenied: User: arn:aws-cn:iam::xxxxxxxxxx:user/mfa is not authorized to perform: sts:AssumeRole on resource: arn:aws-cn:iam::xxxxxxxxxx:role/to-assume
```

I think profile 'work'  should use MFA config of profile 'root' .  just like awscli.
```
➜ aws sts get-caller-identity --profile work --no-cli-pager
Enter MFA code for arn:aws-cn:iam::xxxxxxxxxx:mfa/mfa:
```