### PR TITLE
Fix mfa_process compatibility issue on Windows

### DIFF
--- a/vault/mfa.go
+++ b/vault/mfa.go
@@ -2,14 +2,9 @@ package vault
 
 import (
 	"errors"
-	"fmt"
-	"log"
-	"os"
-	"os/exec"
-	"strings"
-
 	"github.com/99designs/aws-vault/v7/prompt"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"log"
 )
 
 // Mfa contains options for an MFA device
@@ -47,13 +42,5 @@ func NewMfa(config *ProfileConfig) Mfa {
 }
 
 func ProcessMfaProvider(processCmd string) (string, error) {
-	cmd := exec.Command("/bin/sh", "-c", processCmd)
-	cmd.Stderr = os.Stderr
-
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("process provider: %w", err)
-	}
-
-	return strings.TrimSpace(string(out)), nil
+	return executeMFACommand(processCmd)
 }

--- a/vault/mfa_unix.go
+++ b/vault/mfa_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package vault
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func executeMFACommand(processCmd string) (string, error) {
+	cmd := exec.Command("/bin/sh", "-c", processCmd)
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("process provider: %w", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}

--- a/vault/mfa_windows.go
+++ b/vault/mfa_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package vault
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+func executeMFACommand(processCmd string) (string, error) {
+	// On windows, its quite involved to launch a process if the binary involved is in a path with spaces
+	// See https://github.com/golang/go/issues/17149 for details and workaround proposals
+	shell := os.Getenv("SystemRoot") + "\\System32\\cmd.exe"
+	cmd := exec.Command(shell)
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: "/C \"" + processCmd + "\""}
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("process provider: %w", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}


### PR DESCRIPTION
This should address #1241 - windows doesn't have /bin/sh.
However, using cmd instead is also not quite straightforward since `exec.Command` has [some pitfalls](https://github.com/golang/go/issues/17149) on windows. This implements the suggested upstream workaround and allows us to launch mfa_process correctly on windows, even if the binary is in a path with spaces.