### PR TITLE
fix(rolechaining): add missing MFA auth logic for session creds

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -254,6 +254,21 @@ func (t *TempCredentialsCreator) getSourceCredWithSession(config *ProfileConfig,
 		return nil, err
 	}
 
+	if hasStoredCredentials || !config.HasRole() {
+		if canUse, reason := t.canUseGetSessionToken(config); !canUse {
+			log.Printf("profile %s: skipping GetSessionToken because %s", config.ProfileName, reason)
+			if !config.HasRole() {
+				return sourcecredsProvider, nil
+			}
+		}
+		t.chainedMfa = config.MfaSerial
+		log.Printf("profile %s: using GetSessionToken %s", config.ProfileName, mfaDetails(false, config))
+		sourcecredsProvider, err = NewSessionTokenProvider(sourcecredsProvider, t.Keyring.Keyring, config, !t.DisableCache)
+		if !config.HasRole() || err != nil {
+			return sourcecredsProvider, err
+		}
+	}
+
 	if config.HasRole() {
 		isMfaChained := config.MfaSerial != "" && config.MfaSerial == t.chainedMfa
 		if isMfaChained {

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -267,12 +267,13 @@ func (t *TempCredentialsCreator) getSourceCredWithSession(config *ProfileConfig,
 
 	if isMasterCredentialsProvider(sourcecredsProvider) || isChainedCredentialSource {
 		canUseGetSessionToken, reason := t.canUseGetSessionToken(config)
-		if canUseGetSessionToken {
-			t.chainedMfa = config.MfaSerial
-			log.Printf("profile %s: using GetSessionToken %s", config.ProfileName, mfaDetails(false, config))
-			return NewSessionTokenProvider(sourcecredsProvider, t.Keyring.Keyring, config, !t.DisableCache)
+		if !canUseGetSessionToken {
+			log.Printf("profile %s: skipping GetSessionToken because %s", config.ProfileName, reason)
+			return sourcecredsProvider, nil
 		}
-		log.Printf("profile %s: skipping GetSessionToken because %s", config.ProfileName, reason)
+		t.chainedMfa = config.MfaSerial
+		log.Printf("profile %s: using GetSessionToken %s", config.ProfileName, mfaDetails(false, config))
+		return NewSessionTokenProvider(sourcecredsProvider, t.Keyring.Keyring, config, !t.DisableCache)
 	}
 
 	return sourcecredsProvider, nil

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -257,7 +257,7 @@ func (t *TempCredentialsCreator) getSourceCredWithSession(config *ProfileConfig,
 	isChainedCredentialSource := config.ChainedFromProfile != nil
 
 	if config.HasRole() && !isChainedCredentialSource {
-		isMfaChained := config.SourceProfile != nil && config.MfaSerial == config.SourceProfile.MfaSerial
+		isMfaChained := config.MfaSerial != "" && config.MfaSerial == t.chainedMfa
 		if isMfaChained {
 			config.MfaSerial = ""
 		}


### PR DESCRIPTION
Based on @thiagosestini observations and after debugging with Delve, I identified that in aws-vault v7 the MFA chaining logic was incomplete compared to v6.

Specifically, v7 was skipping the critical step of calling GetSessionToken to obtain MFA-authenticated session credentials before performing AssumeRole in chained profiles. As a result, AssumeRole calls lacked MFA context, causing AWS to reject them with MFA validation errors.
https://github.com/99designs/aws-vault/blob/1344f1593efb21c7f74a34496082c7d054f7adb8/vault/vault.go#L230-L244

This commit restores the missing logic by wrapping long-term credentials with a session token provider (calling GetSessionToken with MFA) when appropriate. It clears the MFA serial on subsequent chained assumes, preventing repeated MFA prompts and access denials.

This fix aligns v7 behavior with v6 and resolves MFA failures during role chaining.

For the people who wanna test without clone and build the project, i baked some binaries on: https://github.com/propilideno/aws-vault/releases/tag/7.2.1

- https://github.com/99designs/aws-vault/issues/1251
- https://github.com/ByteNess/aws-vault/issues/67